### PR TITLE
feature fix to convergence to append URL to authority

### DIFF
--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -446,6 +446,18 @@ class Oauth2 {
             throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL);
         }
 
+        // Add policy to token request if present.
+
+        if (!StringExtensions.IsNullOrBlank(mRequest.getPolicy())) {
+            String newAuthority = authority.toString();
+            newAuthority = String.format("%s?%s=%s", newAuthority,
+                    AuthenticationConstants.AAD.QUERY_POLICY, URLEncoder.encode(
+                            mRequest.getPolicy(),
+                            AuthenticationConstants.ENCODING_UTF8));
+            authority = StringExtensions.getUrl(newAuthority);
+
+        }
+
         try {
             mWebRequestHandler.setRequestCorrelationId(mRequest.getCorrelationId());
             ClientMetrics.INSTANCE.beginClientMetricsRecord(authority, mRequest.getCorrelationId(),


### PR DESCRIPTION
feature fix to convergence to append URL to authority during token acquisition using code.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/429?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/429'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>