### PR TITLE
update for null acceptable issuers for client tls request

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -652,6 +652,14 @@ public class AuthenticationActivity extends Activity {
             Logger.v(TAG + methodName, "Webview receives client TLS request.");
             
             final Principal[] acceptableCertIssuers = request.getPrincipals();
+            
+            if (acceptableCertIssuers == null)
+            {
+                Logger.v(TAG + methodName, "Received acceptable issuers are null, ignoring the TLS request.");
+                request.ignore();
+                return;
+            }
+            
             for (Principal issuer : acceptableCertIssuers)
             {
                 if (issuer.getName().contains("CN=MS-Organization-Access"))

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -653,7 +653,7 @@ public class AuthenticationActivity extends Activity {
             
             final Principal[] acceptableCertIssuers = request.getPrincipals();
             
-            // ADFS server could send null or empty acceptable issuers, and that basically means user needs to choose for right certificate.
+            // When ADFS server sends null or empty issuers, we'll continue with cert prompt.
             if (acceptableCertIssuers != null)
             {
                 for (Principal issuer : acceptableCertIssuers)

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -653,21 +653,18 @@ public class AuthenticationActivity extends Activity {
             
             final Principal[] acceptableCertIssuers = request.getPrincipals();
             
-            if (acceptableCertIssuers == null)
+            // ADFS server could send null or empty acceptable issuers, and that basically means user needs to choose for right certificate.
+            if (acceptableCertIssuers != null)
             {
-                Logger.v(TAG + methodName, "Received acceptable issuers are null, ignoring the TLS request.");
-                request.ignore();
-                return;
-            }
-            
-            for (Principal issuer : acceptableCertIssuers)
-            {
-                if (issuer.getName().contains("CN=MS-Organization-Access"))
+                for (Principal issuer : acceptableCertIssuers)
                 {
-                    //Checking if received acceptable issuers contain "CN=MS-Organization-Access"
-                    Logger.v(TAG + methodName, "Cancelling the TLS request, not respond to TLS challenge triggered by device authenticaton.");
-                    request.cancel();
-                    return;
+                    if (issuer.getName().contains("CN=MS-Organization-Access"))
+                    {
+                        //Checking if received acceptable issuers contain "CN=MS-Organization-Access"
+                        Logger.v(TAG + methodName, "Cancelling the TLS request, not respond to TLS challenge triggered by device authenticaton.");
+                        request.cancel();
+                        return;
+                    }
                 }
             }
             


### PR DESCRIPTION
Should check for null acceptable issuers, if it's null continue with the request, and prompt user for choosing a cert. 