### PR TITLE
remove catching generic Exception and catch only expected ones

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -179,8 +179,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -161,19 +161,14 @@ public class AuthenticationParameters {
             public void run() {
                 HashMap<String, String> headers = new HashMap<String, String>();
                 headers.put(WebRequestHandler.HEADER_ACCEPT, WebRequestHandler.HEADER_ACCEPT_JSON);
+                HttpWebResponse webResponse = sWebRequest.sendGet(resourceUrl, headers);
 
-                try {
-                    HttpWebResponse webResponse = sWebRequest.sendGet(resourceUrl, headers);
-
-                    if (webResponse != null) {
-                        try {
-                            onCompleted(null, parseResponse(webResponse));
-                        } catch (IllegalArgumentException exc) {
-                            onCompleted(exc, null);
-                        }
+                if (webResponse != null) {
+                    try {
+                        onCompleted(null, parseResponse(webResponse));
+                    } catch (IllegalArgumentException exc) {
+                        onCompleted(exc, null);
                     }
-                } catch (Exception exception) {
-                    onCompleted(exception, null);
                 }
             }
 

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -183,24 +183,6 @@ abstract class BasicWebViewClient extends WebViewClient {
                                 view.loadUrl(loadUrl, headers);
                             }
                         });
-                    } catch (IllegalArgumentException e) {
-                        Logger.e(TAG, "Argument exception", e.getMessage(),
-                                ADALError.ARGUMENT_EXCEPTION, e);
-                        // It should return error code and finish the
-                        // activity, so that onActivityResult implementation
-                        // returns errors to callback.
-                        Intent resultIntent = new Intent();
-                        resultIntent.putExtra(
-                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
-                                        e);
-                        if (mRequest != null) {
-                            resultIntent.putExtra(
-                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
-                                    mRequest);
-                        }
-                        sendResponse(
-                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
-                                resultIntent);
                     } catch (AuthenticationException e) {
                         Logger.e(TAG, "It is failed to create device certificate response",
                                 e.getMessage(), ADALError.DEVICE_CERTIFICATE_RESPONSE_FAILED, e);
@@ -219,20 +201,7 @@ abstract class BasicWebViewClient extends WebViewClient {
                         sendResponse(
                                 AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
                                 resultIntent);
-                    } catch (Exception e) {
-                        Intent resultIntent = new Intent();
-                        resultIntent.putExtra(
-                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
-                                        e);
-                        if (mRequest != null) {
-                            resultIntent.putExtra(
-                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
-                                    mRequest);
                         }
-                        sendResponse(
-                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
-                                resultIntent);
-                    }
                 }
             }).start();
 
