### PR TITLE
report error if access token is not present after broker processing

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -971,21 +971,23 @@ public class AuthenticationActivity extends Activity {
                                 result.taskResult.getExpiresOn().getTime());
                     }
 
-                    if (result.taskResult.getUserInfo() != null) {
+                    UserInfo userinfo = result.taskResult.getUserInfo();
+                    if (userinfo != null) {
                         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID,
-                                result.taskResult.getUserInfo().getUserId());
+                                userinfo.getUserId());
                         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
-                                result.taskResult.getUserInfo().getGivenName());
+                                userinfo.getGivenName());
                         intent.putExtra(
                                 AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
-                                result.taskResult.getUserInfo().getFamilyName());
+                                userinfo.getFamilyName());
                         intent.putExtra(
                                 AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER,
-                                result.taskResult.getUserInfo().getIdentityProvider());
+                                userinfo.getIdentityProvider());
                         intent.putExtra(
                                 AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
-                                result.taskResult.getUserInfo().getDisplayableId());
+                                userinfo.getDisplayableId());
                     }
+                    
                     returnResult(AuthenticationConstants.UIResponse.TOKEN_BROKER_RESPONSE, intent);
                 } else {
                     returnError(ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -58,6 +58,7 @@ import android.webkit.CookieSyncManager;
 import android.webkit.WebView;
 
 import com.google.gson.Gson;
+import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
 
 /**
  * Authentication Activity to launch {@link WebView} for authentication.
@@ -956,29 +957,42 @@ public class AuthenticationActivity extends Activity {
             Logger.v(TAG, "Token task returns the result");
             displaySpinner(false);
             Intent intent = new Intent();
+
             if (result.taskResult != null) {
-                intent.putExtra(AuthenticationConstants.Browser.REQUEST_ID, mWaitingRequestId);
-                intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_ACCESS_TOKEN,
-                        result.taskResult.getAccessToken());
-                intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_NAME, result.accountName);
-                intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE,
-                        result.taskResult.getExpiresOn().getTime());
-                if (result.taskResult.getUserInfo() != null) {
-                    intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID,
-                            result.taskResult.getUserInfo().getUserId());
-                    intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
-                            result.taskResult.getUserInfo().getGivenName());
-                    intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
-                            result.taskResult.getUserInfo().getFamilyName());
-                    intent.putExtra(
-                            AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER,
-                            result.taskResult.getUserInfo().getIdentityProvider());
-                    intent.putExtra(
-                            AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
-                            result.taskResult.getUserInfo().getDisplayableId());
+
+                if (result.taskResult.getStatus().equals(AuthenticationStatus.Succeeded)) {
+                    intent.putExtra(AuthenticationConstants.Browser.REQUEST_ID, mWaitingRequestId);
+                    intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_ACCESS_TOKEN,
+                            result.taskResult.getAccessToken());
+                    intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_NAME, result.accountName);
+
+                    if (result.taskResult.getExpiresOn() != null) {
+                        intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE,
+                                result.taskResult.getExpiresOn().getTime());
+                    }
+
+                    if (result.taskResult.getUserInfo() != null) {
+                        intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID,
+                                result.taskResult.getUserInfo().getUserId());
+                        intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
+                                result.taskResult.getUserInfo().getGivenName());
+                        intent.putExtra(
+                                AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
+                                result.taskResult.getUserInfo().getFamilyName());
+                        intent.putExtra(
+                                AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER,
+                                result.taskResult.getUserInfo().getIdentityProvider());
+                        intent.putExtra(
+                                AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
+                                result.taskResult.getUserInfo().getDisplayableId());
+                    }
+                    returnResult(AuthenticationConstants.UIResponse.TOKEN_BROKER_RESPONSE, intent);
+                } else {
+                    returnError(ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,
+                            result.taskResult.getErrorDescription());
                 }
-                returnResult(AuthenticationConstants.UIResponse.TOKEN_BROKER_RESPONSE, intent);
             } else {
+                Logger.v(TAG, "Token task has exception");
                 returnError(ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,
                         result.taskException.getMessage());
             }


### PR DESCRIPTION
Issue #353
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/354%23discussion_r26237390%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/354%23discussion_r26237502%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20a506372e1ad6df7bf3315506a1e5482da47b9811%20src/src/com/microsoft/aad/adal/AuthenticationActivity.java%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/354%23discussion_r26237390%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Save%20result.taskResult.getUserInfo%28%29%20in%20a%20variable%22%2C%20%22created_at%22%3A%20%222015-03-11T17%3A53%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/AuthenticationActivity.java%3AL957-999%22%7D%2C%20%22Pull%20a506372e1ad6df7bf3315506a1e5482da47b9811%20src/src/com/microsoft/aad/adal/AuthenticationActivity.java%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/354%23discussion_r26237502%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Signed%20off%20with%20minor%20comment.%22%2C%20%22created_at%22%3A%20%222015-03-11T17%3A54%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/AuthenticationActivity.java%3AL957-999%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull a506372e1ad6df7bf3315506a1e5482da47b9811 src/src/com/microsoft/aad/adal/AuthenticationActivity.java 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/354#discussion_r26237390'>File: src/src/com/microsoft/aad/adal/AuthenticationActivity.java:L957-999</a></b>
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Save result.taskResult.getUserInfo() in a variable
- [ ] <a href='#crh-comment-Pull a506372e1ad6df7bf3315506a1e5482da47b9811 src/src/com/microsoft/aad/adal/AuthenticationActivity.java 70'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/354#discussion_r26237502'>File: src/src/com/microsoft/aad/adal/AuthenticationActivity.java:L957-999</a></b>
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Signed off with minor comment.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/354?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/354?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/354'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>