### PR TITLE
should continue with regular sign-in when no cert found for client TL…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: android
 jdk: oraclejdk7
 android:
   components:
-    - build-tools-19.1.0
+    - build-tools-21.1.1
 env:
     matrix:
-      - ANDROID_SDKS=android-18 ANDROID_TARGET=android-18
+      - ANDROID_SDKS=android-21 ANDROID_TARGET=android-21
 
 before_install:
   # setup maven android sdk deployer
   - git clone git://github.com/mosabua/maven-android-sdk-deployer.git
-  - cd $PWD/maven-android-sdk-deployer/platforms/android-18
+  - cd $PWD/maven-android-sdk-deployer/platforms/android-21
   - mvn clean install
   - cd -
   - cd $PWD/maven-android-sdk-deployer/extras/compatibility-v4
@@ -18,8 +18,8 @@ before_install:
   - cd -
 
   # setup main and testproject
-  - android update lib-project -p src --target android-18
-  - android update project -p tests/testapp --target android-18
+  - android update lib-project -p src --target android-21
+  - android update project -p tests/testapp --target android-21
   - android update test-project -p tests/testapp -m tests
 
 before_script:
@@ -30,7 +30,7 @@ before_script:
   - sleep 5 # wait xvfb to start
   - xdpyinfo -display :99 >/dev/null 2>&1 && echo "In use" || echo "Free"
   # create and start emulator
-  - echo no | android create avd --force -n test -t android-18 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio &   
   # wait for emulator to start
   - chmod +x wait_for_emulator.sh

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -645,18 +645,28 @@ public class AuthenticationActivity extends Activity {
             KeyChain.choosePrivateKeyAlias(AuthenticationActivity.this, new KeyChainAliasCallback() {
 
                 @Override
-                public void alias(String alias) {
+                public void alias(String alias) 
+                {
+                    if (alias == null)
+                    {
+                        request.cancel();
+                        return;
+                    }
+                    
                     try {
-                    	final X509Certificate[] certChain = KeyChain.getCertificateChain(
+                        final X509Certificate[] certChain = KeyChain.getCertificateChain(
                                 getApplicationContext(), alias);
-                    	final PrivateKey privateKey = KeyChain.getPrivateKey(mCallingContext, alias);
-                        request.proceed(privateKey, certChain);
+                        final PrivateKey privateKey = KeyChain.getPrivateKey(mCallingContext, alias);
                         
+                        request.proceed(privateKey, certChain);
+                        return;
                     } catch (KeyChainException e) {
                         Log.e(TAG, "KeyChain exception", e);
                     } catch (InterruptedException e) {
                         Log.e(TAG, "InterruptedException exception", e);
                     }
+                    
+                    request.cancel();
                 }
             }, request.getKeyTypes(), request.getPrincipals(), request.getHost(), request.getPort(), null);
         }

--- a/wait_for_emulator.sh
+++ b/wait_for_emulator.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
+set +e
+
 bootanim=""
 failcounter=0
+timeout_in_sec=360
+
 until [[ "$bootanim" =~ "stopped" ]]; do
-   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1`
-   echo "$bootanim"
-   if [[ "$bootanim" =~ "not found" ]]; then
-      let "failcounter += 1"
-      if [[ $failcounter -gt 3 ]]; then
-        echo "Failed to start emulator"
-        exit 1
-      fi
-   fi
-   sleep 1
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" ]]; then
+    let "failcounter += 1"
+    echo "Waiting for emulator to start"
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  fi
+  sleep 1
 done
-echo "Done"
+
+echo "Emulator is ready"


### PR DESCRIPTION
When webview receives the client TLS request, if there is no cert found, and user clicks on cancel, we should continue with the regular sign-in. 

also update the travis fail since updating the android version to 21