### PR TITLE
Refactor webviewclient to use for dialog and activity

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -343,7 +343,7 @@ public class AuthenticationActivity extends Activity {
         mWebView.getSettings().setDomStorageEnabled(true);
         mWebView.getSettings().setUseWideViewPort(true);
         mWebView.getSettings().setBuiltInZoomControls(true);
-        mWebView.setWebViewClient(new CustomWebViewClient(AuthenticationActivity.this, redirect, queryParam, request));
+        mWebView.setWebViewClient(new CustomWebViewClient());
         mWebView.setVisibility(View.INVISIBLE);
     }
 
@@ -562,8 +562,8 @@ public class AuthenticationActivity extends Activity {
 
     class CustomWebViewClient extends BasicWebViewClient {
 
-        public CustomWebViewClient(Context appContext, String redirect, String query, AuthenticationRequest request){
-            super(appContext, redirect, query, request);
+        public CustomWebViewClient(){
+            super(AuthenticationActivity.this, mRedirectUrl, mQueryParameters, mAuthRequest);
         }
                 
         public void processRedirectUrl(final WebView view, String url){

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -388,6 +388,7 @@ public class AuthenticationActivity extends Activity {
                     loginhint, correlationIdParsed);
             authRequest.setBrokerAccountName(accountName);
             authRequest.setPrompt(promptBehavior);
+            authRequest.setRequestId(mWaitingRequestId);
         } else {
             Serializable request = callingIntent
                     .getSerializableExtra(AuthenticationConstants.Browser.REQUEST_MESSAGE);
@@ -616,8 +617,7 @@ public class AuthenticationActivity extends Activity {
 
         @Override
         public void cancelWebViewRequest() {
-            // TODO Auto-generated method stub
-            
+            cancelRequest();            
         }
 
         @Override

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -243,8 +243,8 @@ abstract class BasicWebViewClient extends WebViewClient {
             if (hasCancelError(url)) {
                 // Catch WEB-UI cancel request
                 Logger.i(TAG, "Sending intent to cancel authentication activity", "");
-                sendResponse(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, new Intent());
                 view.stopLoading();
+                cancelWebViewRequest();
                 return true;
             }
             

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -160,9 +160,8 @@ abstract class BasicWebViewClient extends WebViewClient {
                 @Override
                 public void run() {
                     try {
-                        IJWSBuilder jwsBuilder = new JWSBuilder();
                         ChallangeResponseBuilder certHandler = new ChallangeResponseBuilder(
-                                jwsBuilder);
+                                new JWSBuilder());
                         final ChallangeResponse challangeResponse = certHandler
                                 .getChallangeResponseFromUri(challangeUrl);
                         final HashMap<String, String> headers = new HashMap<String, String>();

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -18,10 +18,18 @@
 
 package com.microsoft.aad.adal;
 
+import java.util.HashMap;
+import java.util.Locale;
+
+import com.microsoft.aad.adal.ChallangeResponseBuilder.ChallangeResponse;
+
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.net.http.SslError;
 import android.view.View;
+import android.webkit.HttpAuthHandler;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -33,27 +41,63 @@ abstract class BasicWebViewClient extends WebViewClient {
     public static final String BLANK_PAGE = "about:blank";
 
     protected String mRedirect;
-
-    protected int mRequestCode;
+    
+    protected String mQueryParam;
 
     protected AuthenticationRequest mRequest;
+    
+    protected Context mCallingContext;
 
     public BasicWebViewClient() {
         mRedirect = null;
-        mRequestCode = 0;
         mRequest = null;
     }
 
-    public BasicWebViewClient(String redirect, int requestCode, AuthenticationRequest request) {
+    public BasicWebViewClient(Context appContext, String redirect, String queryParam, AuthenticationRequest request) {
+        mCallingContext = appContext;
         mRedirect = redirect;
-        mRequestCode = requestCode;
         mRequest = request;
+        mQueryParam = queryParam;
     }
 
     public abstract void showSpinner(boolean status);
 
     public abstract void sendResponse(int returnCode, Intent responseIntent);
+    
+    public abstract void cancelWebViewRequest();
+    
+    public abstract void setPKeyAuthStatus(boolean status);
+    
+    public abstract void postRunnable(Runnable item);
+    
 
+    @Override
+    public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler,
+            String host, String realm) {
+
+        // Create a dialog to ask for creds and post it to the handler.
+        Logger.i(TAG, "onReceivedHttpAuthRequest for host:" + host, "");
+        HttpAuthDialog authDialog = new HttpAuthDialog(mCallingContext, host, realm);
+
+        authDialog.setOkListener(new HttpAuthDialog.OkListener() {
+            public void onOk(String host, String realm, String username, String password) {
+                Logger.i(TAG, "onReceivedHttpAuthRequest: handler proceed" + host, "");
+                handler.proceed(username, password);
+            }
+        });
+
+        authDialog.setCancelListener(new HttpAuthDialog.CancelListener() {
+            public void onCancel() {
+                Logger.i(TAG, "onReceivedHttpAuthRequest: handler cancelled", "");
+                handler.cancel();
+                cancelWebViewRequest();
+            }
+        });
+
+        Logger.i(TAG, "onReceivedHttpAuthRequest: show dialog", "");
+        authDialog.show();
+    }
+    
     @Override
     public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
         super.onReceivedError(view, errorCode, description, failingUrl);
@@ -102,5 +146,147 @@ abstract class BasicWebViewClient extends WebViewClient {
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
         super.onPageStarted(view, url, favicon);
         showSpinner(true);
+    }
+    
+    @Override
+    public boolean shouldOverrideUrlLoading(final WebView view, String url) {
+        Logger.v(TAG, "Navigation is detected");
+        if (url.startsWith(AuthenticationConstants.Broker.CLIENT_TLS_REDIRECT)) {
+            Logger.v(TAG, "Webview detected request for client certificate");
+            view.stopLoading();
+            setPKeyAuthStatus(true);
+            final String challangeUrl = url;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        IJWSBuilder jwsBuilder = new JWSBuilder();
+                        ChallangeResponseBuilder certHandler = new ChallangeResponseBuilder(
+                                jwsBuilder);
+                        final ChallangeResponse challangeResponse = certHandler
+                                .getChallangeResponseFromUri(challangeUrl);
+                        final HashMap<String, String> headers = new HashMap<String, String>();
+                        headers.put(AuthenticationConstants.Broker.CHALLANGE_RESPONSE_HEADER,
+                                challangeResponse.mAuthorizationHeaderValue);
+                        postRunnable(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                String loadUrl = challangeResponse.mSubmitUrl;
+                                HashMap<String, String> parameters = StringExtensions
+                                        .getUrlParameters(challangeResponse.mSubmitUrl);
+                                Logger.v(TAG, "SubmitUrl:" + challangeResponse.mSubmitUrl);
+                                if (!parameters
+                                        .containsKey(AuthenticationConstants.OAuth2.CLIENT_ID)) {
+                                    loadUrl = loadUrl + "?" + mQueryParam;
+                                }
+                                Logger.v(TAG, "Loadurl:" + loadUrl);
+                                view.loadUrl(loadUrl, headers);
+                            }
+                        });
+                    } catch (IllegalArgumentException e) {
+                        Logger.e(TAG, "Argument exception", e.getMessage(),
+                                ADALError.ARGUMENT_EXCEPTION, e);
+                        // It should return error code and finish the
+                        // activity, so that onActivityResult implementation
+                        // returns errors to callback.
+                        Intent resultIntent = new Intent();
+                        resultIntent.putExtra(
+                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
+                                        e);
+                        if (mRequest != null) {
+                            resultIntent.putExtra(
+                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
+                                    mRequest);
+                        }
+                        sendResponse(
+                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
+                                resultIntent);
+                    } catch (AuthenticationException e) {
+                        Logger.e(TAG, "It is failed to create device certificate response",
+                                e.getMessage(), ADALError.DEVICE_CERTIFICATE_RESPONSE_FAILED, e);
+                        // It should return error code and finish the
+                        // activity, so that onActivityResult implementation
+                        // returns errors to callback.
+                        Intent resultIntent = new Intent();
+                        resultIntent.putExtra(
+                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
+                                        e);
+                        if (mRequest != null) {
+                            resultIntent.putExtra(
+                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
+                                    mRequest);
+                        }
+                        sendResponse(
+                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
+                                resultIntent);
+                    } catch (Exception e) {
+                        Intent resultIntent = new Intent();
+                        resultIntent.putExtra(
+                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
+                                        e);
+                        if (mRequest != null) {
+                            resultIntent.putExtra(
+                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
+                                    mRequest);
+                        }
+                        sendResponse(
+                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
+                                resultIntent);
+                    }
+                }
+            }).start();
+
+            return true;
+        } else if (url.toLowerCase(Locale.US).startsWith(mRedirect.toLowerCase(Locale.US))) {
+            
+            if (hasCancelError(url)) {
+                // Catch WEB-UI cancel request
+                Logger.i(TAG, "Sending intent to cancel authentication activity", "");
+                sendResponse(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, new Intent());
+                view.stopLoading();
+                return true;
+            }
+            
+            processRedirectUrl(view, url);
+            return true;
+        } else if (url.startsWith(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX)) {
+            Logger.v(TAG, "It is an external website request");
+            openLinkInBrowser(url);
+            view.stopLoading();
+            cancelWebViewRequest();
+            return true;
+        }
+
+        return processInvalidUrl(view, url);
+    }
+    
+    public abstract void processRedirectUrl(final WebView view, String url);
+
+    public abstract boolean processInvalidUrl(final WebView view, String url);
+    
+    protected void openLinkInBrowser(String url) {
+        String link = url
+                .replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
+        mCallingContext.startActivity(intent);
+    }
+    
+    private boolean hasCancelError(String redirectUrl) {
+        try {
+            HashMap<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
+            String error = parameters.get("error");
+            String errorDescription = parameters.get("error_description");
+
+            if (!StringExtensions.IsNullOrBlank(error)) {
+                Logger.v(TAG, "Cancel error:" + error + " " + errorDescription);
+                return true;
+            }
+        } catch (Exception exc) {
+            Logger.e(TAG, "Error in processing url parameters", "Url:" + redirectUrl,
+                    ADALError.ERROR_WEBVIEW);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Issue #342 

Move code from AuthenticationActivity->CustomWebviewClient to BasicWebviewClient
Create abstract methods to call from AuthenticationActivity and AuthenticationDialog
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/343%23discussion_r24133160%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/343%23discussion_r24133189%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/343%23discussion_r24133523%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/343%23discussion_r24133627%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20827abe288a30870a2ad3ebf2f0b5b150d5d489b8%20src/src/com/microsoft/aad/adal/AuthenticationActivity.java%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/343%23discussion_r24133189%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22can%20you%20name%20the%20webviews%20more%20meaningful%20instead%20of%20webview1%3F%22%2C%20%22created_at%22%3A%20%222015-02-05T00%3A17%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20inside%20the%20existing%20layout%20file.%20It%20will%20be%20breaking%20change%20for%20developers%20using%20this%20layout.%22%2C%20%22created_at%22%3A%20%222015-02-05T00%3A23%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/AuthenticationActivity.java%3AL189-198%22%7D%2C%20%22Pull%20827abe288a30870a2ad3ebf2f0b5b150d5d489b8%20src/src/com/microsoft/aad/adal/BasicWebViewClient.java%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/343%23discussion_r24133160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20have%20an%20interface%20for%20a%20jwsbuilder%3F%22%2C%20%22created_at%22%3A%20%222015-02-05T00%3A16%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22right%2C%20not%20needed%20there.%20JWSBuilder%20itself%20fine.%22%2C%20%22created_at%22%3A%20%222015-02-05T00%3A25%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/BasicWebViewClient.java%3AL147-293%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 827abe288a30870a2ad3ebf2f0b5b150d5d489b8 src/src/com/microsoft/aad/adal/BasicWebViewClient.java 106'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/343#discussion_r24133160'>File: src/src/com/microsoft/aad/adal/BasicWebViewClient.java:L147-293</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> why have an interface for a jwsbuilder?
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> right, not needed there. JWSBuilder itself fine.
- [ ] <a href='#crh-comment-Pull 827abe288a30870a2ad3ebf2f0b5b150d5d489b8 src/src/com/microsoft/aad/adal/AuthenticationActivity.java 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/343#discussion_r24133189'>File: src/src/com/microsoft/aad/adal/AuthenticationActivity.java:L189-198</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> can you name the webviews more meaningful instead of webview1?
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> It is inside the existing layout file. It will be breaking change for developers using this layout.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/343?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/343?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/343'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>