### PR TITLE
Update readme to include detail on how to get diagnostics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,13 @@ You set the log level like this:
 Logger.getInstance().setLogLevel(Logger.LogLevel.Verbose);
  ```
  
- When you are debugging your app, Eclipse will update your manifest file to add debuggable element to the application object. Adal's Logger methods also output using android.util.Log. You will get the log output with Logcat. You can use adb logcat cmds to direct logcat outputs for debugging.
- More examples: https://developer.android.com/tools/debugging/debugging-log.html#startingLogcat
+ All log messages are sent to logcat in addition to any custom log callbacks.
+ You can get log to a file form logcat as shown belog:
  
  ```
   adb logcat > "C:\logmsg\logfile.txt"
  ```
+ More examples about adb cmds: https://developer.android.com/tools/debugging/debugging-log.html#startingLogcat
  
 #### Network Traces
 


### PR DESCRIPTION
Logger usage related update
Add links for Fiddler
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23issuecomment-66219752%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Address%20my%20last%20comment%20and%20go%20ahead%20and%20commit.%20%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222014-12-09T01%3A21%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-12-09T01%3A22%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c2dac8885a83004236317ad21bfe910fe12a9f2d%20README.md%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21485867%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Were%20you%20going%20to%20fix%20this%20Debug%20level%20thing%3F%20%20%5Cr%5Cn%5Cr%5CnFor%20those%20just%20joining%20us%2C%20currently%20Debug%20level%20sends%20some%20amount%20of%20logs%20to%20the%20debug%20output%20stream.%20%20However%2C%20that%20should%20really%20be%20a%20separate%2C%20orthogonal%20option.%22%2C%20%22created_at%22%3A%20%222014-12-08T21%3A11%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22adding%20instructions%20about%20debugging%20and%20logcat.%22%2C%20%22created_at%22%3A%20%222014-12-08T22%3A05%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20README.md%3AL284-355%22%7D%2C%20%22Pull%20c2dac8885a83004236317ad21bfe910fe12a9f2d%20README.md%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21485902%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20add%20something%20in%20the%20logging%20section%20about%20how%20to%20send%20the%20log%20entries%20to%20the%20debug%20output%20so%20that%20they%20can%20be%20seen%20while%20debugging%2C%20and%20also%20so%20that%20they%20can%20be%20cut%20and%20paste%20in%20to%20a%20file%20easily.%22%2C%20%22created_at%22%3A%20%222014-12-08T21%3A12%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20README.md%3AL284-355%22%7D%2C%20%22Commit%20244753cacf1e895f218d2cdba81b4b038e932e90%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/commit/244753cacf1e895f218d2cdba81b4b038e932e90%23commitcomment-8884936%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20just%20remove%20the%20debug%20line%20rather%20than%20advertise%20it%20as%20deprecated.%20People%20that%20are%20new%20to%20the%20library%20don%27t%20know%20about%20that%20setting%2C%20and%20there%20is%20no%20reason%20to%20advertise%20it%20to%20them.%20%22%2C%20%22created_at%22%3A%20%222014-12-08T23%3A14%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%20244753c%20comments%22%7D%2C%20%22Pull%2047be651fa1429f9ed9daa9f7acbff25f0564e32d%20README.md%2068%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21501485%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20you%20can%20shorten%20this.%20%20If%20I%20understand%20correctly%20logCat%20and%20its%20use%20in%20Android%20development%20should%20be%20well%20understood%20by%20the%20average%20Android%20developer.%20%20I%20would%20leave%20that%20kind%20of%20detail%20out.%20%20How%20about%20just%20saying%20this%3A%5Cr%5Cn%5Cr%5Cn%3E%20All%20log%20messages%20are%20sent%20to%20logcat%20in%20addition%20to%20any%20customer%20log%20callbacks.%22%2C%20%22created_at%22%3A%20%222014-12-09T01%3A21%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20README.md%3AL284-362%22%7D%2C%20%22Pull%20c2dac8885a83004236317ad21bfe910fe12a9f2d%20README.md%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21486170%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22How%20about%20saying%20something%20like%3A%5Cr%5Cn%5Cr%5Cn%60%60%60Messages%20can%20be%20written%20to%20a%20custom%20log%20file%20as%20seen%20below.%20%20Unfortunately%2C%20there%20is%20no%20standard%20way%20of%20getting%20logs%20from%20a%20device.%20%20There%20are%20some%20services%20that%20can%20help%20you%20with%20this.%20%20You%20can%20also%20invent%20your%20own%2C%20such%20as%20sending%20the%20file%20to%20a%20server.%60%60%60%22%2C%20%22created_at%22%3A%20%222014-12-08T21%3A16%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20README.md%3AL284-355%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23issuecomment-66219752%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23issuecomment-66219850%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21485867%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21485902%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21486170%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21490073%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/316%23discussion_r21501485%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/commit/244753cacf1e895f218d2cdba81b4b038e932e90%23commitcomment-8884936%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-Pull c2dac8885a83004236317ad21bfe910fe12a9f2d README.md 62'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/316#discussion_r21485867'>File: README.md:L284-355</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Were you going to fix this Debug level thing?
  For those just joining us, currently Debug level sends some amount of logs to the debug output stream.  However, that should really be a separate, orthogonal option.
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> adding instructions about debugging and logcat.
- [x] <a href='#crh-comment-Pull c2dac8885a83004236317ad21bfe910fe12a9f2d README.md 67'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/316#discussion_r21485902'>File: README.md:L284-355</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Can you add something in the logging section about how to send the log entries to the debug output so that they can be seen while debugging, and also so that they can be cut and paste in to a file easily.
- [x] <a href='#crh-comment-Pull c2dac8885a83004236317ad21bfe910fe12a9f2d README.md 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/316#discussion_r21486170'>File: README.md:L284-355</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> How about saying something like:
  `Messages can be written to a custom log file as seen below.  Unfortunately, there is no standard way of getting logs from a device.  There are some services that can help you with this.  You can also invent your own, such as sending the file to a server.`
- [x] <a href='#crh-comment-Commit 244753cacf1e895f218d2cdba81b4b038e932e90'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/commit/244753cacf1e895f218d2cdba81b4b038e932e90#commitcomment-8884936'>Commit 244753c comments</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> I would just remove the debug line rather than advertise it as deprecated. People that are new to the library don't know about that setting, and there is no reason to advertise it to them.
- [ ] <a href='#crh-comment-Pull 47be651fa1429f9ed9daa9f7acbff25f0564e32d README.md 68'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/316#discussion_r21501485'>File: README.md:L284-362</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> I think you can shorten this.  If I understand correctly logCat and its use in Android development should be well understood by the average Android developer.  I would leave that kind of detail out.  How about just saying this:
  > All log messages are sent to logcat in addition to any customer log callbacks.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/316#issuecomment-66219752'>General Comment</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Address my last comment and go ahead and commit. :shipit:

<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/316?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/316?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/316?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/316'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
