### PR TITLE
Update comment for key spec and usage for secretkey

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationSettings.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationSettings.java
@@ -51,7 +51,8 @@ public enum AuthenticationSettings {
     }
 
     /**
-     * set raw bytes to derive secretKey to use in encrypt/decrypt
+     * set raw bytes to derive secretKey to use in encrypt/decrypt. KeySpec
+     * algorithm is AES.
      * 
      * @param rawKey
      */

--- a/tests/Functional/src/com/microsoft/aad/adal/test/StorageHelperTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/StorageHelperTests.java
@@ -223,7 +223,7 @@ public class StorageHelperTests extends AndroidTestCase {
         // API level, data needs to be updated
         String keyVersionCheck = new String(bytes, 0, 4, "UTF-8");
         Log.v(TAG, "Key version check:" + keyVersionCheck);
-        if (Build.VERSION.SDK_INT < 18) {
+        if (Build.VERSION.SDK_INT < 18 || AuthenticationSettings.INSTANCE.getSecretKeyData() != null) {
             assertEquals("It should use user defined", "U001", keyVersionCheck);
         } else {
             assertEquals("It should use user defined", "A001", keyVersionCheck);


### PR DESCRIPTION
Issue #213 
User specified secretkey will be used for all versions if specified. If developer does not want to use AndroidKeyStore to save secretkey, AuthenticationSettings can be used to specify secretkey for all versions. ADAL will not generate key if it is specified.
