### PR TITLE
Fix test issues for eclipse test build

### DIFF
--- a/src/src/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
+++ b/src/src/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
@@ -4,7 +4,7 @@ package com.microsoft.aad.adal;
  * ADAL exception for the case when server response doesn't have expected data
  * e.g. missing header, wrong status code, invalid format
  */
-class ResourceAuthenticationChallengeException extends Exception {
+public class ResourceAuthenticationChallengeException extends Exception {
 
     static final long serialVersionUID = 1;
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AndroidTestHelper.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AndroidTestHelper.java
@@ -72,7 +72,24 @@ public class AndroidTestHelper extends InstrumentationTestCase {
     }
 
     public void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
-            final ThrowableRunnable testCode) {
+                                      final ThrowableRunnable testCode) {
+        try {
+            testCode.run();
+            Assert.fail("This is expecting an exception, but it was not thrown.");
+        } catch (final Throwable result) {
+            if (!expected.isInstance(result)) {
+                Assert.fail("Exception was not correct");
+            }
+
+            if (hasMessage != null && !hasMessage.isEmpty()) {
+                assertTrue("Message has the text",
+                        (result.getMessage().toLowerCase(Locale.US).contains(hasMessage)));
+            }
+        }
+    }
+
+    public void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
+            final Runnable testCode) {
         try {
             testCode.run();
             Assert.fail("This is expecting an exception, but it was not thrown.");

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationParamsTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationParamsTests.java
@@ -278,7 +278,7 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
     public void testcreateFromResourceUrlNoCallback() throws MalformedURLException {
 
         final URL url = new URL("https://www.something.com");
-        assertThrowsException(IllegalArgumentException.class, "callback", new ThrowableRunnable() {
+        assertThrowsException(IllegalArgumentException.class, "callback", new Runnable() {
 
             @Override
             public void run() {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/FileTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/FileTokenCacheStoreTests.java
@@ -91,7 +91,7 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
     public void testFileCacheWriteError() {
         final FileMockContext mockContext = new FileMockContext(targetContex);
         assertThrowsException(IllegalStateException.class,
-                "it could not access the authorization cache directory", new ThrowableRunnable() {
+                "it could not access the authorization cache directory", new Runnable() {
                     @Override
                     public void run() {
                         ITokenCacheStore store = new FileTokenCacheStore(mockContext,


### PR DESCRIPTION
ResourceAuthenticationChallengeException needs to be public since tests are in different package
assertThrowsException should allow Runnable and ThrowableRunnable as argument