### PR TITLE
AuthenticationException derive from Exceptions

### DIFF
--- a/src/src/com/microsoft/aad/adal/ADALError.java
+++ b/src/src/com/microsoft/aad/adal/ADALError.java
@@ -500,7 +500,17 @@ public enum ADALError {
     /**
      * The redirectUri for broker is invalid.
      */
-    DEVELOPER_REDIRECTURI_INVALID("The redirectUri for broker is invalid");
+    DEVELOPER_REDIRECTURI_INVALID("The redirectUri for broker is invalid"),
+
+    /**
+     * Device challenge failure
+     */
+    DEVICE_CHALLENGE_FAILURE("Device challenge failure"),
+
+    /**
+     * Resource authentication challenge failure
+     */
+    RESOURCE_AUTHENTICATION_CHALLENGE_FAILURE("Resource authentication challenge failure");
 
     private String mDescription;
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -814,7 +814,7 @@ public class AuthenticationActivity extends Activity {
             try {
                 result.taskResult = oauthRequest.getToken(urlItems[0]);
                 Logger.v(TAG, "TokenTask processed the result. " + mRequest.getLogInfo());
-            } catch (IOException | AuthenticationServerProtocolException exc) {
+            } catch (IOException | AuthenticationException exc) {
                 Logger.e(TAG, "Error in processing code to get a token. " + mRequest.getLogInfo(),
                         "Request url:" + urlItems[0],
                         ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, exc);

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -537,7 +537,7 @@ public class AuthenticationContext {
     private String checkInputParameters(String resource, String clientId, String redirectUri,
             PromptBehavior behavior, AuthenticationCallback<AuthenticationResult> callback) {
         if (mContext == null) {
-            throw new AuthenticationException(ADALError.DEVELOPER_CONTEXT_IS_NOT_PROVIDED);
+            throw new IllegalArgumentException("context", new AuthenticationException(ADALError.DEVELOPER_CONTEXT_IS_NOT_PROVIDED));
         }
 
         if (StringExtensions.IsNullOrBlank(resource)) {
@@ -794,7 +794,7 @@ public class AuthenticationContext {
                                     result = oauthRequest.getToken(endingUrl);
                                     Logger.v(TAG, "OnActivityResult processed the result. "
                                             + authenticationRequest.getLogInfo());
-                                } catch (IOException | AuthenticationServerProtocolException exc) {
+                                } catch (IOException | AuthenticationException exc) {
                                     String msg = "Error in processing code to get token. "
                                             + authenticationRequest.getLogInfo() + correlationInfo;
                                     Logger.e(TAG, msg,
@@ -1042,8 +1042,6 @@ public class AuthenticationContext {
                         return;
                     }
                 });
-            } else {
-                throw e;
             }
         }
 
@@ -1136,7 +1134,7 @@ public class AuthenticationContext {
      * @throws AuthenticationException
      * @return true if the redirectUri is valid or fail and throw the AuthenticationException
      */
-    private boolean verifyBrokerRedirectUri(final AuthenticationRequest request) {   
+    private boolean verifyBrokerRedirectUri(final AuthenticationRequest request) throws AuthenticationException {
         final String methodName = ":verifyBrokerRedirectUri";
         final String inputUri = request.getRedirectUri();
         final String actualUri = getRedirectUriForBroker();
@@ -1534,7 +1532,7 @@ public class AuthenticationContext {
     }
 
     private void setItemToCache(final AuthenticationRequest request, AuthenticationResult result,
-            boolean afterPrompt) throws AuthenticationException {
+            boolean afterPrompt) {
         if (mTokenCacheStore != null) {
 
             // User can ask for token without login hint. Next call from same
@@ -1604,8 +1602,7 @@ public class AuthenticationContext {
     }
 
     private void setItemToCacheFromRefresh(final RefreshItem refreshItem,
-            final AuthenticationRequest request, AuthenticationResult result)
-            throws AuthenticationException {
+            final AuthenticationRequest request, AuthenticationResult result) {
         if (mTokenCacheStore != null) {
             // Use same key to store refreshed result. This key may belong to
             // normal token or MRRT token.
@@ -1620,7 +1617,7 @@ public class AuthenticationContext {
         }
     }
 
-    private void removeItemFromCache(final RefreshItem refreshItem) throws AuthenticationException {
+    private void removeItemFromCache(final RefreshItem refreshItem) {
         if (mTokenCacheStore != null) {
             Logger.v(TAG, "Remove refresh item from cache:" + refreshItem.mKey);
             mTokenCacheStore.removeItem(refreshItem.mKey);
@@ -1675,7 +1672,7 @@ public class AuthenticationContext {
                 Logger.v(TAG, "Refresh token is not returned or empty");
                 result.setRefreshToken(refreshItem.mRefreshToken);
             }
-        } catch (IOException | AuthenticationServerProtocolException exc) {
+        } catch (IOException | AuthenticationException exc) {
             // Server side error or similar
             Logger.e(TAG, "Error in refresh token for request:" + request.getLogInfo(),
                     ExceptionExtensions.getExceptionMessage(exc), ADALError.AUTH_FAILED_NO_TOKEN,
@@ -1958,7 +1955,7 @@ public class AuthenticationContext {
         PackageManager pm = mContext.getPackageManager();
         if (PackageManager.PERMISSION_GRANTED != pm.checkPermission("android.permission.INTERNET",
                 mContext.getPackageName())) {
-            throw new AuthenticationException(ADALError.DEVELOPER_INTERNET_PERMISSION_MISSING);
+            throw new IllegalStateException(new AuthenticationException(ADALError.DEVELOPER_INTERNET_PERMISSION_MISSING));
         }
     }
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationException.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationException.java
@@ -23,7 +23,7 @@ import android.content.Context;
 /**
  * ADAL exception.
  */
-public class AuthenticationException extends RuntimeException {
+public class AuthenticationException extends Exception {
     static final long serialVersionUID = 1;
 
     protected ADALError mCode;

--- a/src/src/com/microsoft/aad/adal/AuthenticationServerProtocolException.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationServerProtocolException.java
@@ -3,12 +3,12 @@ package com.microsoft.aad.adal;
 /**
  * ADAL exception for device challenge processing
  */
-class AuthenticationServerProtocolException extends Exception {
+class AuthenticationServerProtocolException extends AuthenticationException {
 
     static final long serialVersionUID = 1;
 
     public AuthenticationServerProtocolException(String detailMessage) {
-        super(detailMessage);
+        super(ADALError.DEVICE_CHALLENGE_FAILURE, detailMessage);
     }
 }
 

--- a/src/src/com/microsoft/aad/adal/BrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/BrokerProxy.java
@@ -201,7 +201,9 @@ class BrokerProxy implements IBrokerProxy {
      * Gets accessToken from Broker component.
      */
     @Override
-    public AuthenticationResult getAuthTokenInBackground(final AuthenticationRequest request) {
+    public AuthenticationResult getAuthTokenInBackground(final AuthenticationRequest request)
+            throws AuthenticationException
+    {
 
         AuthenticationResult authResult = null;
         verifyNotOnMainThread();
@@ -269,7 +271,7 @@ class BrokerProxy implements IBrokerProxy {
         return null;
     }
 
-    private AuthenticationResult getResultFromBrokerResponse(Bundle bundleResult) {
+    private AuthenticationResult getResultFromBrokerResponse(Bundle bundleResult) throws AuthenticationException {
         if (bundleResult == null) {
             throw new IllegalArgumentException("bundleResult");
         }

--- a/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
+++ b/src/src/com/microsoft/aad/adal/ChallangeResponseBuilder.java
@@ -86,19 +86,19 @@ class ChallangeResponseBuilder {
      * @return Return Device challange response
      */
     public ChallangeResponse getChallangeResponseFromUri(final String redirectUri)
-            throws AuthenticationServerProtocolException {
+            throws AuthenticationServerProtocolException, AuthenticationException  {
         ChallangeRequest request = getChallangeRequest(redirectUri);
         return getDeviceCertResponse(request);
     }
 
     public ChallangeResponse getChallangeResponseFromHeader(final String challangeHeaderValue,
-            final String endpoint) throws UnsupportedEncodingException, AuthenticationServerProtocolException {
+            final String endpoint) throws UnsupportedEncodingException, AuthenticationServerProtocolException, AuthenticationException {
         ChallangeRequest request = getChallangeRequestFromHeader(challangeHeaderValue);
         request.mSubmitUrl = endpoint;
         return getDeviceCertResponse(request);
     }
 
-    private ChallangeResponse getDeviceCertResponse(ChallangeRequest request) {
+    private ChallangeResponse getDeviceCertResponse(ChallangeRequest request) throws AuthenticationException {
         ChallangeResponse response = getNoDeviceCertResponse(request);
         response.mSubmitUrl = request.mSubmitUrl;
 
@@ -144,7 +144,8 @@ class ChallangeResponseBuilder {
         return true;
     }
 
-    private IDeviceCertificate getWPJAPIInstance(Class<IDeviceCertificate> certClazz) {
+    private IDeviceCertificate getWPJAPIInstance(Class<IDeviceCertificate> certClazz) 
+    	throws AuthenticationException {
         IDeviceCertificate deviceCertProxy = null;
         Constructor<?> constructor;
         try {
@@ -179,7 +180,7 @@ class ChallangeResponseBuilder {
     }
 
     private ChallangeRequest getChallangeRequestFromHeader(final String headerValue)
-            throws UnsupportedEncodingException, AuthenticationServerProtocolException {
+            throws UnsupportedEncodingException, AuthenticationException {
         final String methodName = ":getChallangeRequestFromHeader";
         
         if (StringExtensions.IsNullOrBlank(headerValue)) {
@@ -259,7 +260,7 @@ class ChallangeResponseBuilder {
     }
 
     private void validateChallangeRequest(HashMap<String, String> headerItems,
-            boolean redirectFormat) {
+            boolean redirectFormat) throws AuthenticationException{
         if (!(headerItems.containsKey(RequestField.Nonce.name()) || headerItems
                 .containsKey(RequestField.Nonce.name().toLowerCase(Locale.US)))) {
             throw new AuthenticationException(ADALError.DEVICE_CERTIFICATE_REQUEST_INVALID, "Nonce");
@@ -282,7 +283,8 @@ class ChallangeResponseBuilder {
         }
     }
 
-    private ChallangeRequest getChallangeRequest(final String redirectUri) throws AuthenticationServerProtocolException {
+    private ChallangeRequest getChallangeRequest(final String redirectUri)
+            throws AuthenticationException {
         if (StringExtensions.IsNullOrBlank(redirectUri)) {
             throw new AuthenticationServerProtocolException("redirectUri");
         }

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -334,11 +334,11 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
 
     private void argumentCheck() {
         if (mContext == null) {
-            throw new AuthenticationException(ADALError.DEVELOPER_CONTEXT_IS_NOT_PROVIDED);
+            throw new IllegalArgumentException("context", new AuthenticationException(ADALError.DEVELOPER_CONTEXT_IS_NOT_PROVIDED));
         }
 
         if (mPrefs == null) {
-            throw new AuthenticationException(ADALError.DEVICE_SHARED_PREF_IS_NOT_AVAILABLE);
+            throw new IllegalArgumentException("prefs", new AuthenticationException(ADALError.DEVICE_SHARED_PREF_IS_NOT_AVAILABLE));
         }
     }
 

--- a/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/FileTokenCacheStore.java
@@ -110,7 +110,7 @@ public class FileTokenCacheStore implements ITokenCacheStore {
             // if it is not possible to load the cache because of permissions or
             // similar, it will not work again. File cache is not working and
             // not make sense to use it.
-            throw new AuthenticationException(ADALError.DEVICE_FILE_CACHE_IS_NOT_LOADED_FROM_FILE);
+            throw new IllegalStateException(ex);
 
         }
     }

--- a/src/src/com/microsoft/aad/adal/IBrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/IBrokerProxy.java
@@ -54,7 +54,8 @@ interface IBrokerProxy {
      * @param request
      * @return AuthenticationResult
      */
-    AuthenticationResult getAuthTokenInBackground(final AuthenticationRequest request);
+    AuthenticationResult getAuthTokenInBackground(final AuthenticationRequest request)
+            throws AuthenticationException;
 
     /**
      * only gets intent to start from calling app's activity.

--- a/src/src/com/microsoft/aad/adal/IJWSBuilder.java
+++ b/src/src/com/microsoft/aad/adal/IJWSBuilder.java
@@ -42,5 +42,5 @@ public interface IJWSBuilder {
      * @return Signed JWT
      */
     public String generateSignedJWT(String nonce, String submitUrl, RSAPrivateKey privateKey,
-            RSAPublicKey pubKey, X509Certificate x509Certificate);
+            RSAPublicKey pubKey, X509Certificate x509Certificate) throws AuthenticationException;
 }

--- a/src/src/com/microsoft/aad/adal/JWSBuilder.java
+++ b/src/src/com/microsoft/aad/adal/JWSBuilder.java
@@ -82,7 +82,7 @@ class JWSBuilder implements IJWSBuilder {
      * 
      */
     public String generateSignedJWT(String nonce, String audience, RSAPrivateKey privateKey,
-            RSAPublicKey pubKey, X509Certificate cert) {
+            RSAPublicKey pubKey, X509Certificate cert) throws AuthenticationException {
         // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-25
         // In the JWS Compact Serialization, a JWS object is represented as the
         // combination of these three string values,
@@ -157,7 +157,7 @@ class JWSBuilder implements IJWSBuilder {
      * @param input
      * @return
      */
-    private static String sign(RSAPrivateKey privateKey, final byte[] input) {
+    private static String sign(RSAPrivateKey privateKey, final byte[] input) throws AuthenticationException {
         Signature signer = null;
         try {
             signer = Signature.getInstance(JWS_ALGORITHM);

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -335,7 +335,7 @@ class Oauth2 {
         }
     }
 
-    public AuthenticationResult refreshToken(String refreshToken) throws IOException, AuthenticationServerProtocolException {
+    public AuthenticationResult refreshToken(String refreshToken) throws IOException, AuthenticationException {
         String requestMessage = null;
         if (mWebRequestHandler == null) {
             Logger.v(TAG, "Web request is not set correctly");
@@ -369,7 +369,8 @@ class Oauth2 {
      *         not have protocol error.
      * @throws Exception
      */
-    public AuthenticationResult getToken(String authorizationUrl) throws IOException, AuthenticationServerProtocolException {
+    public AuthenticationResult getToken(String authorizationUrl)
+            throws IOException, AuthenticationServerProtocolException, AuthenticationException {
 
         if (StringExtensions.IsNullOrBlank(authorizationUrl)) {
             throw new IllegalArgumentException("authorizationUrl");
@@ -418,7 +419,7 @@ class Oauth2 {
      * @return Token in the AuthenticationResult
      * @throws Exception
      */
-    public AuthenticationResult getTokenForCode(String code) throws IOException, AuthenticationServerProtocolException {
+    public AuthenticationResult getTokenForCode(String code) throws IOException, AuthenticationException {
 
         String requestMessage = null;
         if (mWebRequestHandler == null) {
@@ -438,7 +439,7 @@ class Oauth2 {
     }
 
     private AuthenticationResult postMessage(String requestMessage, HashMap<String, String> headers)
-            throws IOException, AuthenticationServerProtocolException {
+            throws IOException, AuthenticationException {
         URL authority = null;
         AuthenticationResult result = null;
         authority = StringExtensions.getUrl(getTokenEndpoint());

--- a/src/src/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
+++ b/src/src/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
@@ -4,11 +4,11 @@ package com.microsoft.aad.adal;
  * ADAL exception for the case when server response doesn't have expected data
  * e.g. missing header, wrong status code, invalid format
  */
-class ResourceAuthenticationChallengeException extends Exception {
+class ResourceAuthenticationChallengeException extends AuthenticationException {
 
     static final long serialVersionUID = 1;
 
     public ResourceAuthenticationChallengeException(String detailMessage) {
-        super(detailMessage);
+        super(ADALError.RESOURCE_AUTHENTICATION_CHALLENGE_FAILURE, detailMessage);
     }
 }

--- a/src/src/com/microsoft/aad/adal/WebviewHelper.java
+++ b/src/src/com/microsoft/aad/adal/WebviewHelper.java
@@ -136,7 +136,7 @@ public class WebviewHelper {
     }
 
     public PreKeyAuthInfo getPreKeyAuthInfo(String challengeUrl)
-            throws UnsupportedEncodingException, AuthenticationServerProtocolException {
+            throws UnsupportedEncodingException, AuthenticationException {
         IJWSBuilder jwsBuilder = new JWSBuilder();
 
         ChallangeResponseBuilder certHandler = new ChallangeResponseBuilder(jwsBuilder);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -285,6 +285,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
         // Verify that web request send correct headers
         Log.v(TAG, "Response msg:" + response.message);
+        assertNotNull("Server response isn't null ", response.message);
         assertTrue("Server response has same correlationId",
                 response.message.contains(requestCorrelationId.toString()));
     }
@@ -1160,7 +1161,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         // Same call with correct upn will return from cache
         final CountDownLatch signalCallback2 = new CountDownLatch(1);
         callback.mSignal = signalCallback2;
-        context.acquireToken(null, "resource", "clientid", "redirectUri", idtoken.upn, callback);
+        context.acquireToken(testActivity, "resource", "clientid", "redirectUri", TestIdToken.upn, callback);
         signalCallback2.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
         verifyTokenResult(idtoken, callback.mResult);
 
@@ -1225,7 +1226,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
     public void testFamilyClientIdCorrectlyStoredInCache() throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,
             NoSuchMethodException, InstantiationException, InvocationTargetException,
-            NoSuchAlgorithmException, NoSuchPaddingException {
+            NoSuchAlgorithmException, NoSuchPaddingException, AuthenticationException {
 
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
@@ -1288,7 +1289,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
     public void testRefreshTokenRequestWithFamilyIdSuccess() throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,
             NoSuchMethodException, InstantiationException, InvocationTargetException,
-            NoSuchAlgorithmException, NoSuchPaddingException {
+            NoSuchAlgorithmException, NoSuchPaddingException, AuthenticationException {
         
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheWithFamilyIdForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
@@ -1652,7 +1653,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         final CountDownLatch signal3 = new CountDownLatch(1);
         MockAuthenticationCallback callback3 = new MockAuthenticationCallback(signal3);
 
-        context.acquireToken(null, resource, clientId, "http://redirectUri", "userName1", callback3);
+        context.acquireToken(new MockActivity(null), resource, clientId, "http://redirectUri", "userName1", callback3);
         signal3.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
         
         // Check response in callback

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -209,7 +209,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
             assertEquals("Permission related message",
                     ADALError.DEVELOPER_INTERNET_PERMISSION_MISSING,
-                    ((AuthenticationException)e).getCode());
+                    ((AuthenticationException)e.getCause()).getCode());
         }
     }
 
@@ -1008,7 +1008,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
     public void testRefreshTokenPositive() throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,
             NoSuchMethodException, InstantiationException, InvocationTargetException,
-            NoSuchAlgorithmException, NoSuchPaddingException {
+            NoSuchAlgorithmException, NoSuchPaddingException, AuthenticationException {
 
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
@@ -1055,7 +1055,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
             IllegalArgumentException, NoSuchFieldException, IllegalAccessException,
             ClassNotFoundException, NoSuchMethodException, InstantiationException,
             InvocationTargetException, NoSuchAlgorithmException, NoSuchPaddingException,
-            UnsupportedEncodingException {
+            UnsupportedEncodingException, AuthenticationException {
         scenario_UserId_LoginHint("test@user.com", "test@user.com", "test@user.com");
     }
 
@@ -1063,7 +1063,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
             String acquireTokenHint) throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,
             NoSuchMethodException, InstantiationException, InvocationTargetException,
-            NoSuchAlgorithmException, NoSuchPaddingException, UnsupportedEncodingException {
+            NoSuchAlgorithmException, NoSuchPaddingException, UnsupportedEncodingException,
+            AuthenticationException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false);
@@ -1114,7 +1115,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
             IllegalArgumentException, NoSuchFieldException, IllegalAccessException,
             ClassNotFoundException, NoSuchMethodException, InstantiationException,
             InvocationTargetException, NoSuchAlgorithmException, NoSuchPaddingException,
-            UnsupportedEncodingException {
+            UnsupportedEncodingException, AuthenticationException {
         scenario_UserId_LoginHint("test@user.com", "", "");
     }
 
@@ -1123,7 +1124,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
             IllegalArgumentException, NoSuchFieldException, IllegalAccessException,
             ClassNotFoundException, NoSuchMethodException, InstantiationException,
             InvocationTargetException, NoSuchAlgorithmException, NoSuchPaddingException,
-            UnsupportedEncodingException {
+            UnsupportedEncodingException, AuthenticationException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false);
@@ -1173,7 +1174,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
     public void testScenario_Empty_IdToken() throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,
             NoSuchMethodException, InstantiationException, InvocationTargetException,
-            NoSuchAlgorithmException, NoSuchPaddingException, UnsupportedEncodingException {
+            NoSuchAlgorithmException, NoSuchPaddingException, UnsupportedEncodingException,
+            AuthenticationException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final AuthenticationContext context = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false);
@@ -1257,7 +1259,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
     public void testAcquireTokenSilentSync_Positive() throws NoSuchAlgorithmException,
             NoSuchPaddingException, NoSuchFieldException, IllegalAccessException,
-            InterruptedException, ExecutionException {
+            InterruptedException, ExecutionException, AuthenticationException {
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
         final AuthenticationContext context = getAuthenticationContext(mockContext,
@@ -1282,7 +1284,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
     public void testAcquireTokenSilentSync_Negative() throws NoSuchAlgorithmException,
             NoSuchPaddingException, NoSuchFieldException, IllegalAccessException,
-            InterruptedException, ExecutionException {
+            InterruptedException, ExecutionException, AuthenticationException {
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
         final AuthenticationContext context = getAuthenticationContext(mockContext,
@@ -1297,6 +1299,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
         // Call refresh token in silent API method
+
         try {
             context.acquireTokenSilentSync(null, "clientid", TEST_IDTOKEN_USERID);
             Assert.fail("Expected argument exception");
@@ -1993,7 +1996,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         catch(InvocationTargetException e)
         {
             assertTrue(e.getCause() instanceof AuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((AuthenticationException)e.getCause()).getCode());
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID, ((AuthenticationException) e.getCause()).getCode());
             assertTrue(((AuthenticationException)e.getCause()).getMessage().toString().contains("signature"));
         }
     }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/ChallangeResponseBuilderTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/ChallangeResponseBuilderTests.java
@@ -50,7 +50,7 @@ public class ChallangeResponseBuilderTests extends AndroidTestHelper {
     public void testGetChallangeResponseFromHeader_Positive() throws ClassNotFoundException,
             InstantiationException, IllegalAccessException, IllegalArgumentException,
             InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
-            NoSuchAlgorithmException {
+            NoSuchAlgorithmException, AuthenticationException {
         KeyPair keyPair = getKeyPair();
         RSAPublicKey publicKey = (RSAPublicKey)keyPair.getPublic();
         RSAPrivateKey privateKey = (RSAPrivateKey)keyPair.getPrivate();
@@ -90,7 +90,7 @@ public class ChallangeResponseBuilderTests extends AndroidTestHelper {
     public void testGetChallangeResponseFromHeader_CertAuthorityPresent() throws ClassNotFoundException,
     InstantiationException, IllegalAccessException, IllegalArgumentException,
     InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
-    NoSuchAlgorithmException {
+    NoSuchAlgorithmException, AuthenticationException {
         KeyPair keyPair = getKeyPair();
         RSAPublicKey publicKey = (RSAPublicKey)keyPair.getPublic();
         RSAPrivateKey privateKey = (RSAPrivateKey)keyPair.getPrivate();
@@ -352,7 +352,7 @@ public class ChallangeResponseBuilderTests extends AndroidTestHelper {
     public void testGetChallangeResponse_Positive() throws ClassNotFoundException,
             InstantiationException, IllegalAccessException, IllegalArgumentException,
             InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
-            NoSuchAlgorithmException {
+            NoSuchAlgorithmException, AuthenticationException {
         KeyPair keyPair = getKeyPair();
         RSAPublicKey publicKey = (RSAPublicKey)keyPair.getPublic();
         RSAPrivateKey privateKey = (RSAPrivateKey)keyPair.getPrivate();

--- a/tests/Functional/src/com/microsoft/aad/adal/test/DefaultTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/DefaultTokenCacheStoreTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.security.DigestException;
+import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
@@ -76,12 +77,8 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         super.tearDown();
     }
 
-    public void testSharedCache() throws NoSuchAlgorithmException, NoSuchPaddingException,
-            InvalidKeyException, InvalidKeySpecException, KeyStoreException, CertificateException,
-            NoSuchProviderException, InvalidAlgorithmParameterException,
-            UnrecoverableEntryException, DigestException, IllegalBlockSizeException,
-            BadPaddingException, IOException, NameNotFoundException, NoSuchFieldException,
-            IllegalArgumentException, IllegalAccessException {
+    public void testSharedCache() throws GeneralSecurityException, IOException, NameNotFoundException,
+            NoSuchFieldException, IllegalAccessException {
         AuthenticationSettings.INSTANCE.setSharedPrefPackageName("mockpackage");
         StorageHelper mockSecure = mock(StorageHelper.class);
         Context mockContext = mock(Context.class);
@@ -123,12 +120,8 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         assertEquals(2, users.size());
     }
 
-    public void testDateTimeFormatterOldFormat() throws NoSuchAlgorithmException,
-            NoSuchPaddingException, InvalidKeyException, InvalidKeySpecException,
-            KeyStoreException, CertificateException, NoSuchProviderException,
-            InvalidAlgorithmParameterException, UnrecoverableEntryException, DigestException,
-            IllegalBlockSizeException, BadPaddingException, IOException, NameNotFoundException,
-            NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+    public void testDateTimeFormatterOldFormat() throws GeneralSecurityException, IOException, NameNotFoundException,
+            NoSuchFieldException, IllegalAccessException {
         StorageHelper mockSecure = mock(StorageHelper.class);
         Context mockContext = mock(Context.class);
         SharedPreferences prefs = mock(SharedPreferences.class);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -449,7 +449,7 @@ public class OauthTests extends AndroidTestCase {
     public void testRefreshTokenWebResponse_DeviceChallenge_Positive()
             throws IllegalArgumentException, ClassNotFoundException, NoSuchMethodException,
             InstantiationException, IllegalAccessException, InvocationTargetException,
-            NoSuchAlgorithmException, MalformedURLException {
+            NoSuchAlgorithmException, MalformedURLException, AuthenticationException {
         IWebRequestHandler mockWebRequest = mock(IWebRequestHandler.class);
         KeyPair keyPair = getKeyPair();
         RSAPublicKey publicKey = (RSAPublicKey)keyPair.getPublic();


### PR DESCRIPTION
It allows to detect where this exception need to be caught
Also derive internal errors (AuthenticationServerProtocolException and ResourceAuthenticationChallengeException) from AuthenticationException to keep exception system consistent
Some developer exceptions better to stay as Runtime, using IlligalStateException/IlligalArgumentException for that cases