### PR TITLE
remove static sKey and sMacKey, also fix issue 512

### DIFF
--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -115,7 +115,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
 
     private String decrypt(final String key, final String value) {
         if (StringExtensions.IsNullOrBlank(key)) {
-            throw new IllegalArgumentException("key is null");
+            throw new IllegalArgumentException("key is null or blank");
         }
         
         try {

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -113,7 +113,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
         return null;
     }
 
-    private String decrypt(final String key, String value) {
+    private String decrypt(final String key, final String value) {
         try {
             return sHelper.decrypt(value);
         } catch (Exception e) {

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -118,7 +118,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
             return sHelper.decrypt(value);
         } catch (Exception e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.ENCRYPTION_FAILED, e);
-            if (!StringExtensions.IsNullOrBlank(value)) {
+            if (!StringExtensions.IsNullOrBlank(key)) {
                 removeItem(key);
                 Logger.v(TAG, String.format("Decryption error, item removed for key: '%s'", key));
             }

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -114,14 +114,16 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     }
 
     private String decrypt(final String key, final String value) {
+        if (StringExtensions.IsNullOrBlank(key)) {
+            throw new IllegalArgumentException("key is null");
+        }
+        
         try {
             return sHelper.decrypt(value);
         } catch (Exception e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.ENCRYPTION_FAILED, e);
-            if (!StringExtensions.IsNullOrBlank(key)) {
-                removeItem(key);
-                Logger.v(TAG, String.format("Decryption error, item removed for key: '%s'", key));
-            }
+            removeItem(key);
+            Logger.v(TAG, String.format("Decryption error, item removed for key: '%s'", key));
         }
 
         return null;

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.crypto.NoSuchPaddingException;
 
@@ -112,16 +113,16 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
         return null;
     }
 
-    private String decrypt(String value) {
+    private String decrypt(final String key, String value) {
         try {
             return sHelper.decrypt(value);
         } catch (Exception e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.ENCRYPTION_FAILED, e);
             if (!StringExtensions.IsNullOrBlank(value)) {
                 Logger.v(TAG, String.format("Decryption error for key: '%s'. Item will be removed",
-                        value));
-                removeItem(value);
-                Logger.v(TAG, String.format("Item removed for key: '%s'", value));
+                        key));
+                removeItem(key);
+                Logger.v(TAG, String.format("Item removed for key: '%s'", key));
             }
         }
 
@@ -139,7 +140,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
 
         if (mPrefs.contains(key)) {
             String json = mPrefs.getString(key, "");
-            String decrypted = decrypt(json);
+            String decrypted = decrypt(key, json);
             if (decrypted != null) {
                 return mGson.fromJson(decrypted, TokenCacheItem.class);
             }
@@ -213,17 +214,22 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
 
         @SuppressWarnings("unchecked")
         Map<String, String> results = (Map<String, String>)mPrefs.getAll();
-        Iterator<String> values = results.values().iterator();
 
         // create objects
         ArrayList<TokenCacheItem> tokens = new ArrayList<TokenCacheItem>(results.values().size());
-
-        while (values.hasNext()) {
-            String json = values.next();
-            String decrypted = decrypt(json);
-            if (decrypted != null) {
-                TokenCacheItem cacheItem = mGson.fromJson(decrypted, TokenCacheItem.class);
-                tokens.add(cacheItem);
+        
+        Iterator<Entry<String, String>> tokenResultEntrySet = results.entrySet().iterator();
+        while (tokenResultEntrySet.hasNext())
+        {
+            final Entry<String, String> tokenEntry = tokenResultEntrySet.next();
+            final String tokenKey = tokenEntry.getKey();
+            final String tokenValue = tokenEntry.getValue();
+            
+            final String decryptedValue = decrypt(tokenKey, tokenValue);
+            if (decryptedValue != null)
+            {
+                final TokenCacheItem tokenCacheItem = mGson.fromJson(decryptedValue, TokenCacheItem.class);
+                tokens.add(tokenCacheItem);
             }
         }
 

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -119,10 +119,8 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
         } catch (Exception e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.ENCRYPTION_FAILED, e);
             if (!StringExtensions.IsNullOrBlank(value)) {
-                Logger.v(TAG, String.format("Decryption error for key: '%s'. Item will be removed",
-                        key));
                 removeItem(key);
-                Logger.v(TAG, String.format("Item removed for key: '%s'", key));
+                Logger.v(TAG, String.format("Decryption error, item removed for key: '%s'", key));
             }
         }
 

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -127,7 +127,7 @@ public class StorageHelper {
 
     private static String sBlobVersion;
 
-    private SecretKey sKey = null, sMacKey = null;
+    private SecretKey mKey = null, mMacKey = null;
 
     private static SecretKey sSecretKeyFromAndroidKeyStore = null;
 
@@ -148,7 +148,7 @@ public class StorageHelper {
             InvalidKeySpecException {
         // Loading key only once for performance. If API is upgraded, it will
         // restart the device anyway. It will load the correct key for new API. 
-        if (sKey != null && sMacKey != null)
+        if (mKey != null && mMacKey != null)
             return;
 
         synchronized (LOCK_OBJ) {
@@ -160,8 +160,8 @@ public class StorageHelper {
                     // key for Encryption and HMac.
                     // If user specifies secret key, it will use the provided
                     // key.
-                    sKey = getSecretKeyFromAndroidKeyStore();
-                    sMacKey = getMacKey(sKey);
+                    mKey = getSecretKeyFromAndroidKeyStore();
+                    mMacKey = getMacKey(mKey);
                     sBlobVersion = VERSION_ANDROID_KEY_STORE;
                     return;
                 } catch (Exception e) {
@@ -171,8 +171,8 @@ public class StorageHelper {
             }
 
             Logger.v(TAG, "Encryption will use secret key from Settings");
-            sKey = getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
-            sMacKey = getMacKey(sKey);
+            mKey = getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
+            mMacKey = getMacKey(mKey);
             sBlobVersion = VERSION_USER_DEFINED;
         }
     }
@@ -285,13 +285,13 @@ public class StorageHelper {
         // Set to encrypt mode
         Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
         Mac mac = Mac.getInstance(MAC_ALGORITHM);
-        cipher.init(Cipher.ENCRYPT_MODE, sKey, ivSpec);
+        cipher.init(Cipher.ENCRYPT_MODE, mKey, ivSpec);
 
         byte[] encrypted = cipher.doFinal(bytes);
 
         // Mac output to sign encryptedData+IV. Keyversion is not included
         // in the digest. It defines what to use for Mac Key.
-        mac.init(sMacKey);
+        mac.init(mMacKey);
         mac.update(blobVersion);
         mac.update(encrypted);
         mac.update(iv);

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -147,10 +147,7 @@ public class StorageHelper {
     final private void loadSecretKeyForAPI() throws NoSuchAlgorithmException,
             InvalidKeySpecException {
         // Loading key only once for performance. If API is upgraded, it will
-        // restart the device anyway. It will load the correct key for new API.
-        // Remove the static class variable sKey and sMacKey. Static variables are 
-        // shared across instances. Once issue identified related to this is when two
-        // broker apps are involved. 
+        // restart the device anyway. It will load the correct key for new API. 
         if (sKey != null && sMacKey != null)
             return;
 

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -127,7 +127,7 @@ public class StorageHelper {
 
     private static String sBlobVersion;
 
-    private static SecretKey sKey = null, sMacKey = null;
+    private SecretKey sKey = null, sMacKey = null;
 
     private static SecretKey sSecretKeyFromAndroidKeyStore = null;
 
@@ -148,6 +148,9 @@ public class StorageHelper {
             InvalidKeySpecException {
         // Loading key only once for performance. If API is upgraded, it will
         // restart the device anyway. It will load the correct key for new API.
+        // Remove the static class variable sKey and sMacKey. Static variables are 
+        // shared across instances. Once issue identified related to this is when two
+        // broker apps are involved. 
         if (sKey != null && sMacKey != null)
             return;
 

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -125,7 +125,7 @@ public class StorageHelper {
 
     private static final Object LOCK_OBJ = new Object();
 
-    private static String sBlobVersion;
+    private String mBlobVersion;
 
     private SecretKey mKey = null, mMacKey = null;
 
@@ -162,7 +162,7 @@ public class StorageHelper {
                     // key.
                     mKey = getSecretKeyFromAndroidKeyStore();
                     mMacKey = getMacKey(mKey);
-                    sBlobVersion = VERSION_ANDROID_KEY_STORE;
+                    mBlobVersion = VERSION_ANDROID_KEY_STORE;
                     return;
                 } catch (Exception e) {
                     Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
@@ -173,7 +173,7 @@ public class StorageHelper {
             Logger.v(TAG, "Encryption will use secret key from Settings");
             mKey = getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
             mMacKey = getMacKey(mKey);
-            sBlobVersion = VERSION_USER_DEFINED;
+            mBlobVersion = VERSION_USER_DEFINED;
         }
     }
 
@@ -273,8 +273,8 @@ public class StorageHelper {
 
         // load key for encryption if not loaded
         loadSecretKeyForAPI();
-        Logger.v(TAG, "Encrypt version:" + sBlobVersion);
-        final byte[] blobVersion = sBlobVersion.getBytes(AuthenticationConstants.ENCODING_UTF8);
+        Logger.v(TAG, "Encrypt version:" + mBlobVersion);
+        final byte[] blobVersion = mBlobVersion.getBytes(AuthenticationConstants.ENCODING_UTF8);
         final byte[] bytes = clearText.getBytes(AuthenticationConstants.ENCODING_UTF8);
 
         // IV: Initialization vector that is needed to start CBC


### PR DESCRIPTION
1. fix issue 512
2. remove the static class variable for solving the decryption problem when two broker apps are involved: 
1) installing azure authenticator, and doing wpj from azure authenticator, perform CA flow
2) install company portal
3) uninstall AA app. 
Company portal requires user to do sign in, and when sign-in happened, the static variable will be set. When CA flow happened, data will always be encrypted with company portal's key, and will be decrypted with the key stored in account manager userdata. 
