### PR TITLE
Helper method for developer to see redirecturi for broker usage

### DIFF
--- a/samples/hello/src/com/microsoft/aad/adal/hello/MainActivity.java
+++ b/samples/hello/src/com/microsoft/aad/adal/hello/MainActivity.java
@@ -20,6 +20,8 @@ package com.microsoft.aad.adal.hello;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -32,8 +34,13 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Intent;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.Signature;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.util.Base64;
 import android.util.Log;
 import android.view.Menu;
 import android.view.View;
@@ -89,7 +96,7 @@ public class MainActivity extends Activity {
         } catch (Exception e) {
             Toast.makeText(getApplicationContext(), "Encryption failed", Toast.LENGTH_SHORT).show();
         }
-
+         
         Toast.makeText(getApplicationContext(), TAG + "done", Toast.LENGTH_SHORT).show();
     }
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -248,6 +248,7 @@ public class AuthenticationContext {
 
     /**
      * Gets username for current broker user
+     * 
      * @return Username
      */
     public String getBrokerUser() {
@@ -256,6 +257,25 @@ public class AuthenticationContext {
         }
 
         return null;
+    }
+
+    /**
+     * Get expected redirect Uri for your app to use in broker. You need to
+     * register this redirectUri in order to get token from Broker.
+     * 
+     * @return RedirectUri string to use for broker requests.
+     */
+    public String getRedirectUriForBroker() {
+        PackageHelper helper = new PackageHelper(mContext);
+        String packageName = mContext.getPackageName();
+
+        // First available signature. Applications can be signed with multiple
+        // signatures.
+        String signatureDigest = helper.getCurrentSignatureForPackage(packageName);
+        String redirectUri = PackageHelper.getBrokerRedirectUrl(packageName, signatureDigest);
+        Logger.v(TAG, "Broker redirectUri:" + redirectUri + " packagename:" + packageName
+                + " signatureDigest:" + signatureDigest);
+        return redirectUri;
     }
 
     /**
@@ -273,13 +293,15 @@ public class AuthenticationContext {
      * @param callback required
      */
     public void acquireToken(Activity activity, String resource, String clientId,
-            String redirectUri, String login_hint, AuthenticationCallback<AuthenticationResult> callback) {
+            String redirectUri, String login_hint,
+            AuthenticationCallback<AuthenticationResult> callback) {
 
         redirectUri = checkInputParameters(activity, resource, clientId, redirectUri,
                 PromptBehavior.Auto, callback);
 
         final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, login_hint, PromptBehavior.Auto, null, getRequestCorrelationId());
+                clientId, redirectUri, login_hint, PromptBehavior.Auto, null,
+                getRequestCorrelationId());
 
         acquireTokenLocal(activity, request, callback);
     }
@@ -295,9 +317,9 @@ public class AuthenticationContext {
      * @param clientId
      * @param redirectUri Optional. It will use packagename and provided suffix
      *            for this.
-     * @param loginHint Optional. This parameter will be used to pre-populate the
-     *            username field in the authentication form. Please note that
-     *            the end user can still edit the username field and
+     * @param loginHint Optional. This parameter will be used to pre-populate
+     *            the username field in the authentication form. Please note
+     *            that the end user can still edit the username field and
      *            authenticate as a different user. This parameter can be null.
      * @param extraQueryParameters Optional. This parameter will be appended as
      *            is to the query string in the HTTP authentication request to
@@ -401,8 +423,8 @@ public class AuthenticationContext {
      * @param callback
      */
     public void acquireToken(Activity activity, String resource, String clientId,
-            String redirectUri, String loginHint, PromptBehavior prompt, String extraQueryParameters,
-            AuthenticationCallback<AuthenticationResult> callback) {
+            String redirectUri, String loginHint, PromptBehavior prompt,
+            String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
 
         redirectUri = checkInputParameters(activity, resource, clientId, redirectUri, prompt,
                 callback);
@@ -669,7 +691,7 @@ public class AuthenticationContext {
                                     result = oauthRequest.getToken(endingUrl);
                                     Logger.v(TAG, "OnActivityResult processed the result. "
                                             + authenticationRequest.getLogInfo());
-                                    
+
                                 } catch (Exception exc) {
                                     String msg = "Error in processing code to get token. "
                                             + authenticationRequest.getLogInfo();
@@ -1185,7 +1207,7 @@ public class AuthenticationContext {
                 item = mTokenCacheStore.getItem(CacheKey.createCacheKey(request,
                         request.getLoginHint()));
             }
-            
+
             if (item != null) {
                 Logger.v(TAG,
                         "getItemFromCache accessTokenId:" + getTokenHash(item.getAccessToken())
@@ -1244,8 +1266,8 @@ public class AuthenticationContext {
             // include the resourceId in the cachekey
             Logger.v(TAG, "Looking for regular refresh token" + getCorrelationLogInfo());
             String userId = request.getUserId();
-            if(StringExtensions.IsNullOrBlank(userId)){
-                // acquireTokenSilent expects  userid field from UserInfo
+            if (StringExtensions.IsNullOrBlank(userId)) {
+                // acquireTokenSilent expects userid field from UserInfo
                 userId = request.getLoginHint();
             }
             String keyUsed = CacheKey.createCacheKey(request, userId);
@@ -1280,10 +1302,10 @@ public class AuthenticationContext {
             // method should use token from cache.
             Logger.v(TAG, "Setting item to cache" + getCorrelationLogInfo());
             String userKey = request.getUserId();
-            if(StringExtensions.IsNullOrBlank(userKey)){
+            if (StringExtensions.IsNullOrBlank(userKey)) {
                 userKey = request.getLoginHint();
             }
-            
+
             // Calculate token hashcode
             logReturnedToken(request, result);
             setItemToCacheForUser(request, result, userKey);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/ADALErrorTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/ADALErrorTest.java
@@ -82,7 +82,7 @@ public class ADALErrorTest extends InstrumentationTestCase {
         
         assertFalse("Error decription is different in resource", msg.equalsIgnoreCase(localizedMsg));
         assertTrue("in locale specified",
-                localizedMsg.contains("DEVELOPER BEH�RDE nicht validiert werden kann"));
+                localizedMsg.contains("DEVELOPER BEHÖRDE nicht validiert werden kann"));
         
         Locale localefr = new Locale("fr");
         Locale.setDefault(localefr);


### PR DESCRIPTION
Issue #179 
User needs to register redirectUri for the packagename and signature. Current AAD UX does not allow to input additional fields for mobile apps. RedirectUri will be used temporarily to store app information. Initial call to broker will use this redirectUri and it needs to be registered for the app. User can register multiple redirectURIs.
