### PR TITLE
use real Spec.Builder instead of reflective methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ android:
     - build-tools-21.1.1
 env:
     matrix:
-      - ANDROID_SDKS=android-21 ANDROID_TARGET=android-21
+      - ANDROID_SDKS=android-23 ANDROID_TARGET=android-23
 
 before_install:
   # setup maven android sdk deployer
   - git clone git://github.com/mosabua/maven-android-sdk-deployer.git
-  - cd $PWD/maven-android-sdk-deployer/platforms/android-21
+  - cd $PWD/maven-android-sdk-deployer/platforms/android-23
   - mvn clean install
   - cd -
   - cd $PWD/maven-android-sdk-deployer/extras/compatibility-v4
@@ -18,8 +18,8 @@ before_install:
   - cd -
 
   # setup main and testproject
-  - android update lib-project -p src --target android-21
-  - android update project -p tests/testapp --target android-21
+  - android update lib-project -p src --target android-23
+  - android update project -p tests/testapp --target android-23
   - android update test-project -p tests/testapp -m tests
 
 before_script:
@@ -30,7 +30,7 @@ before_script:
   - sleep 5 # wait xvfb to start
   - xdpyinfo -display :99 >/dev/null 2>&1 && echo "In use" || echo "Free"
   # create and start emulator
-  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-23 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio &   
   # wait for emulator to start
   - chmod +x wait_for_emulator.sh

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
     <scm.branch>master</scm.branch>
     <maven.version>3.1.1</maven.version>
     <adal.version>1.1.14</adal.version>
-    <android.platform.maven.plugin>21</android.platform.maven.plugin>
+    <android.platform.maven.plugin>23</android.platform.maven.plugin>
     <android.version>[4.1.1.4,)</android.version>
-    <android.support.version>[21,)</android.support.version>
+    <android.support.version>[23,)</android.support.version>
     <android.support.name>support-v4</android.support.name>
     <gson.name>gson</gson.name>
     <gson.version>2.3.1</gson.version>

--- a/samples/hello/pom.xml
+++ b/samples/hello/pom.xml
@@ -14,7 +14,7 @@
   <packaging>apk</packaging>
   <name>Hello App for Demo</name>
   <properties>
-    <android.support.version>[21,)</android.support.version>
+    <android.support.version>[23,)</android.support.version>
   </properties>
   <dependencies>
     <dependency>

--- a/samples/hello/project.properties
+++ b/samples/hello/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-21
+target=android-23
 android.library.reference.1=../../src

--- a/src/AndroidManifest.xml
+++ b/src/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="21" />
+        android:targetSdkVersion="23" />
 
     <application
         android:allowBackup="true">

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -11,9 +11,9 @@
     <scm.branch>master</scm.branch>
     <maven.version>3.1.1</maven.version>
     <adal.version>1.1.14</adal.version>
-    <android.platform.maven.plugin>21</android.platform.maven.plugin>
+    <android.platform.maven.plugin>23</android.platform.maven.plugin>
     <android.version>[4.1.1.4,)</android.version>
-    <android.support.version>[21,)</android.support.version>
+    <android.support.version>[23,)</android.support.version>
     <android.support.name>support-v4</android.support.name>
     <gson.name>gson</gson.name>
     <gson.version>2.3.1</gson.version>
@@ -167,7 +167,7 @@
           <resourceDirectory>${project.basedir}/res</resourceDirectory>
           <nativeLibrariesDirectory>${project.basedir}/src/main/native</nativeLibrariesDirectory>
           <sdk>
-            <platform>21</platform>
+            <platform>23</platform>
           </sdk>
           <dexCoreLibrary>true</dexCoreLibrary>
           <deleteConflictingFiles>true</deleteConflictingFiles>

--- a/src/project.properties
+++ b/src/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-21
+target=android-23
 android.library=true

--- a/tests/Functional/project.properties
+++ b/tests/Functional/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-21
+target=android-23
 android.library.reference.1=../../src


### PR DESCRIPTION
KeyPairGeneratorSpec was deprecated since API 23,
and we were getting javax.crypto.BadPaddingException: error:0407109F:rsa routines:RSA_padding_check_PKCS1_type_2:pkcs decoding error 
on android M devices because our encryption type requires this flag 
setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)