### PR TITLE
Added pom.xml configuration to integrate ADAL with Maven based projects

### DIFF
--- a/adal/pom.xml
+++ b/adal/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.microsoft.adal</groupId>
+    <artifactId>adal</artifactId>
+    <version>0.5-alpha</version>
+    <packaging>aar</packaging>
+    <name>adal</name>
+
+    <dependencies>
+        <dependency>
+          <groupId>android</groupId>
+          <artifactId>android</artifactId>
+          <version>4.4.2_r2</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>android.support</groupId>
+          <artifactId>compatibility-v4</artifactId>
+          <version>19.0.1</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.4</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <artifactId>android-maven-plugin</artifactId>
+                <version>3.8.2</version>
+                <configuration>
+                    <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
+                    <assetsDirectory>${project.basedir}/assets</assetsDirectory>
+                    <resourceDirectory>${project.basedir}/res</resourceDirectory>
+                    <nativeLibrariesDirectory>${project.basedir}/src/main/native</nativeLibrariesDirectory>
+                    <sdk>
+                        <platform>19</platform>
+                    </sdk>
+                    <deleteConflictingFiles>true</deleteConflictingFiles>
+                    <undeployBeforeDeploy>true</undeployBeforeDeploy>
+                </configuration>
+                <extensions>true</extensions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Fixes #56. Artifact is .AAR android archive including both compiled classes and resources.

Prerequisites:
- Maven v3.1.1.
  Download: http://maven.apache.org/download.cgi

Usage:
- Execute `mvn install` in the root directory containing `pom.xml` to create `adal-0.5-alpha.aar` library and install it into your local Maven repository.
- Execute `mvn package` in the root directory containing `pom.xml` to create `adal-0.5-alpha.aar` library.
