### PR TITLE
Reveal uncaught exceptions

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -179,8 +179,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -279,7 +279,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
         // Call acquire token with prompt never to prevent activity launch
         context.setRequestCorrelationId(requestCorrelationId);
-        context.acquireTokenSilent(expectedResource, expectedClientId, expectedUser, callback);
+        context.acquireTokenSilentAsync(expectedResource, expectedClientId, expectedUser, callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Verify that web request send correct headers
@@ -979,7 +979,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         final TestLogResponse response = new TestLogResponse();
         response.listenLogForMessageSegments(signal, "Refresh token did not return accesstoken");
 
-        context.acquireTokenSilent("resource", "clientid", TEST_IDTOKEN_USERID, callback);
+        context.acquireTokenSilentAsync("resource", "clientid", TEST_IDTOKEN_USERID, callback);
 
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
@@ -1431,7 +1431,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
 
         // Acquire token call will return from cache
-        context.acquireTokenSilent(resource, clientId, "user1", callback);
+        context.acquireTokenSilentAsync(resource, clientId, "user1", callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
@@ -1464,7 +1464,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
 
         // Acquire token call will return from cache
-        context.acquireTokenSilent(resource, clientId, "userid1", callback);
+        context.acquireTokenSilentAsync(resource, clientId, "userid1", callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
@@ -1478,7 +1478,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         MockAuthenticationCallback callback2 = new MockAuthenticationCallback(signal2);
 
         // Acquire token call will return from cache
-        context.acquireTokenSilent(resource, clientId, "userid2", callback2);
+        context.acquireTokenSilentAsync(resource, clientId, "userid2", callback2);
         signal2.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -57,6 +57,7 @@ import android.test.AndroidTestCase;
 import android.test.UiThreadTest;
 import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.SmallTest;
+import android.test.suitebuilder.annotation.Suppress;
 import android.util.Base64;
 import android.util.Log;
 import android.util.SparseArray;
@@ -1947,6 +1948,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         refreshItem.setAccessToken(token);
         refreshItem.setRefreshToken("refreshToken=");
         refreshItem.setExpiresOn(timeAhead.getTime());
+        refreshItem.setUserInfo(new UserInfo(user, "", "", "", user));
         cache.setItem(
                 CacheKey.createCacheKey(VALID_AUTHORITY, resource, client, isMultiResource, user),
                 refreshItem);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/FileMockContext.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/FileMockContext.java
@@ -29,6 +29,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.net.ConnectivityManager;
 import android.os.Looper;
 import android.test.mock.MockContext;
 import android.test.mock.MockPackageManager;
@@ -80,8 +81,10 @@ class FileMockContext extends MockContext {
 
     @Override
     public Object getSystemService(String name) {
-        if (name.equals("account")) {
+        if (name.equalsIgnoreCase("account")) {
             return mock(AccountManager.class);
+        } else if(name.equalsIgnoreCase("connectivity")) {
+            return mock(ConnectivityManager.class);
         }
         return new Object();
     }


### PR DESCRIPTION
All async tasks currently swallow runtime exceptions because if you use ExecutorSerice.submit() the only way to get exceptions is to call blocking get() method of the Future that was returned by submit.
When switch to execute it will throw exceptions to thread parent.
To support backward compat for existing public methods creating SettableFuture that will provide Future behavior (blocking get() until get results)

Also fixed some unit tests that apprerently were failing half way with NullPointerExceptions and no one was aware of it.