### PR TITLE
CallbackHandle checks if callback isn't null

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1023,7 +1023,7 @@ public class AuthenticationContext {
 
     private Handler mHandler;
 
-    class CallbackHandler {
+    private static class CallbackHandler {
         private Handler mRefHandler;
 
         private AuthenticationCallback<AuthenticationResult> callback;
@@ -1231,12 +1231,8 @@ public class AuthenticationContext {
                 } catch (AuthenticationException ex) {
                     // pass back to caller for known exceptions such as failure
                     // to encrypt
-                    if (callbackHandle.callback != null) {
-                        callbackHandle.onError(ex);
-                        return null;
-                    } else {
-                        throw ex;
-                    }
+                    callbackHandle.onError(ex);
+                    return null;
                 }
             } else {
                 Logger.v(TAG, "User is not specified for background token request");
@@ -1245,9 +1241,7 @@ public class AuthenticationContext {
             if (result != null && result.getAccessToken() != null
                     && !result.getAccessToken().isEmpty()) {
                 Logger.v(TAG, "Token is returned from background call ");
-                if (callbackHandle.callback != null) {
-                    callbackHandle.onSuccess(result);
-                }
+                callbackHandle.onSuccess(result);
                 return result;
             }
 
@@ -1257,7 +1251,7 @@ public class AuthenticationContext {
             // record calling uid for the account. This happens for Prompt auto
             // or always behavior.
             Logger.v(TAG, "Token is not returned from backgroud call");
-            if (!request.isSilent() && callbackHandle.callback != null && activity != null) {
+            if (!request.isSilent() && activity != null) {
 
                 // Only happens with callback since silent call does not show UI
                 Logger.v(TAG, "Launch activity for Authenticator");
@@ -1316,20 +1310,14 @@ public class AuthenticationContext {
         // Lookup access token from cache
         AuthenticationResult cachedItem = getItemFromCache(request);
         if (cachedItem != null && isUserMisMatch(request, cachedItem)) {
-            if (callbackHandle.callback != null) {
-                callbackHandle.onError(new AuthenticationException(
-                        ADALError.AUTH_FAILED_USER_MISMATCH));
-                return null;
-            } else {
-                throw new AuthenticationException(ADALError.AUTH_FAILED_USER_MISMATCH);
-            }
+            callbackHandle.onError(new AuthenticationException(
+                    ADALError.AUTH_FAILED_USER_MISMATCH));
+            return null;
         }
 
         if (!promptUser(request.getPrompt()) && isValidCache(cachedItem)) {
             Logger.v(TAG, "Token is returned from cache");
-            if (callbackHandle.callback != null) {
-                callbackHandle.onSuccess(cachedItem);
-            }
+            callbackHandle.onSuccess(cachedItem);
             return cachedItem;
         }
 
@@ -1341,7 +1329,7 @@ public class AuthenticationContext {
             return refreshToken(callbackHandle, activity, useDialog, request, refreshItem, true);
         } else {
             Logger.v(TAG, "Refresh token is not available");
-            if (!request.isSilent() && callbackHandle.callback != null
+            if (!request.isSilent()
                     && (activity != null || useDialog)) {
                 //Check if there is network connection
                 if (!mConnectionService.isConnectionAvailable()) {


### PR DESCRIPTION
There is no need to double check if callback is null
And if callback is null, that means nothing should happen, user doesn't want to know about results of operation
Internally we always set callback to non-null value