### PR TITLE
Dev fix broker return

### DIFF
--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -306,6 +306,7 @@ class BrokerProxy implements IBrokerProxy {
             
             final Date expires;
             if (bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE) == 0) {
+            	Logger.v(TAG, "Broker doesn't return expire date, set it current date plus one hour");
             	final Calendar currentTime = new GregorianCalendar();
             	currentTime.add(Calendar.SECOND, AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC);;
             	expires = currentTime.getTime(); 

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -301,7 +301,7 @@ class BrokerProxy implements IBrokerProxy {
             // IDtoken is not present in the current broker user model
             UserInfo userinfo = UserInfo.getUserInfoFromBrokerResult(bundleResult);
             final String tenantId = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID, "");
-            final Date expires = new Date( bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE));
+            final Date expires = new Date(bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE));
             
             AuthenticationResult result = new AuthenticationResult(
                     bundleResult.getString(AccountManager.KEY_AUTHTOKEN), "", expires, false,

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -21,7 +21,9 @@ package com.microsoft.aad.adal;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 
 import android.accounts.Account;
@@ -301,7 +303,16 @@ class BrokerProxy implements IBrokerProxy {
             // IDtoken is not present in the current broker user model
             UserInfo userinfo = UserInfo.getUserInfoFromBrokerResult(bundleResult);
             final String tenantId = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID, "");
-            final Date expires = new Date(bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE));
+            
+            final Date expires;
+            if (bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE) == 0) {
+            	final Calendar currentTime = new GregorianCalendar();
+            	currentTime.add(Calendar.SECOND, AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC);;
+            	expires = currentTime.getTime(); 
+            }
+            else {
+            	expires = new Date(bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE));
+            }
             
             AuthenticationResult result = new AuthenticationResult(
                     bundleResult.getString(AccountManager.KEY_AUTHTOKEN), "", expires, false,

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -21,6 +21,7 @@ package com.microsoft.aad.adal;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Date;
 import java.util.List;
 
 import android.accounts.Account;
@@ -299,9 +300,12 @@ class BrokerProxy implements IBrokerProxy {
 
             // IDtoken is not present in the current broker user model
             UserInfo userinfo = UserInfo.getUserInfoFromBrokerResult(bundleResult);
+            final String tenantId = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID, "");
+            final Date expires = new Date( bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE));
+            
             AuthenticationResult result = new AuthenticationResult(
-                    bundleResult.getString(AccountManager.KEY_AUTHTOKEN), "", null, false,
-                    userinfo, "", "");
+                    bundleResult.getString(AccountManager.KEY_AUTHTOKEN), "", expires, false,
+                    userinfo, tenantId, "");
             return result;
         }
     }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -381,6 +381,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = getAuthenticationContext(mockContext,
                 "https://login.windows.net/common", false, null);
+        setConnectionAvailable(context, true);
         final MockActivity testActivity = new MockActivity();
         final CountDownLatch signal = new CountDownLatch(1);
         MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
@@ -416,6 +417,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = getAuthenticationContext(mockContext,
                 "https://login.windows.net/common", false, null);
+        setConnectionAvailable(context, true);
         final MockActivity testActivity = new MockActivity();
         final CountDownLatch signal = new CountDownLatch(1);
         MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
@@ -441,6 +443,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = getAuthenticationContext(mockContext,
                 "https://login.windows.net/common", false, null);
+        setConnectionAvailable(context, true);
         final MockActivity testActivity = new MockActivity();
         final CountDownLatch signal = new CountDownLatch(1);
         MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
@@ -484,6 +487,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = getAuthenticationContext(mockContext,
                 "https://login.windows.net/common", false, null);
+        setConnectionAvailable(context, true);
         final MockActivity testActivity = new MockActivity();
         final CountDownLatch signal = new CountDownLatch(1);
         String expected = "&extraParam=1";
@@ -806,6 +810,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         AuthenticationContext context = new AuthenticationContext(mockContext, VALID_AUTHORITY,
                 true);
+        setConnectionAvailable(context, true);
         final CountDownLatch signal = new CountDownLatch(1);
         MockActivity testActivity = new MockActivity();
         testActivity.mSignal = signal;
@@ -832,6 +837,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY,
                 true, null);
+        setConnectionAvailable(context, true);
         final CountDownLatch signal = new CountDownLatch(1);
         UUID correlationId = UUID.randomUUID();
         MockActivity testActivity = new MockActivity();
@@ -921,6 +927,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = getAuthenticationContext(mockContext,
                 VALID_AUTHORITY, false, null);
+        setConnectionAvailable(context, true);
         final MockActivity testActivity = new MockActivity();
         final CountDownLatch signal = new CountDownLatch(1);
         testActivity.mSignal = signal;
@@ -1798,7 +1805,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
         clearCache(context);
     }
-
+ 
     @SmallTest
     public void testAcquireTokenMultiResource_ADFSIssue() throws InterruptedException,
             IllegalArgumentException, NoSuchFieldException, IllegalAccessException,

--- a/tests/Functional/src/com/microsoft/aad/adal/test/BrokerProxyTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/BrokerProxyTests.java
@@ -57,7 +57,6 @@ import android.content.pm.Signature;
 import android.os.Bundle;
 import android.os.Handler;
 import android.test.AndroidTestCase;
-import android.test.suitebuilder.annotation.Suppress;
 import android.util.Base64;
 import android.util.Log;
 
