### PR TITLE
remove catching generic Exception and catch only expected ones

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -179,8 +179,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -814,7 +814,7 @@ public class AuthenticationActivity extends Activity {
             try {
                 result.taskResult = oauthRequest.getToken(urlItems[0]);
                 Logger.v(TAG, "TokenTask processed the result. " + mRequest.getLogInfo());
-            } catch (IOException exc) {
+            } catch (IOException | UnexpectedServerResponseException exc) {
                 Logger.e(TAG, "Error in processing code to get a token. " + mRequest.getLogInfo(),
                         "Request url:" + urlItems[0],
                         ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, exc);

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.DigestException;
+import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
@@ -127,24 +128,18 @@ public class AuthenticationActivity extends Activity {
             Logger.v(TAG, "ActivityBroadcastReceiver onReceive");
 
             if (intent.getAction().equalsIgnoreCase(AuthenticationConstants.Browser.ACTION_CANCEL)) {
-                try {
-                    Logger.v(TAG,
-                            "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity");
+                Logger.v(TAG,
+                        "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity");
 
-                    int cancelRequestId = intent.getIntExtra(
-                            AuthenticationConstants.Browser.REQUEST_ID, 0);
+                int cancelRequestId = intent.getIntExtra(
+                        AuthenticationConstants.Browser.REQUEST_ID, 0);
 
-                    if (cancelRequestId == mWaitingRequestId) {
-                        Logger.v(TAG, "Waiting requestId is same and cancelling this activity");
-                        AuthenticationActivity.this.finish();
-                        // no need to send result back to activity. It is
-                        // cancelled
-                        // and callback will be called after this request.
-                    }
-                } catch (Exception ex) {
-                    Logger.e(TAG, "ActivityBroadcastReceiver onReceive exception",
-                            ExceptionExtensions.getExceptionMessage(ex),
-                            ADALError.BROADCAST_RECEIVER_ERROR);
+                if (cancelRequestId == mWaitingRequestId) {
+                    Logger.v(TAG, "Waiting requestId is same and cancelling this activity");
+                    AuthenticationActivity.this.finish();
+                    // no need to send result back to activity. It is
+                    // cancelled
+                    // and callback will be called after this request.
                 }
             }
         }
@@ -776,7 +771,7 @@ public class AuthenticationActivity extends Activity {
             try {
                 result.taskResult = oauthRequest.getToken(urlItems[0]);
                 Logger.v(TAG, "TokenTask processed the result. " + mRequest.getLogInfo());
-            } catch (Exception exc) {
+            } catch (IOException exc) {
                 Logger.e(TAG, "Error in processing code to get a token. " + mRequest.getLogInfo(),
                         "Request url:" + urlItems[0],
                         ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, exc);
@@ -790,7 +785,7 @@ public class AuthenticationActivity extends Activity {
                 // Record account in the AccountManager service
                 try {
                     setAccount(result);
-                } catch (Exception exc) {
+                } catch (GeneralSecurityException | IOException exc) {
                     Logger.e(TAG, "Error in setting the account" + mRequest.getLogInfo(), "",
                             ADALError.BROKER_ACCOUNT_SAVE_FAILED, exc);
                     result.taskException = exc;
@@ -826,7 +821,7 @@ public class AuthenticationActivity extends Activity {
             } else {
                 try {
                     appIdList = cryptoHelper.decrypt(appIdList);
-                } catch (Exception ex) {
+                } catch (GeneralSecurityException | IOException ex) {
                     Logger.e(TAG, "appUIDList failed to decrypt", "appIdList:" + appIdList,
                             ADALError.ENCRYPTION_FAILED, ex);
                     appIdList = "";

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -814,7 +814,7 @@ public class AuthenticationActivity extends Activity {
             try {
                 result.taskResult = oauthRequest.getToken(urlItems[0]);
                 Logger.v(TAG, "TokenTask processed the result. " + mRequest.getLogInfo());
-            } catch (IOException | UnexpectedServerResponseException exc) {
+            } catch (IOException | AuthenticationServerProtocolException exc) {
                 Logger.e(TAG, "Error in processing code to get a token. " + mRequest.getLogInfo(),
                         "Request url:" + urlItems[0],
                         ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, exc);

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -793,7 +793,7 @@ public class AuthenticationContext {
                                     result = oauthRequest.getToken(endingUrl);
                                     Logger.v(TAG, "OnActivityResult processed the result. "
                                             + authenticationRequest.getLogInfo());
-                                } catch (IOException | UnexpectedServerResponseException exc) {
+                                } catch (IOException | AuthenticationServerProtocolException exc) {
                                     String msg = "Error in processing code to get token. "
                                             + authenticationRequest.getLogInfo() + correlationInfo;
                                     Logger.e(TAG, msg,
@@ -1595,7 +1595,7 @@ public class AuthenticationContext {
                 Logger.v(TAG, "Refresh token is not returned or empty");
                 result.setRefreshToken(refreshItem.mRefreshToken);
             }
-        } catch (IOException | UnexpectedServerResponseException exc) {
+        } catch (IOException | AuthenticationServerProtocolException exc) {
             // Server side error or similar
             Logger.e(TAG, "Error in refresh token for request:" + request.getLogInfo(),
                     ExceptionExtensions.getExceptionMessage(exc), ADALError.AUTH_FAILED_NO_TOKEN,

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -793,7 +793,7 @@ public class AuthenticationContext {
                                     result = oauthRequest.getToken(endingUrl);
                                     Logger.v(TAG, "OnActivityResult processed the result. "
                                             + authenticationRequest.getLogInfo());
-                                } catch (IOException exc) {
+                                } catch (IOException | UnexpectedServerResponseException exc) {
                                     String msg = "Error in processing code to get token. "
                                             + authenticationRequest.getLogInfo() + correlationInfo;
                                     Logger.e(TAG, msg,
@@ -1595,7 +1595,7 @@ public class AuthenticationContext {
                 Logger.v(TAG, "Refresh token is not returned or empty");
                 result.setRefreshToken(refreshItem.mRefreshToken);
             }
-        } catch (IOException exc) {
+        } catch (IOException | UnexpectedServerResponseException exc) {
             // Server side error or similar
             Logger.e(TAG, "Error in refresh token for request:" + request.getLogInfo(),
                     ExceptionExtensions.getExceptionMessage(exc), ADALError.AUTH_FAILED_NO_TOKEN,

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -166,7 +166,7 @@ public class AuthenticationParameters {
                 if (webResponse != null) {
                     try {
                         onCompleted(null, parseResponse(webResponse));
-                    } catch (IllegalArgumentException exc) {
+                    } catch (UnexpectedServerResponseException exc) {
                         onCompleted(exc, null);
                     }
                 }
@@ -191,11 +191,11 @@ public class AuthenticationParameters {
      * @return {@link AuthenticationParameters}
      */
     public static AuthenticationParameters createFromResponseAuthenticateHeader(
-            String authenticateHeader) {
+            String authenticateHeader) throws UnexpectedServerResponseException{
         AuthenticationParameters authParams = null;
 
         if (StringExtensions.IsNullOrBlank(authenticateHeader)) {
-            throw new IllegalArgumentException(AUTH_HEADER_MISSING);
+            throw new UnexpectedServerResponseException(AUTH_HEADER_MISSING);
         } else {
             Pattern p = Pattern.compile(REGEX);
             Matcher m = p.matcher(authenticateHeader);
@@ -239,7 +239,7 @@ public class AuthenticationParameters {
                         headerItems.put(key, value);
                     } else {
                         // invalid format
-                        throw new IllegalArgumentException(AUTH_HEADER_INVALID_FORMAT);
+                        throw new UnexpectedServerResponseException(AUTH_HEADER_INVALID_FORMAT);
                     }
                 }
 
@@ -250,17 +250,17 @@ public class AuthenticationParameters {
                             StringExtensions.removeQuoteInHeaderValue(headerItems.get(RESOURCE_KEY)));
                 } else {
                     // invalid format
-                    throw new IllegalArgumentException(AUTH_HEADER_MISSING_AUTHORITY);
+                    throw new UnexpectedServerResponseException(AUTH_HEADER_MISSING_AUTHORITY);
                 }
             } else {
-                throw new IllegalArgumentException(AUTH_HEADER_INVALID_FORMAT);
+                throw new UnexpectedServerResponseException(AUTH_HEADER_INVALID_FORMAT);
             }
         }
 
         return authParams;
     }
 
-    private static AuthenticationParameters parseResponse(HttpWebResponse webResponse) {
+    private static AuthenticationParameters parseResponse(HttpWebResponse webResponse) throws UnexpectedServerResponseException{
         // Depending on the service side implementation for this resource
         if (webResponse.getStatusCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
             Map<String, List<String>> responseHeaders = webResponse.getResponseHeaders();
@@ -273,8 +273,8 @@ public class AuthenticationParameters {
                 }
             }
 
-            throw new IllegalArgumentException(AUTH_HEADER_MISSING);
+            throw new UnexpectedServerResponseException(AUTH_HEADER_MISSING);
         }
-        throw new IllegalArgumentException(AUTH_HEADER_WRONG_STATUS);
+        throw new UnexpectedServerResponseException(AUTH_HEADER_WRONG_STATUS);
     }
 }

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -18,7 +18,6 @@
 
 package com.microsoft.aad.adal;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -166,11 +165,11 @@ public class AuthenticationParameters {
 
                 if (webResponse != null) {
                     if(webResponse.getResponseException() != null) {
-                        onCompleted(new IOException(webResponse.getResponseException()), null);
+                        onCompleted(webResponse.getResponseException(), null);
                     }
                     try {
                         onCompleted(null, parseResponse(webResponse));
-                    } catch (UnexpectedServerResponseException exc) {
+                    } catch (ResourceAuthenticationChallengeException exc) {
                         onCompleted(exc, null);
                     }
                 }
@@ -195,11 +194,11 @@ public class AuthenticationParameters {
      * @return {@link AuthenticationParameters}
      */
     public static AuthenticationParameters createFromResponseAuthenticateHeader(
-            String authenticateHeader) throws UnexpectedServerResponseException{
+            String authenticateHeader) throws ResourceAuthenticationChallengeException {
         AuthenticationParameters authParams = null;
 
         if (StringExtensions.IsNullOrBlank(authenticateHeader)) {
-            throw new UnexpectedServerResponseException(AUTH_HEADER_MISSING);
+            throw new ResourceAuthenticationChallengeException(AUTH_HEADER_MISSING);
         } else {
             Pattern p = Pattern.compile(REGEX);
             Matcher m = p.matcher(authenticateHeader);
@@ -243,7 +242,7 @@ public class AuthenticationParameters {
                         headerItems.put(key, value);
                     } else {
                         // invalid format
-                        throw new UnexpectedServerResponseException(AUTH_HEADER_INVALID_FORMAT);
+                        throw new ResourceAuthenticationChallengeException(AUTH_HEADER_INVALID_FORMAT);
                     }
                 }
 
@@ -254,17 +253,17 @@ public class AuthenticationParameters {
                             StringExtensions.removeQuoteInHeaderValue(headerItems.get(RESOURCE_KEY)));
                 } else {
                     // invalid format
-                    throw new UnexpectedServerResponseException(AUTH_HEADER_MISSING_AUTHORITY);
+                    throw new ResourceAuthenticationChallengeException(AUTH_HEADER_MISSING_AUTHORITY);
                 }
             } else {
-                throw new UnexpectedServerResponseException(AUTH_HEADER_INVALID_FORMAT);
+                throw new ResourceAuthenticationChallengeException(AUTH_HEADER_INVALID_FORMAT);
             }
         }
 
         return authParams;
     }
 
-    private static AuthenticationParameters parseResponse(HttpWebResponse webResponse) throws UnexpectedServerResponseException{
+    private static AuthenticationParameters parseResponse(HttpWebResponse webResponse) throws ResourceAuthenticationChallengeException {
         // Depending on the service side implementation for this resource
         if (webResponse.getStatusCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
             Map<String, List<String>> responseHeaders = webResponse.getResponseHeaders();
@@ -277,8 +276,8 @@ public class AuthenticationParameters {
                 }
             }
 
-            throw new UnexpectedServerResponseException(AUTH_HEADER_MISSING);
+            throw new ResourceAuthenticationChallengeException(AUTH_HEADER_MISSING);
         }
-        throw new UnexpectedServerResponseException(AUTH_HEADER_WRONG_STATUS);
+        throw new ResourceAuthenticationChallengeException(AUTH_HEADER_WRONG_STATUS);
     }
 }

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -18,6 +18,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -164,6 +165,9 @@ public class AuthenticationParameters {
                 HttpWebResponse webResponse = sWebRequest.sendGet(resourceUrl, headers);
 
                 if (webResponse != null) {
+                    if(webResponse.getResponseException() != null) {
+                        onCompleted(new IOException(webResponse.getResponseException()), null);
+                    }
                     try {
                         onCompleted(null, parseResponse(webResponse));
                     } catch (UnexpectedServerResponseException exc) {

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -161,19 +161,14 @@ public class AuthenticationParameters {
             public void run() {
                 HashMap<String, String> headers = new HashMap<String, String>();
                 headers.put(WebRequestHandler.HEADER_ACCEPT, WebRequestHandler.HEADER_ACCEPT_JSON);
+                HttpWebResponse webResponse = sWebRequest.sendGet(resourceUrl, headers);
 
-                try {
-                    HttpWebResponse webResponse = sWebRequest.sendGet(resourceUrl, headers);
-
-                    if (webResponse != null) {
-                        try {
-                            onCompleted(null, parseResponse(webResponse));
-                        } catch (IllegalArgumentException exc) {
-                            onCompleted(exc, null);
-                        }
+                if (webResponse != null) {
+                    try {
+                        onCompleted(null, parseResponse(webResponse));
+                    } catch (IllegalArgumentException exc) {
+                        onCompleted(exc, null);
                     }
-                } catch (Exception exception) {
-                    onCompleted(exception, null);
                 }
             }
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationServerProtocolException.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationServerProtocolException.java
@@ -1,0 +1,14 @@
+package com.microsoft.aad.adal;
+
+/**
+ * ADAL exception for device challenge processing
+ */
+class AuthenticationServerProtocolException extends Exception {
+
+    static final long serialVersionUID = 1;
+
+    public AuthenticationServerProtocolException(String detailMessage) {
+        super(detailMessage);
+    }
+}
+

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -183,24 +183,6 @@ abstract class BasicWebViewClient extends WebViewClient {
                                 view.loadUrl(loadUrl, headers);
                             }
                         });
-                    } catch (IllegalArgumentException e) {
-                        Logger.e(TAG, "Argument exception", e.getMessage(),
-                                ADALError.ARGUMENT_EXCEPTION, e);
-                        // It should return error code and finish the
-                        // activity, so that onActivityResult implementation
-                        // returns errors to callback.
-                        Intent resultIntent = new Intent();
-                        resultIntent.putExtra(
-                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
-                                        e);
-                        if (mRequest != null) {
-                            resultIntent.putExtra(
-                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
-                                    mRequest);
-                        }
-                        sendResponse(
-                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
-                                resultIntent);
                     } catch (AuthenticationException e) {
                         Logger.e(TAG, "It is failed to create device certificate response",
                                 e.getMessage(), ADALError.DEVICE_CERTIFICATE_RESPONSE_FAILED, e);
@@ -219,20 +201,7 @@ abstract class BasicWebViewClient extends WebViewClient {
                         sendResponse(
                                 AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
                                 resultIntent);
-                    } catch (Exception e) {
-                        Intent resultIntent = new Intent();
-                        resultIntent.putExtra(
-                                        AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
-                                        e);
-                        if (mRequest != null) {
-                            resultIntent.putExtra(
-                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
-                                    mRequest);
                         }
-                        sendResponse(
-                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
-                                resultIntent);
-                    }
                 }
             }).start();
 
@@ -281,18 +250,13 @@ abstract class BasicWebViewClient extends WebViewClient {
     }
     
     private boolean hasCancelError(String redirectUrl) {
-        try {
-            HashMap<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
-            String error = parameters.get("error");
-            String errorDescription = parameters.get("error_description");
+        HashMap<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
+        String error = parameters.get("error");
+        String errorDescription = parameters.get("error_description");
 
-            if (!StringExtensions.IsNullOrBlank(error)) {
-                Logger.v(TAG, "Cancel error:" + error + " " + errorDescription);
-                return true;
-            }
-        } catch (Exception exc) {
-            Logger.e(TAG, "Error in processing url parameters", "Url:" + redirectUrl,
-                    ADALError.ERROR_WEBVIEW);
+        if (!StringExtensions.IsNullOrBlank(error)) {
+            Logger.w(TAG, "Cancel error:" + error, errorDescription, null);
+            return true;
         }
 
         return false;

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -20,6 +20,7 @@ package com.microsoft.aad.adal;
 
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import com.microsoft.aad.adal.ChallangeResponseBuilder.ChallangeResponse;
 
@@ -183,6 +184,24 @@ abstract class BasicWebViewClient extends WebViewClient {
                                 view.loadUrl(loadUrl, headers);
                             }
                         });
+                    } catch (UnexpectedServerResponseException e) {
+                        Logger.e(TAG, "Argument exception", e.getMessage(),
+                                ADALError.ARGUMENT_EXCEPTION, e);
+                        // It should return error code and finish the
+                        // activity, so that onActivityResult implementation
+                        // returns errors to callback.
+                        Intent resultIntent = new Intent();
+                        resultIntent.putExtra(
+                                AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION,
+                                e);
+                        if (mRequest != null) {
+                            resultIntent.putExtra(
+                                    AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
+                                    mRequest);
+                        }
+                        sendResponse(
+                                AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
+                                resultIntent);
                     } catch (AuthenticationException e) {
                         Logger.e(TAG, "It is failed to create device certificate response",
                                 e.getMessage(), ADALError.DEVICE_CERTIFICATE_RESPONSE_FAILED, e);
@@ -250,7 +269,7 @@ abstract class BasicWebViewClient extends WebViewClient {
     }
     
     private boolean hasCancelError(String redirectUrl) {
-        HashMap<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
+        Map<String, String> parameters = StringExtensions.getUrlParameters(redirectUrl);
         String error = parameters.get("error");
         String errorDescription = parameters.get("error_description");
 

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -185,7 +185,7 @@ abstract class BasicWebViewClient extends WebViewClient {
                                 view.loadUrl(loadUrl, headers);
                             }
                         });
-                    } catch (UnexpectedServerResponseException e) {
+                    } catch (AuthenticationServerProtocolException e) {
                         Logger.e(TAG, "Argument exception", e.getMessage(),
                                 ADALError.ARGUMENT_EXCEPTION, e);
                         // It should return error code and finish the

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -220,7 +220,7 @@ class BrokerProxy implements IBrokerProxy {
                 if (matchingUser != null) {
                     targetAccount = findAccount(matchingUser.getDisplayableId(), accountList);
                 }
-            } catch (Exception e) {
+            } catch (IOException | AuthenticatorException | OperationCanceledException e) {
                 Logger.e(TAG, e.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION, e);
             }
         }
@@ -539,7 +539,7 @@ class BrokerProxy implements IBrokerProxy {
                 users = getBrokerUsers();
                 UserInfo matchingUser = findUserInfo(uniqueId, users);
                 return matchingUser != null;
-            } catch (Exception e) {
+            } catch (IOException | AuthenticatorException | OperationCanceledException e) {
                 Logger.e(TAG, "VerifyAccount:" + e.getMessage(), "",
                         ADALError.BROKER_AUTHENTICATOR_EXCEPTION, e);
             }
@@ -592,11 +592,7 @@ class BrokerProxy implements IBrokerProxy {
         } catch (NoSuchAlgorithmException e) {
             Logger.e(TAG, "Digest SHA algorithm does not exists", "",
                     ADALError.DEVICE_NO_SUCH_ALGORITHM);
-        } catch (Exception e) {
-            Logger.e(TAG, "Error in verifying signature", "", ADALError.BROKER_VERIFICATION_FAILED,
-                    e);
         }
-
         return false;
     }
 

--- a/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
+++ b/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
@@ -180,7 +180,6 @@ class ChallangeResponseBuilder {
 
     private ChallangeRequest getChallangeRequestFromHeader(final String headerValue)
             throws UnsupportedEncodingException, UnexpectedServerResponseException {
-    {
         final String methodName = ":getChallangeRequestFromHeader";
         
         if (StringExtensions.IsNullOrBlank(headerValue)) {

--- a/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
+++ b/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
@@ -86,13 +86,13 @@ class ChallangeResponseBuilder {
      * @return Return Device challange response
      */
     public ChallangeResponse getChallangeResponseFromUri(final String redirectUri)
-            throws UnexpectedServerResponseException {
+            throws AuthenticationServerProtocolException {
         ChallangeRequest request = getChallangeRequest(redirectUri);
         return getDeviceCertResponse(request);
     }
 
     public ChallangeResponse getChallangeResponseFromHeader(final String challangeHeaderValue,
-            final String endpoint) throws UnsupportedEncodingException, UnexpectedServerResponseException {
+            final String endpoint) throws UnsupportedEncodingException, AuthenticationServerProtocolException {
         ChallangeRequest request = getChallangeRequestFromHeader(challangeHeaderValue);
         request.mSubmitUrl = endpoint;
         return getDeviceCertResponse(request);
@@ -179,11 +179,11 @@ class ChallangeResponseBuilder {
     }
 
     private ChallangeRequest getChallangeRequestFromHeader(final String headerValue)
-            throws UnsupportedEncodingException, UnexpectedServerResponseException {
+            throws UnsupportedEncodingException, AuthenticationServerProtocolException {
         final String methodName = ":getChallangeRequestFromHeader";
         
         if (StringExtensions.IsNullOrBlank(headerValue)) {
-            throw new UnexpectedServerResponseException("headerValue");
+            throw new AuthenticationServerProtocolException("headerValue");
         }
 
         // Header value should start with correct challenge type
@@ -282,9 +282,9 @@ class ChallangeResponseBuilder {
         }
     }
 
-    private ChallangeRequest getChallangeRequest(final String redirectUri) throws UnexpectedServerResponseException{
+    private ChallangeRequest getChallangeRequest(final String redirectUri) throws AuthenticationServerProtocolException {
         if (StringExtensions.IsNullOrBlank(redirectUri)) {
-            throw new UnexpectedServerResponseException("redirectUri");
+            throw new AuthenticationServerProtocolException("redirectUri");
         }
 
         ChallangeRequest challange = new ChallangeRequest();

--- a/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
+++ b/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
@@ -85,13 +85,14 @@ class ChallangeResponseBuilder {
      *            client must convey back>
      * @return Return Device challange response
      */
-    public ChallangeResponse getChallangeResponseFromUri(final String redirectUri) {
+    public ChallangeResponse getChallangeResponseFromUri(final String redirectUri)
+            throws UnexpectedServerResponseException {
         ChallangeRequest request = getChallangeRequest(redirectUri);
         return getDeviceCertResponse(request);
     }
 
     public ChallangeResponse getChallangeResponseFromHeader(final String challangeHeaderValue,
-            final String endpoint) throws UnsupportedEncodingException {
+            final String endpoint) throws UnsupportedEncodingException, UnexpectedServerResponseException {
         ChallangeRequest request = getChallangeRequestFromHeader(challangeHeaderValue);
         request.mSubmitUrl = endpoint;
         return getDeviceCertResponse(request);
@@ -166,9 +167,9 @@ class ChallangeResponseBuilder {
     }
 
     private ChallangeRequest getChallangeRequestFromHeader(final String headerValue)
-            throws UnsupportedEncodingException {
+            throws UnsupportedEncodingException, UnexpectedServerResponseException {
         if (StringExtensions.IsNullOrBlank(headerValue)) {
-            throw new IllegalArgumentException("headerValue");
+            throw new UnexpectedServerResponseException("headerValue");
         }
 
         // Header value should start with correct challenge type
@@ -251,9 +252,9 @@ class ChallangeResponseBuilder {
         }
     }
 
-    private ChallangeRequest getChallangeRequest(final String redirectUri) {
+    private ChallangeRequest getChallangeRequest(final String redirectUri) throws UnexpectedServerResponseException{
         if (StringExtensions.IsNullOrBlank(redirectUri)) {
-            throw new IllegalArgumentException("redirectUri");
+            throw new UnexpectedServerResponseException("redirectUri");
         }
 
         ChallangeRequest challange = new ChallangeRequest();

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -18,6 +18,8 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -105,7 +107,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     private String encrypt(String value) {
         try {
             return sHelper.encrypt(value);
-        } catch (Exception e) {
+        } catch (GeneralSecurityException | IOException e) {
             Logger.e(TAG, "Encryption failure", "", ADALError.ENCRYPTION_FAILED, e);
         }
 
@@ -115,7 +117,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     private String decrypt(String value) {
         try {
             return sHelper.decrypt(value);
-        } catch (Exception e) {
+        } catch (GeneralSecurityException | IOException e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.ENCRYPTION_FAILED, e);
             if (!StringExtensions.IsNullOrBlank(value)) {
                 Logger.v(TAG, String.format("Decryption error for key: '%s'. Item will be removed",

--- a/src/src/com/microsoft/aad/adal/Discovery.java
+++ b/src/src/com/microsoft/aad/adal/Discovery.java
@@ -92,7 +92,9 @@ final class Discovery implements IDiscovery {
                 && !StringExtensions.IsNullOrBlank(authorizationEndpoint.getPath())) {
 
             if (UrlExtensions.isADFSAuthority(authorizationEndpoint)) {
-                throw new AuthenticationException(ADALError.DISCOVERY_NOT_SUPPORTED);
+                Logger.e(TAG, "Instance validation returned error", "",
+                        ADALError.DEVELOPER_AUTHORITY_CAN_NOT_BE_VALIDED, new AuthenticationException(ADALError.DISCOVERY_NOT_SUPPORTED));
+                return false;
             } else if (sValidHosts.contains(authorizationEndpoint.getHost().toLowerCase(Locale.US))) {
                 // host can be the instance or inside the validated list.
                 // Valid hosts will help to skip validation if validated before

--- a/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
@@ -21,8 +21,10 @@ package com.microsoft.aad.adal;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OptionalDataException;
 
 import android.content.Context;
 
@@ -102,7 +104,7 @@ public class FileTokenCacheStore implements ITokenCacheStore {
                 Logger.v(TAG, "There is not any previous cache file to load cache.");
                 mInMemoryCache = new MemoryTokenCacheStore();
             }
-        } catch (Exception ex) {
+        } catch (IOException | ClassNotFoundException ex) {
             Logger.e(TAG, "Exception during cache load",
                     ExceptionExtensions.getExceptionMessage(ex),
                     ADALError.DEVICE_FILE_CACHE_IS_NOT_LOADED_FROM_FILE);
@@ -156,7 +158,7 @@ public class FileTokenCacheStore implements ITokenCacheStore {
                     objectStream.close();
                     outputStream.close();
 
-                } catch (Exception ex) {
+                } catch (IOException ex) {
                     Logger.e(TAG, "Exception during cache flush",
                             ExceptionExtensions.getExceptionMessage(ex),
                             ADALError.DEVICE_FILE_CACHE_IS_NOT_WRITING_TO_FILE);

--- a/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
@@ -24,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OptionalDataException;
 
 import android.content.Context;
 

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -68,7 +68,7 @@ class HttpWebRequest {
 
     int mTimeOut = CONNECT_TIME_OUT;
 
-    private Throwable mException = null;
+    private IOException mException = null;
 
     HashMap<String, String> mRequestHeaders = null;
 
@@ -138,7 +138,7 @@ class HttpWebRequest {
                 mConnection.setUseCaches(mUseCaches);
                 mConnection.setRequestMethod(mRequestMethod);
                 mConnection.setDoInput(true); // it will at least read status
-                // code. Default is true.
+                                              // code. Default is true.
                 setRequestBody();
 
                 byte[] responseBody = null;
@@ -182,8 +182,8 @@ class HttpWebRequest {
                 Logger.v(TAG, "Response is received");
                 response.setBody(responseBody);
                 response.setResponseHeaders(mConnection.getHeaderFields());
-            } catch (InterruptedException ignore) {
-                Logger.v(TAG, "Thread.sleep got interrupted exception " + ignore);
+            } catch (InterruptedException e) {
+                Logger.v(TAG, "Thread.sleep got interrupted exception " + e);
             } catch (IOException e ) {
                 Logger.e(TAG, "IOException:" + e.getMessage(), " Method:" + mRequestMethod,
                         ADALError.SERVER_ERROR, e);

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -68,7 +68,7 @@ class HttpWebRequest {
 
     int mTimeOut = CONNECT_TIME_OUT;
 
-    private Exception mException = null;
+    private Throwable mException = null;
 
     HashMap<String, String> mRequestHeaders = null;
 

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -68,7 +68,7 @@ class HttpWebRequest {
 
     int mTimeOut = CONNECT_TIME_OUT;
 
-    Exception mException = null;
+    private Exception mException = null;
 
     HashMap<String, String> mRequestHeaders = null;
 
@@ -138,7 +138,7 @@ class HttpWebRequest {
                 mConnection.setUseCaches(mUseCaches);
                 mConnection.setRequestMethod(mRequestMethod);
                 mConnection.setDoInput(true); // it will at least read status
-                                              // code. Default is true.
+                // code. Default is true.
                 setRequestBody();
 
                 byte[] responseBody = null;
@@ -182,8 +182,10 @@ class HttpWebRequest {
                 Logger.v(TAG, "Response is received");
                 response.setBody(responseBody);
                 response.setResponseHeaders(mConnection.getHeaderFields());
-            } catch (Exception e) {
-                Logger.e(TAG, "Exception:" + e.getMessage(), " Method:" + mRequestMethod,
+            } catch (InterruptedException ignore) {
+                Logger.v(TAG, "Thread.sleep got interrupted exception " + ignore);
+            } catch (IOException e ) {
+                Logger.e(TAG, "IOException:" + e.getMessage(), " Method:" + mRequestMethod,
                         ADALError.SERVER_ERROR, e);
                 mException = e;
             } finally {

--- a/src/src/com/microsoft/aad/adal/HttpWebResponse.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebResponse.java
@@ -29,7 +29,7 @@ public class HttpWebResponse {
     private int mStatusCode;
     private byte[] mResponseBody;
     private Map<String, List<String>> mResponseHeaders;
-    private Exception mResponseException = null;
+    private Throwable mResponseException = null;
 
     public HttpWebResponse() {
         mStatusCode = HttpURLConnection.HTTP_OK;
@@ -43,11 +43,11 @@ public class HttpWebResponse {
         mResponseHeaders = responseHeaders;
     }
 
-    public Exception getResponseException() {
+    public Throwable getResponseException() {
         return mResponseException;
     }
 
-    public void setResponseException(Exception responseException) {
+    public void setResponseException(Throwable responseException) {
         this.mResponseException = responseException;
     }
 

--- a/src/src/com/microsoft/aad/adal/HttpWebResponse.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebResponse.java
@@ -18,6 +18,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ public class HttpWebResponse {
     private int mStatusCode;
     private byte[] mResponseBody;
     private Map<String, List<String>> mResponseHeaders;
-    private Throwable mResponseException = null;
+    private IOException mResponseException = null;
 
     public HttpWebResponse() {
         mStatusCode = HttpURLConnection.HTTP_OK;
@@ -43,11 +44,11 @@ public class HttpWebResponse {
         mResponseHeaders = responseHeaders;
     }
 
-    public Throwable getResponseException() {
+    public IOException getResponseException() {
         return mResponseException;
     }
 
-    public void setResponseException(Throwable responseException) {
+    public void setResponseException(IOException responseException) {
         this.mResponseException = responseException;
     }
 

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -335,7 +335,7 @@ class Oauth2 {
         }
     }
 
-    public AuthenticationResult refreshToken(String refreshToken) throws IOException {
+    public AuthenticationResult refreshToken(String refreshToken) throws IOException, UnexpectedServerResponseException {
         String requestMessage = null;
         if (mWebRequestHandler == null) {
             Logger.v(TAG, "Web request is not set correctly");
@@ -369,7 +369,7 @@ class Oauth2 {
      *         not have protocol error.
      * @throws Exception
      */
-    public AuthenticationResult getToken(String authorizationUrl) throws IOException {
+    public AuthenticationResult getToken(String authorizationUrl) throws IOException, UnexpectedServerResponseException {
 
         if (StringExtensions.IsNullOrBlank(authorizationUrl)) {
             throw new IllegalArgumentException("authorizationUrl");
@@ -418,7 +418,7 @@ class Oauth2 {
      * @return Token in the AuthenticationResult
      * @throws Exception
      */
-    public AuthenticationResult getTokenForCode(String code) throws IOException {
+    public AuthenticationResult getTokenForCode(String code) throws IOException, UnexpectedServerResponseException {
 
         String requestMessage = null;
         if (mWebRequestHandler == null) {
@@ -438,7 +438,7 @@ class Oauth2 {
     }
 
     private AuthenticationResult postMessage(String requestMessage, HashMap<String, String> headers)
-            throws IOException {
+            throws IOException,UnexpectedServerResponseException {
         URL authority = null;
         AuthenticationResult result = null;
         authority = StringExtensions.getUrl(getTokenEndpoint());

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -18,6 +18,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -315,7 +316,7 @@ class Oauth2 {
                     return idtokenInfo;
                 }
             }
-        } catch (Exception ex) {
+        } catch (JSONException | UnsupportedEncodingException ex) {
             Logger.e(TAG, "Error in parsing user id token", null,
                     ADALError.IDTOKEN_PARSING_FAILURE, ex);
         }
@@ -334,7 +335,7 @@ class Oauth2 {
         }
     }
 
-    public AuthenticationResult refreshToken(String refreshToken) throws Exception {
+    public AuthenticationResult refreshToken(String refreshToken) throws IOException {
         String requestMessage = null;
         if (mWebRequestHandler == null) {
             Logger.v(TAG, "Web request is not set correctly");
@@ -368,7 +369,7 @@ class Oauth2 {
      *         not have protocol error.
      * @throws Exception
      */
-    public AuthenticationResult getToken(String authorizationUrl) throws Exception {
+    public AuthenticationResult getToken(String authorizationUrl) throws IOException {
 
         if (StringExtensions.IsNullOrBlank(authorizationUrl)) {
             throw new IllegalArgumentException("authorizationUrl");
@@ -417,7 +418,7 @@ class Oauth2 {
      * @return Token in the AuthenticationResult
      * @throws Exception
      */
-    public AuthenticationResult getTokenForCode(String code) throws Exception {
+    public AuthenticationResult getTokenForCode(String code) throws IOException {
 
         String requestMessage = null;
         if (mWebRequestHandler == null) {
@@ -437,7 +438,7 @@ class Oauth2 {
     }
 
     private AuthenticationResult postMessage(String requestMessage, HashMap<String, String> headers)
-            throws Exception {
+            throws IOException {
         URL authority = null;
         AuthenticationResult result = null;
         authority = StringExtensions.getUrl(getTokenEndpoint());
@@ -516,7 +517,7 @@ class Oauth2 {
 
                 Logger.v(TAG, "Server error message:" + errMessage);
                 if (response.getResponseException() != null) {
-                    throw response.getResponseException();
+                    throw new IOException(response.getResponseException());
                 }
             } else {
                 ClientMetrics.INSTANCE.setLastErrorCodes(result.getErrorCodes());
@@ -529,7 +530,7 @@ class Oauth2 {
             ClientMetrics.INSTANCE.setLastError(null);
             Logger.e(TAG, e.getMessage(), "", ADALError.ENCODING_IS_NOT_SUPPORTED, e);
             throw e;
-        } catch (Exception e) {
+        } catch (IOException e) {
             ClientMetrics.INSTANCE.setLastError(null);
             Logger.e(TAG, e.getMessage(), "", ADALError.SERVER_ERROR, e);
             throw e;
@@ -584,15 +585,15 @@ class Oauth2 {
             }
         }
 
-        if (webResponse.getBody() != null && webResponse.getBody().length > 0) {
-
+        if (webResponse.getStatusCode() == HttpURLConnection.HTTP_OK
+                && webResponse.getBody() != null && webResponse.getBody().length > 0) {
             // invalid refresh token calls has error related items in the body.
             // Status is 400 for those.
             try {
                 String jsonStr = new String(webResponse.getBody());
                 extractJsonObjects(responseItems, jsonStr);
                 result = processUIResponseParams(responseItems);
-            } catch (final Exception ex) {
+            } catch (final JSONException ex) {
                 // There is no recovery possible here, so
                 // catch the
                 // generic Exception
@@ -614,18 +615,13 @@ class Oauth2 {
 
         // Set correlationId in the result
         if (correlationIdInHeader != null && !correlationIdInHeader.isEmpty()) {
-            try {
-                UUID correlation = UUID.fromString(correlationIdInHeader);
-                if (!correlation.equals(mRequest.getCorrelationId())) {
-                    Logger.w(TAG, "CorrelationId is not matching", "",
-                            ADALError.CORRELATION_ID_NOT_MATCHING_REQUEST_RESPONSE);
-                }
-
-                Logger.v(TAG, "Response correlationId:" + correlationIdInHeader);
-            } catch (Exception ex) {
-                Logger.e(TAG, "Wrong format of the correlation ID:" + correlationIdInHeader, "",
-                        ADALError.CORRELATION_ID_FORMAT, ex);
+            UUID correlation = UUID.fromString(correlationIdInHeader);
+            if (!correlation.equals(mRequest.getCorrelationId())) {
+                Logger.w(TAG, "CorrelationId is not matching", "",
+                        ADALError.CORRELATION_ID_NOT_MATCHING_REQUEST_RESPONSE);
             }
+
+            Logger.v(TAG, "Response correlationId:" + correlationIdInHeader);
         }
 
         return result;

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -522,7 +522,7 @@ class Oauth2 {
             } else {
                 ClientMetrics.INSTANCE.setLastErrorCodes(result.getErrorCodes());
             }
-        } catch (IllegalArgumentException e) {
+        } catch (UnexpectedServerResponseException e) {
             ClientMetrics.INSTANCE.setLastError(null);
             Logger.e(TAG, e.getMessage(), "", ADALError.ARGUMENT_EXCEPTION, e);
             throw e;

--- a/src/src/com/microsoft/aad/adal/PRNGFixes.java
+++ b/src/src/com/microsoft/aad/adal/PRNGFixes.java
@@ -36,6 +36,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
@@ -101,7 +102,7 @@ final class PRNGFixes {
                 throw new IOException("Unexpected number of bytes read from Linux PRNG: "
                         + bytesRead);
             }
-        } catch (Exception e) {
+        } catch (IOException | ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             Logger.e(TAG, "Failed to seed OpenSSL PRNG", "", ADALError.DEVICE_PRNG_FIX_ERROR, e);
             throw new SecurityException("Failed to seed OpenSSL PRNG", e);
         }

--- a/src/src/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
+++ b/src/src/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
@@ -4,10 +4,11 @@ package com.microsoft.aad.adal;
  * ADAL exception for the case when server response doesn't have expected data
  * e.g. missing header, wrong status code, invalid format
  */
-public class UnexpectedServerResponseException extends Exception {
+class ResourceAuthenticationChallengeException extends Exception {
+
     static final long serialVersionUID = 1;
 
-    public UnexpectedServerResponseException(String detailMessage) {
+    public ResourceAuthenticationChallengeException(String detailMessage) {
         super(detailMessage);
     }
 }

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -466,10 +466,10 @@ public class StorageHelper {
             final byte[] encryptedKey = readKeyData(keyFile);
             sSecretKeyFromAndroidKeyStore = unwrap(wrapCipher, encryptedKey);
             Logger.v(TAG, "Finished reading SecretKey");
-        } catch (GeneralSecurityException ex) {
+        } catch (GeneralSecurityException | IOException ex) {
             // Reset KeyPair info so that new request will generate correct KeyPairs.
             // All tokens with previous SecretKey are not possible to decrypt.
-            Logger.e(TAG, "Unwrap failed for AndroidKeyStore", "", ADALError.ANDROIDKEYSTORE_FAILED);
+            Logger.e(TAG, "Unwrap failed for AndroidKeyStore", "", ADALError.ANDROIDKEYSTORE_FAILED, ex);
             mKeyPair = null;
             sSecretKeyFromAndroidKeyStore = null;
             deleteKeyFile();

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -164,7 +164,7 @@ public class StorageHelper {
                     sMacKey = getMacKey(sKey);
                     sBlobVersion = VERSION_ANDROID_KEY_STORE;
                     return;
-                } catch (Exception e) {
+                } catch (IOException | GeneralSecurityException e) {
                     Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
                             ADALError.ANDROIDKEYSTORE_FAILED, e);
                 }
@@ -207,7 +207,7 @@ public class StorageHelper {
                     // key
                     // used for Encryption and HMac
                     return getSecretKeyFromAndroidKeyStore();
-                } catch (Exception e) {
+                } catch (IOException | GeneralSecurityException e) {
                     Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
                             ADALError.ANDROIDKEYSTORE_FAILED, e);
                 }
@@ -466,7 +466,7 @@ public class StorageHelper {
             final byte[] encryptedKey = readKeyData(keyFile);
             sSecretKeyFromAndroidKeyStore = unwrap(wrapCipher, encryptedKey);
             Logger.v(TAG, "Finished reading SecretKey");
-        } catch (Exception ex) {
+        } catch (GeneralSecurityException ex) {
             // Reset KeyPair info so that new request will generate correct KeyPairs.
             // All tokens with previous SecretKey are not possible to decrypt.
             Logger.e(TAG, "Unwrap failed for AndroidKeyStore", "", ADALError.ANDROIDKEYSTORE_FAILED);

--- a/src/src/com/microsoft/aad/adal/UnexpectedServerResponseException.java
+++ b/src/src/com/microsoft/aad/adal/UnexpectedServerResponseException.java
@@ -1,0 +1,14 @@
+package com.microsoft.aad.adal;
+
+import java.io.IOException;
+
+/**
+ * Created by imakhal on 2/17/2016.
+ */
+public class UnexpectedServerResponseException extends IOException {
+    static final long serialVersionUID = 1;
+
+    public UnexpectedServerResponseException(String detailMessage) {
+        super(detailMessage);
+    }
+}

--- a/src/src/com/microsoft/aad/adal/UnexpectedServerResponseException.java
+++ b/src/src/com/microsoft/aad/adal/UnexpectedServerResponseException.java
@@ -1,11 +1,10 @@
 package com.microsoft.aad.adal;
 
-import java.io.IOException;
-
 /**
- * Created by imakhal on 2/17/2016.
+ * ADAL exception for the case when server response doesn't have expected data
+ * e.g. missing header, wrong status code, invalid format
  */
-public class UnexpectedServerResponseException extends IOException {
+public class UnexpectedServerResponseException extends Exception {
     static final long serialVersionUID = 1;
 
     public UnexpectedServerResponseException(String detailMessage) {

--- a/src/src/com/microsoft/aad/adal/WebviewHelper.java
+++ b/src/src/com/microsoft/aad/adal/WebviewHelper.java
@@ -136,7 +136,7 @@ public class WebviewHelper {
     }
 
     public PreKeyAuthInfo getPreKeyAuthInfo(String challengeUrl)
-            throws UnsupportedEncodingException {
+            throws UnsupportedEncodingException, UnexpectedServerResponseException {
         IJWSBuilder jwsBuilder = new JWSBuilder();
 
         ChallangeResponseBuilder certHandler = new ChallangeResponseBuilder(jwsBuilder);

--- a/src/src/com/microsoft/aad/adal/WebviewHelper.java
+++ b/src/src/com/microsoft/aad/adal/WebviewHelper.java
@@ -136,7 +136,7 @@ public class WebviewHelper {
     }
 
     public PreKeyAuthInfo getPreKeyAuthInfo(String challengeUrl)
-            throws UnsupportedEncodingException, UnexpectedServerResponseException {
+            throws UnsupportedEncodingException, AuthenticationServerProtocolException {
         IJWSBuilder jwsBuilder = new JWSBuilder();
 
         ChallangeResponseBuilder certHandler = new ChallangeResponseBuilder(jwsBuilder);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AndroidTestHelper.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AndroidTestHelper.java
@@ -72,7 +72,7 @@ public class AndroidTestHelper extends InstrumentationTestCase {
     }
 
     public void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
-            final Runnable testCode) {
+            final ThrowableRunnable testCode) {
         try {
             testCode.run();
             Assert.fail("This is expecting an exception, but it was not thrown.");
@@ -142,4 +142,8 @@ public class AndroidTestHelper extends InstrumentationTestCase {
         }
     }
 
+    interface ThrowableRunnable
+    {
+        void run( ) throws Exception;
+    }
 }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationParamsTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationParamsTests.java
@@ -32,11 +32,7 @@ import junit.framework.Assert;
 import android.test.suitebuilder.annotation.Suppress;
 import android.util.Log;
 
-import com.microsoft.aad.adal.ADALError;
-import com.microsoft.aad.adal.AuthenticationParameters;
 import com.microsoft.aad.adal.AuthenticationParameters.AuthenticationParamCallback;
-import com.microsoft.aad.adal.HttpWebResponse;
-import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.Logger.ILogger;
 import com.microsoft.aad.adal.Logger.LogLevel;
 
@@ -68,21 +64,21 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
     }
 
     public void testCreateFromResponseAuthenticateHeader() {
-        assertThrowsException(UnexpectedServerResponseException.class,
+        assertThrowsException(ResourceAuthenticationChallengeException.class,
                 AuthenticationParameters.AUTH_HEADER_MISSING.toLowerCase(), new ThrowableRunnable() {
 
                     @Override
-                    public void run() throws UnexpectedServerResponseException{
+                    public void run() throws ResourceAuthenticationChallengeException {
                         AuthenticationParameters.createFromResponseAuthenticateHeader(null);
                     }
                 });
 
         // empty value inside the authorization_uri will throw exception
-        assertThrowsException(UnexpectedServerResponseException.class,
+        assertThrowsException(ResourceAuthenticationChallengeException.class,
                 AuthenticationParameters.AUTH_HEADER_INVALID_FORMAT.toLowerCase(), new ThrowableRunnable() {
 
                     @Override
-                    public void run() throws UnexpectedServerResponseException {
+                    public void run() throws ResourceAuthenticationChallengeException {
                         AuthenticationParameters
                                 .createFromResponseAuthenticateHeader("Bearer\t resource=\"is=outer, space=ornot\",\t\t  authorization_uri=\"\"");
                     }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationParamsTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationParamsTests.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import junit.framework.Assert;
+
+import android.test.suitebuilder.annotation.Suppress;
 import android.util.Log;
 
 import com.microsoft.aad.adal.ADALError;
@@ -66,21 +68,21 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
     }
 
     public void testCreateFromResponseAuthenticateHeader() {
-        assertThrowsException(IllegalArgumentException.class,
-                AuthenticationParameters.AUTH_HEADER_MISSING.toLowerCase(), new Runnable() {
+        assertThrowsException(UnexpectedServerResponseException.class,
+                AuthenticationParameters.AUTH_HEADER_MISSING.toLowerCase(), new ThrowableRunnable() {
 
                     @Override
-                    public void run() {
+                    public void run() throws UnexpectedServerResponseException{
                         AuthenticationParameters.createFromResponseAuthenticateHeader(null);
                     }
                 });
 
         // empty value inside the authorization_uri will throw exception
-        assertThrowsException(IllegalArgumentException.class,
-                AuthenticationParameters.AUTH_HEADER_INVALID_FORMAT.toLowerCase(), new Runnable() {
+        assertThrowsException(UnexpectedServerResponseException.class,
+                AuthenticationParameters.AUTH_HEADER_INVALID_FORMAT.toLowerCase(), new ThrowableRunnable() {
 
                     @Override
-                    public void run() {
+                    public void run() throws UnexpectedServerResponseException {
                         AuthenticationParameters
                                 .createFromResponseAuthenticateHeader("Bearer\t resource=\"is=outer, space=ornot\",\t\t  authorization_uri=\"\"");
                     }
@@ -90,6 +92,8 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
     /**
      * test external service deployed at Azure
      */
+    @Suppress
+    // Test doesn't work because external service is down
     public void testCreateFromResourceUrlPositive() {
         Log.d(TAG, "test:" + getName() + "thread:" + android.os.Process.myTid());
 
@@ -278,7 +282,7 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
     public void testcreateFromResourceUrlNoCallback() throws MalformedURLException {
 
         final URL url = new URL("https://www.something.com");
-        assertThrowsException(IllegalArgumentException.class, "callback", new Runnable() {
+        assertThrowsException(IllegalArgumentException.class, "callback", new ThrowableRunnable() {
 
             @Override
             public void run() {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/DiscoveryTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/DiscoveryTests.java
@@ -173,8 +173,8 @@ public class DiscoveryTests extends AndroidTestHelper {
         callIsValidAuthority(discovery, endpointAdfs, responseAdfs, true);
 
         assertNotNull("response should not be null", responseAdfs);
-        assertNotNull("It should have exception", responseAdfs.exception.getCause().getMessage()
-                .equals(ADALError.DISCOVERY_NOT_SUPPORTED.getDescription()));
+        assertFalse("Instance should be invalid", responseFragment.result);
+        assertNull("It should not have exception", responseFragment.exception);
 
         final TestResponse responseInvalidPath = new TestResponse();
         final URL endpointInvalidPath = new URL("https://login.windows.net/common/test/test");

--- a/tests/Functional/src/com/microsoft/aad/adal/test/FileTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/FileTokenCacheStoreTests.java
@@ -91,7 +91,7 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
     public void testFileCacheWriteError() {
         final FileMockContext mockContext = new FileMockContext(targetContex);
         assertThrowsException(IllegalStateException.class,
-                "it could not access the authorization cache directory", new Runnable() {
+                "it could not access the authorization cache directory", new ThrowableRunnable() {
                     @Override
                     public void run() {
                         ITokenCacheStore store = new FileTokenCacheStore(mockContext,

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -585,16 +585,10 @@ public class OauthTests extends AndroidTestCase {
         logResponse2.listenLogForMessageSegments(null, "Wrong format of the correlation ID:");
 
         // send call with mocks
-        Throwable throwable = null;
-        try {
-            m.invoke(oauth, mockResponse);
-        } catch (InvocationTargetException e) {
-            throwable = e.getCause();
-            // verify error
-            assertTrue("Unexpected exception",
-                    IllegalArgumentException.class.equals(e.getCause().getClass()));
-        }
-        assertNotNull(throwable);
+        m.invoke(oauth, mockResponse);
+        // verify same token
+        assertTrue("Log response has message",
+                logResponse2.errorCode.equals(ADALError.CORRELATION_ID_FORMAT));
     }
 
     @SmallTest

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -588,8 +588,12 @@ public class OauthTests extends AndroidTestCase {
         m.invoke(oauth, mockResponse);
 
         // verify same token
-        assertTrue("Log response has message",
-                logResponse2.errorCode.equals(ADALError.CORRELATION_ID_FORMAT));
+        try {
+            m.invoke(oauth, mockResponse);
+        } catch (InvocationTargetException e) {
+            assertTrue("Unexpected exception",
+                    IllegalArgumentException.class.equals(e.getCause().getClass()));
+        }
     }
 
     @SmallTest

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -585,15 +585,16 @@ public class OauthTests extends AndroidTestCase {
         logResponse2.listenLogForMessageSegments(null, "Wrong format of the correlation ID:");
 
         // send call with mocks
-        m.invoke(oauth, mockResponse);
-
-        // verify same token
+        Throwable throwable = null;
         try {
             m.invoke(oauth, mockResponse);
         } catch (InvocationTargetException e) {
+            throwable = e.getCause();
+            // verify error
             assertTrue("Unexpected exception",
                     IllegalArgumentException.class.equals(e.getCause().getClass()));
         }
+        assertNotNull(throwable);
     }
 
     @SmallTest


### PR DESCRIPTION
+bump up target version to support multi catch statement
Recreated pull request against dev branch (instead of master).
Currently all Runtime exceptions are swallowed and if they happen it's hard to trace the reason why token is not obtained.
 Instead it's better to catch only excepted exceptions, because if unexpected exception happens mobile app should crash and give a stack trace what went wrong, that way it's easy to fix the problem.
 Sample: You have button but when you click nothing happens. Or button that crashes you app and you see NPE in you logs...From user stand point - nothing changes because button doesn't work, from dev standpoint - much more info from second case.