### PR TITLE
Dev exxon

### DIFF
--- a/src/AndroidManifest.xml
+++ b/src/AndroidManifest.xml
@@ -6,11 +6,10 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application
-        android:allowBackup="true"
-        android:theme="@style/AppTheme" >
+        android:allowBackup="true">
         <activity android:name="com.microsoft.aad.adal.AuthenticationActivity" >
         </activity>
     </application>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -167,7 +167,7 @@
           <resourceDirectory>${project.basedir}/res</resourceDirectory>
           <nativeLibrariesDirectory>${project.basedir}/src/main/native</nativeLibrariesDirectory>
           <sdk>
-            <platform>18</platform>
+            <platform>21</platform>
           </sdk>
           <dexCoreLibrary>true</dexCoreLibrary>
           <deleteConflictingFiles>true</deleteConflictingFiles>

--- a/src/project.properties
+++ b/src/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-19
+target=android-21
 android.library=true

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -668,7 +668,7 @@ public class AuthenticationActivity extends Activity {
                     } catch (KeyChainException e) {
                         Log.e(TAG, "KeyChain exception", e);
                     } catch (InterruptedException e) {
-                        Log.e(TAG, "KeyChain exception", e);
+                        Log.e(TAG, "InterruptedException exception", e);
                     }
                 }
             }, request.getKeyTypes(), request.getPrincipals(), request.getHost(), request.getPort(), null);

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -68,8 +68,7 @@ abstract class BasicWebViewClient extends WebViewClient {
     
     public abstract void setPKeyAuthStatus(boolean status);
     
-    public abstract void postRunnable(Runnable item);
-    
+    public abstract void postRunnable(Runnable item);    
 
     @Override
     public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler,
@@ -144,6 +143,7 @@ abstract class BasicWebViewClient extends WebViewClient {
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
+    	Logger.v(TAG + "onPageStarted", "page is started with the url " + url);
         super.onPageStarted(view, url, favicon);
         showSpinner(true);
     }


### PR DESCRIPTION
1. support client tls for authenticating user
2. remove android:theme in manifest, as a library, we shouldn't provide it, this could potentially cause calling app building errors. 