@@ -68,7 +67,7 @@ import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.UserInfo;
-@Suppress
+
 public class BrokerProxyTests extends AndroidTestCase {
 
     private static final String TAG = "BrokerProxyTests";

--- a/tests/Functional/src/com/microsoft/aad/adal/test/BrokerProxyTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/BrokerProxyTests.java
@@ -30,6 +30,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Date;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -56,6 +57,7 @@ import android.content.pm.Signature;
 import android.os.Bundle;
 import android.os.Handler;
 import android.test.AndroidTestCase;
+import android.test.suitebuilder.annotation.Suppress;
 import android.util.Base64;
 import android.util.Log;
 
@@ -66,7 +68,7 @@ import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.UserInfo;
-
+@Suppress
 public class BrokerProxyTests extends AndroidTestCase {
 
     private static final String TAG = "BrokerProxyTests";
@@ -467,6 +469,64 @@ public class BrokerProxyTests extends AndroidTestCase {
         AuthenticationResult result = (AuthenticationResult)m.invoke(brokerProxy, authRequest);
 
         // assert
+        assertNotNull("userinfo is expected", result.getUserInfo());
+        assertEquals("userid in userinfo is expected", acctName, result.getUserInfo().getUserId());
+        assertEquals("givenName in userinfo is expected", "givenName", result.getUserInfo()
+                .getGivenName());
+        assertEquals("familyName in userinfo is expected", "familyName", result.getUserInfo()
+                .getFamilyName());
+        assertEquals("idp in userinfo is expected", "idp", result.getUserInfo()
+                .getIdentityProvider());
+        assertEquals("displayable in userinfo is expected", acctName, result.getUserInfo()
+                .getDisplayableId());
+    }
+    
+    public void testGetAuthTokenInBackground_VerifyAuthenticationResult() throws IllegalAccessException,
+    IllegalArgumentException, InvocationTargetException, ClassNotFoundException,
+    NoSuchMethodException, InstantiationException, OperationCanceledException,
+    AuthenticatorException, IOException, NoSuchFieldException {
+    	Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
+    	String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+    	String acctName = "testAcct123";
+        Object authRequest = createAuthenticationRequest("https://login.windows.net/authtest",
+                "resource", "client", "redirect", acctName.toLowerCase(Locale.US),
+                PromptBehavior.Auto, "", UUID.randomUUID());
+        
+        Account [] accts = getAccountList(acctName, authenticatorType);
+        Bundle expected = new Bundle();
+        expected.putString(AccountManager.KEY_AUTHTOKEN, "token123");
+        expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID, "testTenant");
+        expected.putLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE, 1000);
+        expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID, acctName);
+        expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME, "givenName");
+        expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
+                "familyName");
+        expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER, "idp");
+        expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
+                acctName);
+        
+        AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
+        AccountManager mockAcctManager = mock(AccountManager.class);
+        when(mockFuture.getResult()).thenReturn(expected);
+        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
+        when(
+                mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class),
+                        eq(false), (AccountManagerCallback<Bundle>)eq(null), any(Handler.class)))
+                .thenReturn(mockFuture);
+        Context mockContext = mock(Context.class);
+        when(mockContext.getMainLooper()).thenReturn(null);
+        updateContextToSaveAccount(mockContext, "", acctName);
+        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
+        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
+
+        // action
+        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground",
+                authRequest.getClass());
+        AuthenticationResult result = (AuthenticationResult)m.invoke(brokerProxy, authRequest);
+        
+        //Make sure what returned from broker is consistent with what returned from adal
+        assertEquals("tenant id is expected", "testTenant", result.getTenantId());
+        assertEquals("token expires is expected", new Date(1000), result.getExpiresOn());
         assertNotNull("userinfo is expected", result.getUserInfo());
         assertEquals("userid in userinfo is expected", acctName, result.getUserInfo().getUserId());
         assertEquals("givenName in userinfo is expected", "givenName", result.getUserInfo()


### PR DESCRIPTION
read expire date and tenant id from broker response.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/445%23discussion_r42199949%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2081f36b78a9d069aa1bef1228908a165b3a810c25%20src/src/com/microsoft/aad/adal/BrokerProxy.java%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-android/pull/445%23discussion_r42199949%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20will%20mark%20the%20token%20as%20expired%20on%20Jan%201%2C%201970.%20if%20date%20is%20not%20returned%20from%20the%20broker%20then%20we%20should%20assume%201%20hour%20as%20the%20default%20expiration%20time.%20This%20is%20how%20iOS%20and%20.NET%20work%20when%20date%20is%20not%20returned%20from%20the%20SERVER.%20In%20this%20case%20you%20are%20speaking%20to%20the%20broker%20that%20does%20return%20the%20value%2C%20but%20we%20should%20still%20bullet%20proof%20the%20code.%22%2C%20%22created_at%22%3A%20%222015-10-16T01%3A00%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/src/com/microsoft/aad/adal/BrokerProxy.java%3AL300-312%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 81f36b78a9d069aa1bef1228908a165b3a810c25 src/src/com/microsoft/aad/adal/BrokerProxy.java 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/445#discussion_r42199949'>File: src/src/com/microsoft/aad/adal/BrokerProxy.java:L300-312</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> this will mark the token as expired on Jan 1, 1970. if date is not returned from the broker then we should assume 1 hour as the default expiration time. This is how iOS and .NET work when date is not returned from the SERVER. In this case you are speaking to the broker that does return the value, but we should still bullet proof the code.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/445?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-android/pull/445?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/445'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>