### PR TITLE
The redirectUri should not be checked if it is a silent request

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1280,7 +1280,9 @@ public class AuthenticationContext {
             //check if the redirectUri is valid
             try
             {
-                verifyBrokerRedirectUri(request);
+                if(!request.isSilent()){
+                    verifyBrokerRedirectUri(request);
+                }
             }
             catch(AuthenticationException exception)
             {

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1211,47 +1211,36 @@ public class AuthenticationContext {
         final String actualUri = getRedirectUriForBroker();
         String errMsg = "";
         
-        if(StringExtensions.IsNullOrBlank(inputUri))
-        {
+        if(StringExtensions.IsNullOrBlank(inputUri)) {
             errMsg = "The redirectUri is null or blank. "
                     + "so the redirect uri is expected to be:" + actualUri;
             Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID); 
             throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
-        }
-        else if(!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://"))
-        {
+        } else if(!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://")) {
             errMsg = "The prefix of the redirect uri does not match the expected value. "
                     + " The valid broker redirect URI prefix: " + AuthenticationConstants.Broker.REDIRECT_PREFIX
                     + " so the redirect uri is expected to be: " + actualUri;
             Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);
             throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
-        } 
-        else
-        {
-            try 
-            {
+        } else {
+            try {
                 PackageHelper packageHelper = new PackageHelper(mContext);
                 String base64URLEncodePackagename = URLEncoder.encode(mContext.getPackageName(), AuthenticationConstants.ENCODING_UTF8);
                 String base64URLEncodeSignature = URLEncoder.encode(packageHelper.getCurrentSignatureForPackage(mContext.getPackageName()), AuthenticationConstants.ENCODING_UTF8);
-                if(!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://" + base64URLEncodePackagename + "/"))
-                {
+                if(!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://" + base64URLEncodePackagename + "/")) {
                     errMsg = "The base64 url encoded package name component of the redirect uri does not match the expected value. "
                             + " This apps package name is: " + base64URLEncodePackagename
                             + " so the redirect uri is expected to be: " + actualUri;
                     Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);     
                     throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
-                }
-                else if(!inputUri.equalsIgnoreCase(actualUri))
-                {
+                } else if(!inputUri.equalsIgnoreCase(actualUri)) {
                     errMsg = "The base64 url encoded signature component of the redirect uri does not match the expected value. "
                             + " This apps signature is: " + base64URLEncodeSignature
                             + " so the redirect uri is expected to be: " + actualUri;
                     Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);     
                     throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
                 }
-            } 
-            catch (UnsupportedEncodingException e) 
-            {
+            } catch (UnsupportedEncodingException e) {
                 Logger.e(TAG + methodName, e.getMessage(), "", ADALError.ENCODING_IS_NOT_SUPPORTED, e);
                 throw new DeveloperAuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED, "The verifying BrokerRedirectUri "
                         + "process failed because the base64 url encoding is not supported.", e);
@@ -1278,18 +1267,15 @@ public class AuthenticationContext {
             request.setBrokerAccountName(request.getLoginHint());
             
             //check if the redirectUri is valid
-            try
-            {
-            	//the broker redirectUri will be checked only if 
-            	//the request from client App is not silent
-            	//otherwise the acquiretokensilent might be interrupted 
-            	//by DeveloperAuthenticationException
-                if(!request.isSilent()){
+            try {
+                //the broker redirectUri will be checked only if 
+                //the request from client App is not silent
+                //otherwise the acquiretokensilent might be interrupted 
+                //by DeveloperAuthenticationException
+                if(!request.isSilent()) {
                     verifyBrokerRedirectUri(request);
                 }
-            }
-            catch(DeveloperAuthenticationException exception)
-            {
+            } catch(DeveloperAuthenticationException exception) {
                 Logger.v(TAG + methodName, "Did not pass the verification of the broker redirect URI");
                 callbackHandle.onError(exception);
                 return result;

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1202,10 +1202,10 @@ public class AuthenticationContext {
      * redirectUri format %PREFIX://%PACKAGE_NAME/%SIGNATURE
      * 
      * @param request
-     * @throws AuthenticationException
+     * @throws DeveloperAuthenticationException
      * @return true if the redirectUri is valid or fail and throw the AuthenticationException
      */
-    private boolean verifyBrokerRedirectUri(final AuthenticationRequest request) {   
+    private boolean verifyBrokerRedirectUri(final AuthenticationRequest request) throws DeveloperAuthenticationException {   
         final String methodName = ":verifyBrokerRedirectUri";
         final String inputUri = request.getRedirectUri();
         final String actualUri = getRedirectUriForBroker();
@@ -1216,7 +1216,7 @@ public class AuthenticationContext {
             errMsg = "The redirectUri is null or blank. "
                     + "so the redirect uri is expected to be:" + actualUri;
             Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID); 
-            throw new AuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+            throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
         }
         else if(!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://"))
         {
@@ -1224,7 +1224,7 @@ public class AuthenticationContext {
                     + " The valid broker redirect URI prefix: " + AuthenticationConstants.Broker.REDIRECT_PREFIX
                     + " so the redirect uri is expected to be: " + actualUri;
             Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);
-            throw new AuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+            throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
         } 
         else
         {
@@ -1239,7 +1239,7 @@ public class AuthenticationContext {
                             + " This apps package name is: " + base64URLEncodePackagename
                             + " so the redirect uri is expected to be: " + actualUri;
                     Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);     
-                    throw new AuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+                    throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
                 }
                 else if(!inputUri.equalsIgnoreCase(actualUri))
                 {
@@ -1247,13 +1247,13 @@ public class AuthenticationContext {
                             + " This apps signature is: " + base64URLEncodeSignature
                             + " so the redirect uri is expected to be: " + actualUri;
                     Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);     
-                    throw new AuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+                    throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
                 }
             } 
             catch (UnsupportedEncodingException e) 
             {
                 Logger.e(TAG + methodName, e.getMessage(), "", ADALError.ENCODING_IS_NOT_SUPPORTED, e);
-                throw new AuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED, "The verifying BrokerRedirectUri "
+                throw new DeveloperAuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED, "The verifying BrokerRedirectUri "
                         + "process failed because the base64 url encoding is not supported.", e);
             }
         }
@@ -1280,11 +1280,15 @@ public class AuthenticationContext {
             //check if the redirectUri is valid
             try
             {
+            	//the broker redirectUri will be checked only if 
+            	//the request from client App is not silent
+            	//otherwise the acquiretokensilent might be interrupted 
+            	//by DeveloperAuthenticationException
                 if(!request.isSilent()){
                     verifyBrokerRedirectUri(request);
                 }
             }
-            catch(AuthenticationException exception)
+            catch(DeveloperAuthenticationException exception)
             {
                 Logger.v(TAG + methodName, "Did not pass the verification of the broker redirect URI");
                 callbackHandle.onError(exception);

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1202,10 +1202,10 @@ public class AuthenticationContext {
      * redirectUri format %PREFIX://%PACKAGE_NAME/%SIGNATURE
      * 
      * @param request
-     * @throws DeveloperAuthenticationException
+     * @throws UsageAuthenticationException
      * @return true if the redirectUri is valid or fail and throw the AuthenticationException
      */
-    private boolean verifyBrokerRedirectUri(final AuthenticationRequest request) throws DeveloperAuthenticationException {   
+    private boolean verifyBrokerRedirectUri(final AuthenticationRequest request) throws UsageAuthenticationException {   
         final String methodName = ":verifyBrokerRedirectUri";
         final String inputUri = request.getRedirectUri();
         final String actualUri = getRedirectUriForBroker();
@@ -1215,13 +1215,13 @@ public class AuthenticationContext {
             errMsg = "The redirectUri is null or blank. "
                     + "so the redirect uri is expected to be:" + actualUri;
             Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID); 
-            throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+            throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
         } else if(!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://")) {
             errMsg = "The prefix of the redirect uri does not match the expected value. "
                     + " The valid broker redirect URI prefix: " + AuthenticationConstants.Broker.REDIRECT_PREFIX
                     + " so the redirect uri is expected to be: " + actualUri;
             Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);
-            throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+            throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
         } else {
             try {
                 PackageHelper packageHelper = new PackageHelper(mContext);
@@ -1232,17 +1232,17 @@ public class AuthenticationContext {
                             + " This apps package name is: " + base64URLEncodePackagename
                             + " so the redirect uri is expected to be: " + actualUri;
                     Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);     
-                    throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+                    throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
                 } else if(!inputUri.equalsIgnoreCase(actualUri)) {
                     errMsg = "The base64 url encoded signature component of the redirect uri does not match the expected value. "
                             + " This apps signature is: " + base64URLEncodeSignature
                             + " so the redirect uri is expected to be: " + actualUri;
                     Logger.e(TAG + methodName, errMsg , "", ADALError.DEVELOPER_REDIRECTURI_INVALID);     
-                    throw new DeveloperAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
+                    throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, errMsg);
                 }
             } catch (UnsupportedEncodingException e) {
                 Logger.e(TAG + methodName, e.getMessage(), "", ADALError.ENCODING_IS_NOT_SUPPORTED, e);
-                throw new DeveloperAuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED, "The verifying BrokerRedirectUri "
+                throw new UsageAuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED, "The verifying BrokerRedirectUri "
                         + "process failed because the base64 url encoding is not supported.", e);
             }
         }
@@ -1275,7 +1275,7 @@ public class AuthenticationContext {
                 if(!request.isSilent()) {
                     verifyBrokerRedirectUri(request);
                 }
-            } catch(DeveloperAuthenticationException exception) {
+            } catch(UsageAuthenticationException exception) {
                 Logger.v(TAG + methodName, "Did not pass the verification of the broker redirect URI");
                 callbackHandle.onError(exception);
                 return result;

--- a/src/src/com/microsoft/aad/adal/DeveloperAuthenticationException.java
+++ b/src/src/com/microsoft/aad/adal/DeveloperAuthenticationException.java
@@ -1,0 +1,55 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+package com.microsoft.aad.adal;
+
+/**
+ * Developer authentication error.
+ */
+public class DeveloperAuthenticationException extends AuthenticationException {
+    static final long serialVersionUID = 1;
+
+    /**
+     * Constructs a new AuthenticationCancelError.
+     */
+    public DeveloperAuthenticationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new AuthenticationCancelError with message.
+     * 
+     * @param msg Message for cancel request
+     */
+    public DeveloperAuthenticationException(ADALError code, String msg) {
+        super(code, msg);
+    }
+    
+    /**
+     * Constructs a new AuthenticationCancelError with message and the cause exception
+     * 
+     * @param code Resource file related error code. Message will be derived
+     *            from resource with using app context
+     * @param details Details related to the error such as query string, request
+     *            info
+     * @param throwable {@link Throwable}
+     */
+    public DeveloperAuthenticationException(ADALError code, String msg, Throwable throwable) {
+        super(code, msg, throwable);
+    }
+}

--- a/src/src/com/microsoft/aad/adal/UsageAuthenticationException.java
+++ b/src/src/com/microsoft/aad/adal/UsageAuthenticationException.java
@@ -19,15 +19,15 @@
 package com.microsoft.aad.adal;
 
 /**
- * Developer authentication error.
+ * usage authentication error.
  */
-public class DeveloperAuthenticationException extends AuthenticationException {
+public class UsageAuthenticationException extends AuthenticationException {
     static final long serialVersionUID = 1;
 
     /**
      * Constructs a new AuthenticationCancelError.
      */
-    public DeveloperAuthenticationException() {
+    public UsageAuthenticationException() {
         super();
     }
 
@@ -36,7 +36,7 @@ public class DeveloperAuthenticationException extends AuthenticationException {
      * 
      * @param msg Message for cancel request
      */
-    public DeveloperAuthenticationException(ADALError code, String msg) {
+    public UsageAuthenticationException(ADALError code, String msg) {
         super(code, msg);
     }
     
@@ -49,7 +49,7 @@ public class DeveloperAuthenticationException extends AuthenticationException {
      *            info
      * @param throwable {@link Throwable}
      */
-    public DeveloperAuthenticationException(ADALError code, String msg, Throwable throwable) {
+    public UsageAuthenticationException(ADALError code, String msg, Throwable throwable) {
         super(code, msg, throwable);
     }
 }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -53,6 +53,7 @@ import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.CacheKey;
 import com.microsoft.aad.adal.DefaultTokenCacheStore;
+import com.microsoft.aad.adal.DeveloperAuthenticationException;
 import com.microsoft.aad.adal.HttpWebResponse;
 import com.microsoft.aad.adal.IConnectionService;
 import com.microsoft.aad.adal.IDiscovery;
@@ -1942,9 +1943,9 @@ public class AuthenticationContextTest extends AndroidTestCase {
         }
         catch(InvocationTargetException e)
         {
-            assertTrue(e.getCause() instanceof AuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((AuthenticationException)e.getCause()).getCode());
-            assertTrue(((AuthenticationException)e.getCause()).getMessage().toString().contains("prefix"));
+            assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
+            assertTrue((e.getCause()).getMessage().toString().contains("prefix"));
         }
     }
 
@@ -1967,9 +1968,9 @@ public class AuthenticationContextTest extends AndroidTestCase {
         }
         catch(InvocationTargetException e)
         {
-            assertTrue(e.getCause() instanceof AuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((AuthenticationException)e.getCause()).getCode());
-            assertTrue(((AuthenticationException)e.getCause()).getMessage().toString().contains("package name"));
+            assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
+            assertTrue((e.getCause()).getMessage().toString().contains("package name"));
         }
     }
 
@@ -1992,9 +1993,9 @@ public class AuthenticationContextTest extends AndroidTestCase {
         }
         catch(InvocationTargetException e)
         {
-            assertTrue(e.getCause() instanceof AuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((AuthenticationException)e.getCause()).getCode());
-            assertTrue(((AuthenticationException)e.getCause()).getMessage().toString().contains("signature"));
+            assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
+            assertTrue((e.getCause()).getMessage().toString().contains("signature"));
         }
     }
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -43,7 +43,6 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import android.test.suitebuilder.annotation.Suppress;
 import com.microsoft.aad.adal.ADALError;
 import com.microsoft.aad.adal.AuthenticationActivity;
 import com.microsoft.aad.adal.AuthenticationCallback;
@@ -1985,7 +1984,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         //test@case broker redirect uri with invalid signature
         try
         {
-        String testRedirectUri = "msauth://com.microsoft.aad.adal.testapp/falsesignH070%3D";
+        String testRedirectUri = "msauth://" + getContext().getPackageName() + "/falsesignH070%3D";
         Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                 "resource", "clientid", testRedirectUri, "loginHint");
         m.invoke(authContext, authRequest);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -53,7 +53,6 @@ import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.CacheKey;
 import com.microsoft.aad.adal.DefaultTokenCacheStore;
-import com.microsoft.aad.adal.DeveloperAuthenticationException;
 import com.microsoft.aad.adal.HttpWebResponse;
 import com.microsoft.aad.adal.IConnectionService;
 import com.microsoft.aad.adal.IDiscovery;
@@ -61,6 +60,7 @@ import com.microsoft.aad.adal.ITokenCacheStore;
 import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.TokenCacheItem;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 import com.microsoft.aad.adal.UserInfo;
 
 import android.annotation.SuppressLint;
@@ -1944,8 +1944,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
             m.invoke(authContext, authRequest);
             Assert.fail("It is expected to return an exception here.");
         } catch(InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
+            assertTrue(e.getCause() instanceof UsageAuthenticationException);
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((UsageAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("prefix"));
         }
     }
@@ -1968,8 +1968,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
              m.invoke(authContext, authRequest);
              Assert.fail("It is expected to return an exception here.");
         } catch(InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
+            assertTrue(e.getCause() instanceof UsageAuthenticationException);
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((UsageAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("package name"));
         }
     }
@@ -1992,8 +1992,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
         m.invoke(authContext, authRequest);
         Assert.fail("It is expected to return an exception here.");
         } catch(InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
-            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
+            assertTrue(e.getCause() instanceof UsageAuthenticationException);
+            assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((UsageAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("signature"));
         }
     }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -1909,7 +1909,9 @@ public class AuthenticationContextTest extends AndroidTestCase {
     }
     
     @SmallTest
-    public void testVerifyBrokerRedirectUri_valid() throws NoSuchAlgorithmException, NoSuchPaddingException, IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException{
+    public void testVerifyBrokerRedirectUri_valid() throws NoSuchAlgorithmException, NoSuchPaddingException, 
+           IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, 
+           IllegalAccessException, InvocationTargetException {
         ITokenCacheStore cache = mock(ITokenCacheStore.class);
         final AuthenticationContext authContext = new AuthenticationContext(getContext(),
                 VALID_AUTHORITY, false, cache);
@@ -1919,13 +1921,15 @@ public class AuthenticationContextTest extends AndroidTestCase {
         //test@case valid redirect uri
         String testRedirectUri = authContext.getRedirectUriForBroker();
         Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
-                "resource", "clientid", testRedirectUri, "loginHint");
+            "resource", "clientid", testRedirectUri, "loginHint");
         Boolean testResult = (Boolean)m.invoke(authContext, authRequest);
         assertTrue(testResult);
     }
 
     @SmallTest
-    public void testVerifyBrokerRedirectUri_invalidPrefix() throws NoSuchAlgorithmException, NoSuchPaddingException, IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException{
+    public void testVerifyBrokerRedirectUri_invalidPrefix() throws NoSuchAlgorithmException, NoSuchPaddingException, 
+           IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, 
+           IllegalAccessException, InvocationTargetException {
         ITokenCacheStore cache = mock(ITokenCacheStore.class);
         final AuthenticationContext authContext = new AuthenticationContext(getContext(),
                 VALID_AUTHORITY, false, cache);
@@ -1933,16 +1937,13 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
         //test@case broker redirect uri with invalid prefix
-        try
-        {
+        try {
             String testRedirectUri = "http://helloApp";
             Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                     "resource", "clientid", testRedirectUri, "loginHint");
             m.invoke(authContext, authRequest);
             Assert.fail("It is expected to return an exception here.");
-        }
-        catch(InvocationTargetException e)
-        {
+        } catch(InvocationTargetException e) {
             assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
             assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("prefix"));
@@ -1950,7 +1951,9 @@ public class AuthenticationContextTest extends AndroidTestCase {
     }
 
     @SmallTest
-    public void testVerifyBrokerRedirectUri_invalidPackageName() throws NoSuchAlgorithmException, NoSuchPaddingException, IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException{
+    public void testVerifyBrokerRedirectUri_invalidPackageName() throws NoSuchAlgorithmException, NoSuchPaddingException, 
+           IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, 
+           IllegalAccessException, InvocationTargetException {
         ITokenCacheStore cache = mock(ITokenCacheStore.class);
         final AuthenticationContext authContext = new AuthenticationContext(getContext(),
                 VALID_AUTHORITY, false, cache);
@@ -1958,16 +1961,13 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
         //test@case broker redirect uri with invalid packageName
-        try
-        {
+        try {
              String testRedirectUri = "msauth://testapp/gwdiktUBDmQq%2BfbWiJoa%2B%2FYH070%3D";
              Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                      "resource", "clientid", testRedirectUri, "loginHint");
              m.invoke(authContext, authRequest);
              Assert.fail("It is expected to return an exception here.");
-        }
-        catch(InvocationTargetException e)
-        {
+        } catch(InvocationTargetException e) {
             assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
             assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("package name"));
@@ -1975,7 +1975,9 @@ public class AuthenticationContextTest extends AndroidTestCase {
     }
 
     @SmallTest
-    public void testVerifyBrokerRedirectUri_invalidSignature() throws NoSuchAlgorithmException, NoSuchPaddingException, IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException{
+    public void testVerifyBrokerRedirectUri_invalidSignature() throws NoSuchAlgorithmException, NoSuchPaddingException, 
+           IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, 
+        IllegalAccessException, InvocationTargetException {
         ITokenCacheStore cache = mock(ITokenCacheStore.class);
         final AuthenticationContext authContext = new AuthenticationContext(getContext(),
                 VALID_AUTHORITY, false, cache);
@@ -1983,16 +1985,13 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
         //test@case broker redirect uri with invalid signature
-        try
-        {
+        try {
         String testRedirectUri = "msauth://" + getContext().getPackageName() + "/falsesignH070%3D";
         Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                 "resource", "clientid", testRedirectUri, "loginHint");
         m.invoke(authContext, authRequest);
         Assert.fail("It is expected to return an exception here.");
-        }
-        catch(InvocationTargetException e)
-        {
+        } catch(InvocationTargetException e) {
             assertTrue(e.getCause() instanceof DeveloperAuthenticationException);
             assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((DeveloperAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("signature"));


### PR DESCRIPTION
The broker redirectUri will be checked only if the request from client App is not silent. Otherwise the acquiretokensilent() might be interrupted by DeveloperAuthenticationException (I know it is a confusing exception name, any suggestion?)

- add the condition to go to the verifyBrokerRedirectUri()
- modify one unit test