### PR TITLE
fix NPE within startActivityForResult

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -534,12 +534,20 @@ public class AuthenticationContext {
     }
 
     private IWindowComponent wrapActivity(final Activity activity) {
+        if (activity == null) {
+            throw new IllegalArgumentException("activity");
+        }
+
         return new IWindowComponent() {
             Activity refActivity = activity;
 
             @Override
             public void startActivityForResult(Intent intent, int requestCode) {
-                refActivity.startActivityForResult(intent, requestCode);
+                // if user closed an app or switched to another activity
+                // refActivity can die before this method got invoked
+                if(refActivity != null) {
+                    refActivity.startActivityForResult(intent, requestCode);
+                }
             }
         };
     }


### PR DESCRIPTION
stack trace:
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.Activity.startActivityForResult(android.content.Intent, int)' on a null object reference
    at com.microsoft.aad.adal.AuthenticationContext$2.startActivityForResult(AuthenticationContext.java:535)
    at com.microsoft.aad.adal.AuthenticationContext.startAuthenticationActivity(AuthenticationContext.java:1855)
    at com.microsoft.aad.adal.AuthenticationContext.localFlow(AuthenticationContext.java:1444)
    at com.microsoft.aad.adal.AuthenticationContext.acquireTokenAfterValidation(AuthenticationContext.java:1378)
    at com.microsoft.aad.adal.AuthenticationContext.acquireTokenLocalCall(AuthenticationContext.java:1191)
    at com.microsoft.aad.adal.AuthenticationContext.access$600(AuthenticationContext.java:62)
    at com.microsoft.aad.adal.AuthenticationContext$6.run(AuthenticationContext.java:1148)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
    at java.lang.Thread.run(Thread.java:818)