### PR TITLE
For silent request throw exception when access token couldn't be obtained

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1625,7 +1625,11 @@ public class AuthenticationContext {
                 // remove item from cache to avoid same usage of
                 // refresh token in next acquireToken call
                 removeItemFromCache(refreshItem);
-                return acquireTokenLocalCall(callbackHandle, activity, useDialog, request);
+                if (!request.isSilent() && callbackHandle.callback != null && activity != null) {
+                    return acquireTokenLocalCall(callbackHandle, activity, useDialog, request);
+                } else {
+                    throw new AuthenticationException(ADALError.AUTH_FAILED_SERVER_ERROR, request.getLogInfo() + errLogInfo);
+                }
             } else {
                 Logger.v(TAG, "It finished refresh token request:" + request.getLogInfo());
                 if (result.getUserInfo() == null && refreshItem.mUserInfo != null) {


### PR DESCRIPTION
Currently if server response was something that doesn't contain access token, it wipes refresh token from cache and tries to acqure token again.
But if the request was silent we will fail with error "Prompt is not allowed and failed to get token", which doesn't give any info why token was wiped.
I propose in case of silent request shouldn't even try to acquire token, instead throw exception with server response error. It will give info why token was wiped.