### PR TITLE
not repond to client tls if issuer contains CN=MS-Organization-Access

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -303,7 +303,7 @@ public class AuthenticationConstants {
         
         public static final String AZURE_AUTHENTICATOR_APP_PACKAGE_NAME = "com.azure.authenticator";
 
-        public static final String CLIENT_TLS_REDIRECT = "urn:http-auth:PKeyAuth";
+        public static final String PKEYAUTH_REDIRECT = "urn:http-auth:PKeyAuth";
 
         public static final String CHALLANGE_TLS_INCAPABLE = "x-ms-PKeyAuth";
 

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -151,8 +151,8 @@ abstract class BasicWebViewClient extends WebViewClient {
     @Override
     public boolean shouldOverrideUrlLoading(final WebView view, String url) {
         Logger.v(TAG, "Navigation is detected");
-        if (url.startsWith(AuthenticationConstants.Broker.CLIENT_TLS_REDIRECT)) {
-            Logger.v(TAG, "Webview detected request for client certificate");
+        if (url.startsWith(AuthenticationConstants.Broker.PKEYAUTH_REDIRECT)) {
+            Logger.v(TAG, "Webview detected request for pkeyauth challenge.");
             view.stopLoading();
             setPKeyAuthStatus(true);
             final String challangeUrl = url;

--- a/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
+++ b/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
@@ -130,6 +130,18 @@ class ChallangeResponseBuilder {
 
         return response;
     }
+    
+    private boolean isWorkplaceJoined()
+    {
+        @SuppressWarnings("unchecked")
+        Class<IDeviceCertificate> certClass = (Class<IDeviceCertificate>)AuthenticationSettings.INSTANCE.getDeviceCertificateProxy();
+        if (certClass == null)
+        {
+            return false;
+        }
+        
+        return true;
+    }
 
     private IDeviceCertificate getWPJAPIInstance(Class<IDeviceCertificate> certClazz) {
         IDeviceCertificate deviceCertProxy = null;
@@ -166,14 +178,19 @@ class ChallangeResponseBuilder {
     }
 
     private ChallangeRequest getChallangeRequestFromHeader(final String headerValue)
-            throws UnsupportedEncodingException {
-        if (StringExtensions.IsNullOrBlank(headerValue)) {
+            throws UnsupportedEncodingException 
+    {
+        final String methodName = ":getChallangeRequestFromHeader";
+        
+        if (StringExtensions.IsNullOrBlank(headerValue)) 
+        {
             throw new IllegalArgumentException("headerValue");
         }
 
         // Header value should start with correct challenge type
         if (!StringExtensions.hasPrefixInHeader(headerValue,
-                AuthenticationConstants.Broker.CHALLANGE_RESPONSE_TYPE)) {
+                AuthenticationConstants.Broker.CHALLANGE_RESPONSE_TYPE)) 
+        {
             throw new AuthenticationException(ADALError.DEVICE_CERTIFICATE_REQUEST_INVALID,
                     headerValue);
         }
@@ -184,7 +201,8 @@ class ChallangeResponseBuilder {
         ArrayList<String> queryPairs = StringExtensions.splitWithQuotes(authenticateHeader, ',');
         HashMap<String, String> headerItems = new HashMap<String, String>();
 
-        for (String queryPair : queryPairs) {
+        for (String queryPair : queryPairs) 
+        {
             ArrayList<String> pair = StringExtensions.splitWithQuotes(queryPair, '=');
             if (pair.size() == 2 && !StringExtensions.IsNullOrBlank(pair.get(0))
                     && !StringExtensions.IsNullOrBlank(pair.get(1))) {
@@ -195,8 +213,9 @@ class ChallangeResponseBuilder {
                 key = key.trim();
                 value = StringExtensions.removeQuoteInHeaderValue(value.trim());
                 headerItems.put(key, value);
-            } else {
-
+            } 
+            else 
+            {
                 // invalid format
                 throw new AuthenticationException(ADALError.DEVICE_CERTIFICATE_REQUEST_INVALID,
                         authenticateHeader);
@@ -209,17 +228,30 @@ class ChallangeResponseBuilder {
             challange.mNonce = headerItems.get(RequestField.Nonce.name().toLowerCase(Locale.US));
         }
         
-        if (!StringExtensions.IsNullOrBlank(headerItems.get(RequestField.CertThumbprint.name()))){
-        	challange.mThumbprint = headerItems.get(RequestField.CertThumbprint.name());
+        // When pkeyauth header is present, ADFS is always trying to device auth. When hitting token endpoint(device
+        // challenge will be returned via 401 challenge), ADFS is sending back an empty cert thumbprint when they found
+        // the device is not managed. To account for the behavior of how ADFS performs device auth, below code is checking 
+        // if it's already workplace joined before checking the existence of cert thumprint or authority from returned challenge. 
+        if (!isWorkplaceJoined())
+        {
+            Logger.v(TAG + methodName, "Device is not workplace joined. ");
         }
-        else if (headerItems.containsKey(RequestField.CertAuthorities.name())) {
-        	String authorities = headerItems.get(RequestField.CertAuthorities.name());
-        	challange.mCertAuthorities = StringExtensions.getStringTokens(authorities, 
-    				AuthenticationConstants.Broker.CHALLANGE_REQUEST_CERT_AUTH_DELIMETER);
+        else if (!StringExtensions.IsNullOrBlank(headerItems.get(RequestField.CertThumbprint.name())))
+        {
+            Logger.v(TAG + methodName, "CertThumbprint exists in the device auth challenge.");
+            challange.mThumbprint = headerItems.get(RequestField.CertThumbprint.name());
         }
-        else {
-        	throw new AuthenticationException(ADALError.DEVICE_CERTIFICATE_REQUEST_INVALID, 
-        			"Both certThumbprint and certauthorities are not present");
+        else if (headerItems.containsKey(RequestField.CertAuthorities.name())) 
+        {
+            Logger.v(TAG + methodName, "CertAuthorities exists in the device auth challenge.");
+            String authorities = headerItems.get(RequestField.CertAuthorities.name());
+            challange.mCertAuthorities = StringExtensions.getStringTokens(authorities, 
+                AuthenticationConstants.Broker.CHALLANGE_REQUEST_CERT_AUTH_DELIMETER);
+        }
+        else 
+        {
+            throw new AuthenticationException(ADALError.DEVICE_CERTIFICATE_REQUEST_INVALID, 
+                "Both certThumbprint and certauthorities are not present");
         }
         
         challange.mVersion = headerItems.get(RequestField.Version.name());

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationActivityUnitTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationActivityUnitTest.java
@@ -225,7 +225,7 @@ public class AuthenticationActivityUnitTest extends ActivityUnitTestCase<Authent
         MockDeviceCertProxy.reset();
         MockDeviceCertProxy.sValidIssuer = true;
         MockDeviceCertProxy.sPrivateKey = null;
-        String url = AuthenticationConstants.Broker.CLIENT_TLS_REDIRECT
+        String url = AuthenticationConstants.Broker.PKEYAUTH_REDIRECT
                 + "?Nonce=nonce1234&CertAuthorities=ABC&Version=1.0&SubmitUrl=submiturl&Context=serverContext";
         WebViewClient client = getCustomWebViewClient();
         WebView mockview = new WebView(getActivity().getApplicationContext());


### PR DESCRIPTION
1. when webview receives client TLS request, if acceptable issuer contains CN=MS-Organization-Access, then do not respond to the request. 
2. Workarround for responding to device auth challenge returned from ADFS on token endpoint. ADFS is returning an empty cert thumbprint, while ADAL asks either cert thumbprint or cert authority be to present. Fix for this is to check if the device is already workplace joined before checking for the presence of cert thumbprint or authority. 
3. fix some logs. 
4. add unit test for 2