### PR TITLE
Update CLA page's url

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,7 @@ through the process.
 
 ### CONTRIBUTOR LICENSE AGREEMENT
 
-Please visit [https://cla.msopentech.com/](https://cla.msopentech.com/) and sign the Contributor License
+Please visit [https://cla2.msopentech.com/](https://cla2.msopentech.com/) and sign the Contributor License
 Agreement.  You only need to do that once. We can not look at your code until you've submitted this request.
 
 


### PR DESCRIPTION
[The old cla page](https://cla.msopentech.com/) isn't available