### PR TITLE
adding correction id to exception thrown by adal

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -707,7 +707,7 @@ public class AuthenticationContext {
 
                 // Cancel or browser error can use recorded request to figure
                 // out original correlationId send with request.
-                String correlationInfo = getCorrelationInfoFromWaitingRequest(waitingRequest);
+                final String correlationInfo = getCorrelationInfoFromWaitingRequest(waitingRequest);
                 if (resultCode == AuthenticationConstants.UIResponse.TOKEN_BROKER_RESPONSE) {
                     String accessToken = data
                             .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_ACCESS_TOKEN);
@@ -746,7 +746,7 @@ public class AuthenticationContext {
                                 waitingRequest,
                                 requestId,
                                 new AuthenticationException(
-                                        ADALError.WEBVIEW_RETURNED_INVALID_AUTHENTICATION_EXCEPTION));
+                                        ADALError.WEBVIEW_RETURNED_INVALID_AUTHENTICATION_EXCEPTION, correlationInfo));
                     }
                 } else if (resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR) {
                     String errCode = extras
@@ -756,7 +756,7 @@ public class AuthenticationContext {
                     Logger.v(TAG, "Error info:" + errCode + " " + errMessage + " for requestId: "
                             + requestId + correlationInfo);
                     waitingRequestOnError(waitingRequest, requestId, new AuthenticationException(
-                            ADALError.SERVER_INVALID_REQUEST, errCode + " " + errMessage));
+                            ADALError.SERVER_INVALID_REQUEST, errCode + " " + errMessage + correlationInfo));
                 } else if (resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE) {
                     final AuthenticationRequest authenticationRequest = (AuthenticationRequest)extras
                             .getSerializable(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO);
@@ -766,7 +766,7 @@ public class AuthenticationContext {
                         AuthenticationException e = new AuthenticationException(
                                 ADALError.WEBVIEW_RETURNED_EMPTY_REDIRECT_URL,
                                 "Webview did not reach the redirectUrl. "
-                                        + authenticationRequest.getLogInfo());
+                                        + authenticationRequest.getLogInfo() + correlationInfo);
                         Logger.e(TAG, e.getMessage(), "", e.getCode());
                         waitingRequestOnError(waitingRequest, requestId, e);
                     } else {
@@ -795,7 +795,7 @@ public class AuthenticationContext {
                                             + authenticationRequest.getLogInfo());
                                 } catch (Exception exc) {
                                     String msg = "Error in processing code to get token. "
-                                            + authenticationRequest.getLogInfo();
+                                            + authenticationRequest.getLogInfo() + correlationInfo;
                                     Logger.e(TAG, msg,
                                             ExceptionExtensions.getExceptionMessage(exc),
                                             ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,
@@ -831,7 +831,7 @@ public class AuthenticationContext {
                                     } else {
                                         callbackHandle
                                                 .onError(new AuthenticationException(
-                                                        ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN));
+                                                        ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, correlationInfo));
                                     }
                                 } finally {
                                     removeWaitingRequest(requestId);


### PR DESCRIPTION
Fix issue in reported in private ADAL(https://github.com/AzureAD/azure-activedirectory-library-for-android-unity-fork/issues/64). 
Intune is using QoS to capture all the failure during WPJ. Adding correlation id to exception thrown by adal will make it easier for them to diagnose.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23issuecomment-135199811%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38156288%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38156311%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38156318%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38371060%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38371070%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23issuecomment-135199811%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40weijjia__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-26T22%3A55%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c1c026bf985020edd822c88c92e78de3160c38a9%20src/src/com/microsoft/aad/adal/AuthenticationContext.java%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38156311%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Will%20there%20be%20a%20whitespace%20missing%3F%22%2C%20%22created_at%22%3A%20%222015-08-27T22%3A59%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22see%20above%20reply.%20%22%2C%20%22created_at%22%3A%20%222015-08-31T23%3A16%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/AuthenticationContext.java%3AL766-773%22%7D%2C%20%22Pull%20c1c026bf985020edd822c88c92e78de3160c38a9%20src/src/com/microsoft/aad/adal/AuthenticationContext.java%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38156288%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Will%20there%20be%20a%20whitespace%20missing%20between%20errMessage%20%2B%20correlationInfo%20concatination%3F%22%2C%20%22created_at%22%3A%20%222015-08-27T22%3A59%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nope%2C%20the%20correlationInfo%20already%20has%20a%20white%20space%20at%20the%20beginning.%20%22%2C%20%22created_at%22%3A%20%222015-08-31T23%3A15%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/AuthenticationContext.java%3AL756-763%22%7D%2C%20%22Pull%20c1c026bf985020edd822c88c92e78de3160c38a9%20src/src/com/microsoft/aad/adal/AuthenticationContext.java%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/413%23discussion_r38156318%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Will%20there%20be%20a%20whitespace%20missing%3F%22%2C%20%22created_at%22%3A%20%222015-08-27T22%3A59%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/AuthenticationContext.java%3AL795-802%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/413#issuecomment-135199811'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@weijjia__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSBOT;
- [ ] <a href='#crh-comment-Pull c1c026bf985020edd822c88c92e78de3160c38a9 src/src/com/microsoft/aad/adal/AuthenticationContext.java 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/413#discussion_r38156288'>File: src/src/com/microsoft/aad/adal/AuthenticationContext.java:L756-763</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> Will there be a whitespace missing between errMessage + correlationInfo concatination?
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> Nope, the correlationInfo already has a white space at the beginning.
- [ ] <a href='#crh-comment-Pull c1c026bf985020edd822c88c92e78de3160c38a9 src/src/com/microsoft/aad/adal/AuthenticationContext.java 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/413#discussion_r38156311'>File: src/src/com/microsoft/aad/adal/AuthenticationContext.java:L766-773</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> Will there be a whitespace missing?
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> see above reply.
- [ ] <a href='#crh-comment-Pull c1c026bf985020edd822c88c92e78de3160c38a9 src/src/com/microsoft/aad/adal/AuthenticationContext.java 41'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/413#discussion_r38156318'>File: src/src/com/microsoft/aad/adal/AuthenticationContext.java:L795-802</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> Will there be a whitespace missing?


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/413?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/413?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/413'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>