### PR TITLE
Eliminate warnings and add default value for app_loading resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,17 @@ CookieSyncManager.getInstance().sync();
 ```
 More about cookies: http://developer.android.com/reference/android/webkit/CookieSyncManager.html
 
+### Resource Overrides
+
+The ADAL library includes English strings for the following two resources.
+
+Your application should overwrite them if localized strings are desired. 
+
+```Java
+<string name="app_loading">Loading...</string>
+<string name="broker_processing">Broker is processing</string>
+```
+
 =======
 
 ## License

--- a/src/res/values/strings.xml
+++ b/src/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <string name="action_settings">Settings</string>
-    <string name="app_loading"></string>
+    <string name="app_loading">Loading...</string>
     <string name="default_not_supported_msg">This operation is not supported in AAD Broker</string>
     <string name="error_token_type_not_supported">Token type is not supported</string>
     <string name="broker_authentication_request_is_invalid">Authetication request is invalid</string>

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -21,7 +21,6 @@ package com.microsoft.aad.adal;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.security.DigestException;
 import java.security.InvalidAlgorithmParameterException;

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -23,7 +23,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
-import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;

--- a/src/src/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationResult.java
@@ -19,7 +19,6 @@
 package com.microsoft.aad.adal;
 
 import java.io.Serializable;
-import java.util.Calendar;
 import java.util.Date;
 
 /**
@@ -33,7 +32,7 @@ public class AuthenticationResult implements Serializable {
      */
     private static final long serialVersionUID = 2243372613182536368L;
 
-    private static final String TAG = "AuthenticationResult";
+    //private static final String TAG = "AuthenticationResult";
 
     /**
      * Status for authentication.

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -19,7 +19,6 @@
 package com.microsoft.aad.adal;
 
 import java.io.IOException;
-import java.lang.annotation.Target;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 

--- a/src/src/com/microsoft/aad/adal/StringExtensions.java
+++ b/src/src/com/microsoft/aad/adal/StringExtensions.java
@@ -19,7 +19,6 @@
 package com.microsoft.aad.adal;
 
 import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;


### PR DESCRIPTION
Eliminate Warnings: Remove unused import (java.net.URI)

Eliminate Warnings: Remove unused import (java.util.Locale)

Eliminate Warnings: Remove unused import (java.util.Calendar)

Eliminate Warnings: Remove unused import (java.lang.annotation.Target)

Eliminate Warnings: Remove unused import (java.math.BigInteger)

Eliminate Warnings: Comment out unused TAG variable in AuthenticationResult.java

Add default English string value for app_loading (like we do for broker_processing).

Update README.md with info about app_loading and broker_processing string values (to be overwritten by client applications if they wish to have non-English values)