@@ -281,18 +250,13 @@ abstract class BasicWebViewClient extends WebViewClient {
     }
     
     private boolean hasCancelError(String redirectUrl) {
-        try {
-            HashMap<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
-            String error = parameters.get("error");
-            String errorDescription = parameters.get("error_description");
+        HashMap<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
+        String error = parameters.get("error");
+        String errorDescription = parameters.get("error_description");
 
-            if (!StringExtensions.IsNullOrBlank(error)) {
-                Logger.v(TAG, "Cancel error:" + error + " " + errorDescription);
-                return true;
-            }
-        } catch (Exception exc) {
-            Logger.e(TAG, "Error in processing url parameters", "Url:" + redirectUrl,
-                    ADALError.ERROR_WEBVIEW);
+        if (!StringExtensions.IsNullOrBlank(error)) {
+            Logger.w(TAG, "Cancel error:" + error, errorDescription, null);
+            return true;
         }
 
         return false;

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -220,7 +220,7 @@ class BrokerProxy implements IBrokerProxy {
                 if (matchingUser != null) {
                     targetAccount = findAccount(matchingUser.getDisplayableId(), accountList);
                 }
-            } catch (Exception e) {
+            } catch (IOException | AuthenticatorException | OperationCanceledException e) {
                 Logger.e(TAG, e.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION, e);
             }
         }
@@ -539,7 +539,7 @@ class BrokerProxy implements IBrokerProxy {
                 users = getBrokerUsers();
                 UserInfo matchingUser = findUserInfo(uniqueId, users);
                 return matchingUser != null;
-            } catch (Exception e) {
+            } catch (IOException | AuthenticatorException | OperationCanceledException e) {
                 Logger.e(TAG, "VerifyAccount:" + e.getMessage(), "",
                         ADALError.BROKER_AUTHENTICATOR_EXCEPTION, e);
             }
@@ -592,11 +592,7 @@ class BrokerProxy implements IBrokerProxy {
         } catch (NoSuchAlgorithmException e) {
             Logger.e(TAG, "Digest SHA algorithm does not exists", "",
                     ADALError.DEVICE_NO_SUCH_ALGORITHM);
-        } catch (Exception e) {
-            Logger.e(TAG, "Error in verifying signature", "", ADALError.BROKER_VERIFICATION_FAILED,
-                    e);
         }
-
         return false;
     }
 

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -18,6 +18,8 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -105,7 +107,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     private String encrypt(String value) {
         try {
             return sHelper.encrypt(value);
-        } catch (Exception e) {
+        } catch (GeneralSecurityException | IOException e) {
             Logger.e(TAG, "Encryption failure", "", ADALError.ENCRYPTION_FAILED, e);
         }
 
@@ -115,7 +117,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     private String decrypt(String value) {
         try {
             return sHelper.decrypt(value);
-        } catch (Exception e) {
+        } catch (GeneralSecurityException | IOException e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.ENCRYPTION_FAILED, e);
             if (!StringExtensions.IsNullOrBlank(value)) {
                 Logger.v(TAG, String.format("Decryption error for key: '%s'. Item will be removed",

--- a/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
@@ -21,8 +21,10 @@ package com.microsoft.aad.adal;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OptionalDataException;
 
 import android.content.Context;
 
@@ -102,7 +104,7 @@ public class FileTokenCacheStore implements ITokenCacheStore {
                 Logger.v(TAG, "There is not any previous cache file to load cache.");
                 mInMemoryCache = new MemoryTokenCacheStore();
             }
-        } catch (Exception ex) {
+        } catch (IOException | ClassNotFoundException ex) {
             Logger.e(TAG, "Exception during cache load",
                     ExceptionExtensions.getExceptionMessage(ex),
                     ADALError.DEVICE_FILE_CACHE_IS_NOT_LOADED_FROM_FILE);
@@ -156,7 +158,7 @@ public class FileTokenCacheStore implements ITokenCacheStore {
                     objectStream.close();
                     outputStream.close();
 
-                } catch (Exception ex) {
+                } catch (IOException ex) {
                     Logger.e(TAG, "Exception during cache flush",
                             ExceptionExtensions.getExceptionMessage(ex),
                             ADALError.DEVICE_FILE_CACHE_IS_NOT_WRITING_TO_FILE);

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -68,7 +68,7 @@ class HttpWebRequest {
 
     int mTimeOut = CONNECT_TIME_OUT;
 
-    Exception mException = null;
+    private Exception mException = null;
 
     HashMap<String, String> mRequestHeaders = null;
 
@@ -138,7 +138,7 @@ class HttpWebRequest {
                 mConnection.setUseCaches(mUseCaches);
                 mConnection.setRequestMethod(mRequestMethod);
                 mConnection.setDoInput(true); // it will at least read status
-                                              // code. Default is true.
+                // code. Default is true.
                 setRequestBody();
 
                 byte[] responseBody = null;
@@ -182,8 +182,10 @@ class HttpWebRequest {
                 Logger.v(TAG, "Response is received");
                 response.setBody(responseBody);
                 response.setResponseHeaders(mConnection.getHeaderFields());
-            } catch (Exception e) {
-                Logger.e(TAG, "Exception:" + e.getMessage(), " Method:" + mRequestMethod,
+            } catch (InterruptedException ignore) {
+                Logger.v(TAG, "Thread.sleep got interrupted exception " + ignore);
+            } catch (IOException e ) {
+                Logger.e(TAG, "IOException:" + e.getMessage(), " Method:" + mRequestMethod,
                         ADALError.SERVER_ERROR, e);
                 mException = e;
             } finally {

--- a/src/src/com/microsoft/aad/adal/HttpWebResponse.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebResponse.java
@@ -29,7 +29,7 @@ public class HttpWebResponse {
     private int mStatusCode;
     private byte[] mResponseBody;
     private Map<String, List<String>> mResponseHeaders;
-    private Exception mResponseException = null;
+    private Throwable mResponseException = null;
 
     public HttpWebResponse() {
         mStatusCode = HttpURLConnection.HTTP_OK;
@@ -43,11 +43,11 @@ public class HttpWebResponse {
         mResponseHeaders = responseHeaders;
     }
 
-    public Exception getResponseException() {
+    public Throwable getResponseException() {
         return mResponseException;
     }
 
-    public void setResponseException(Exception responseException) {
+    public void setResponseException(Throwable responseException) {
         this.mResponseException = responseException;
     }
 

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -18,6 +18,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -315,7 +316,7 @@ class Oauth2 {
                     return idtokenInfo;
                 }
             }
-        } catch (Exception ex) {
+        } catch (JSONException | UnsupportedEncodingException ex) {
             Logger.e(TAG, "Error in parsing user id token", null,
                     ADALError.IDTOKEN_PARSING_FAILURE, ex);
         }
@@ -326,16 +327,15 @@ class Oauth2 {
             throws JSONException {
         final JSONObject jsonObject = new JSONObject(jsonStr);
 
-        @SuppressWarnings("unchecked")
-        final Iterator<String> i = jsonObject.keys();
+        final Iterator<?> i = jsonObject.keys();
 
         while (i.hasNext()) {
-            final String key = i.next();
+            final String key = (String) i.next();
             responseItems.put(key, jsonObject.getString(key));
         }
     }
 
-    public AuthenticationResult refreshToken(String refreshToken) throws Exception {
+    public AuthenticationResult refreshToken(String refreshToken) throws IOException {
         String requestMessage = null;
         if (mWebRequestHandler == null) {
             Logger.v(TAG, "Web request is not set correctly");
@@ -369,7 +369,7 @@ class Oauth2 {
      *         not have protocol error.
      * @throws Exception
      */
-    public AuthenticationResult getToken(String authorizationUrl) throws Exception {
+    public AuthenticationResult getToken(String authorizationUrl) throws IOException {
 
         if (StringExtensions.IsNullOrBlank(authorizationUrl)) {
             throw new IllegalArgumentException("authorizationUrl");
@@ -418,7 +418,7 @@ class Oauth2 {
      * @return Token in the AuthenticationResult
      * @throws Exception
      */
-    public AuthenticationResult getTokenForCode(String code) throws Exception {
+    public AuthenticationResult getTokenForCode(String code) throws IOException {
 
         String requestMessage = null;
         if (mWebRequestHandler == null) {
@@ -438,7 +438,7 @@ class Oauth2 {
     }
 
     private AuthenticationResult postMessage(String requestMessage, HashMap<String, String> headers)
-            throws Exception {
+            throws IOException {
         URL authority = null;
         AuthenticationResult result = null;
         authority = StringExtensions.getUrl(getTokenEndpoint());
@@ -517,7 +517,7 @@ class Oauth2 {
 
                 Logger.v(TAG, "Server error message:" + errMessage);
                 if (response.getResponseException() != null) {
-                    throw response.getResponseException();
+                    throw new IOException(response.getResponseException());
                 }
             } else {
                 ClientMetrics.INSTANCE.setLastErrorCodes(result.getErrorCodes());
@@ -530,7 +530,7 @@ class Oauth2 {
             ClientMetrics.INSTANCE.setLastError(null);
             Logger.e(TAG, e.getMessage(), "", ADALError.ENCODING_IS_NOT_SUPPORTED, e);
             throw e;
-        } catch (Exception e) {
+        } catch (IOException e) {
             ClientMetrics.INSTANCE.setLastError(null);
             Logger.e(TAG, e.getMessage(), "", ADALError.SERVER_ERROR, e);
             throw e;
@@ -585,15 +585,15 @@ class Oauth2 {
             }
         }
 
-        if (webResponse.getBody() != null && webResponse.getBody().length > 0) {
-
+        if (webResponse.getStatusCode() == HttpURLConnection.HTTP_OK
+                && webResponse.getBody() != null && webResponse.getBody().length > 0) {
             // invalid refresh token calls has error related items in the body.
             // Status is 400 for those.
             try {
                 String jsonStr = new String(webResponse.getBody());
                 extractJsonObjects(responseItems, jsonStr);
                 result = processUIResponseParams(responseItems);
-            } catch (final Exception ex) {
+            } catch (final JSONException ex) {
                 // There is no recovery possible here, so
                 // catch the
                 // generic Exception
@@ -615,18 +615,13 @@ class Oauth2 {
 
         // Set correlationId in the result
         if (correlationIdInHeader != null && !correlationIdInHeader.isEmpty()) {
-            try {
-                UUID correlation = UUID.fromString(correlationIdInHeader);
-                if (!correlation.equals(mRequest.getCorrelationId())) {
-                    Logger.w(TAG, "CorrelationId is not matching", "",
-                            ADALError.CORRELATION_ID_NOT_MATCHING_REQUEST_RESPONSE);
-                }
-
-                Logger.v(TAG, "Response correlationId:" + correlationIdInHeader);
-            } catch (Exception ex) {
-                Logger.e(TAG, "Wrong format of the correlation ID:" + correlationIdInHeader, "",
-                        ADALError.CORRELATION_ID_FORMAT, ex);
+            UUID correlation = UUID.fromString(correlationIdInHeader);
+            if (!correlation.equals(mRequest.getCorrelationId())) {
+                Logger.w(TAG, "CorrelationId is not matching", "",
+                        ADALError.CORRELATION_ID_NOT_MATCHING_REQUEST_RESPONSE);
             }
+
+            Logger.v(TAG, "Response correlationId:" + correlationIdInHeader);
         }
 
         return result;

--- a/src/src/com/microsoft/aad/adal/PRNGFixes.java
+++ b/src/src/com/microsoft/aad/adal/PRNGFixes.java
@@ -36,6 +36,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
@@ -101,7 +102,7 @@ final class PRNGFixes {
                 throw new IOException("Unexpected number of bytes read from Linux PRNG: "
                         + bytesRead);
             }
-        } catch (Exception e) {
+        } catch (IOException | ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             Logger.e(TAG, "Failed to seed OpenSSL PRNG", "", ADALError.DEVICE_PRNG_FIX_ERROR, e);
             throw new SecurityException("Failed to seed OpenSSL PRNG", e);
         }

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -164,7 +164,7 @@ public class StorageHelper {
                     sMacKey = getMacKey(sKey);
                     sBlobVersion = VERSION_ANDROID_KEY_STORE;
                     return;
-                } catch (Exception e) {
+                } catch (IOException | GeneralSecurityException e) {
                     Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
                             ADALError.ANDROIDKEYSTORE_FAILED, e);
                 }
@@ -207,7 +207,7 @@ public class StorageHelper {
                     // key
                     // used for Encryption and HMac
                     return getSecretKeyFromAndroidKeyStore();
-                } catch (Exception e) {
+                } catch (IOException | GeneralSecurityException e) {
                     Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
                             ADALError.ANDROIDKEYSTORE_FAILED, e);
                 }
@@ -466,7 +466,7 @@ public class StorageHelper {
             final byte[] encryptedKey = readKeyData(keyFile);
             sSecretKeyFromAndroidKeyStore = unwrap(wrapCipher, encryptedKey);
             Logger.v(TAG, "Finished reading SecretKey");
-        } catch (Exception ex) {
+        } catch (GeneralSecurityException ex) {
             // Reset KeyPair info so that new request will generate correct KeyPairs.
             // All tokens with previous SecretKey are not possible to decrypt.
             Logger.e(TAG, "Unwrap failed for AndroidKeyStore", "", ADALError.ANDROIDKEYSTORE_FAILED);


### PR DESCRIPTION
Currently all Runtime exceptions are swallowed and if they happen it's hard to trace the reason why token is not obtained.
Instead it's better to catch only excepted exceptions, because if unexpected exception happens mobile app should crash and give a stack trace what went wrong, that way it's easy to fix the problem.
Sample: You have button but when you click nothing happens. Or button that crashes you app and you see NPE in you logs...From user stand point - nothing changes because button doesn't work, from dev standpoint - much more info from second case.