### PR TITLE
Cleanup around StorageHelper and its tests

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -105,7 +105,7 @@ public class AuthenticationActivity extends Activity {
     private String mQueryParameters;
 
     private boolean mPkeyAuthRedirect = false;
-    private StorageHelper mHelper;
+    private StorageHelper mStorageHelper;
 
     // Broadcast receiver is needed to cancel outstanding AuthenticationActivity
     // for this AuthenticationContext since each instance of context can have
@@ -269,6 +269,7 @@ public class AuthenticationActivity extends Activity {
                 " device:" + android.os.Build.VERSION.RELEASE + " " + android.os.Build.MANUFACTURER
                         + android.os.Build.MODEL);
 
+        mStorageHelper = new StorageHelper(getApplicationContext());
         setupWebView(mRedirectUrl, mQueryParameters, mAuthRequest);
         
         if (savedInstanceState == null) {
@@ -283,8 +284,6 @@ public class AuthenticationActivity extends Activity {
         } else {
             Logger.v(TAG, "Reuse webview");
         }
-
-        mHelper = new StorageHelper(getApplicationContext());
     }
 
     private boolean isCallerBrokerInstaller() {
@@ -847,7 +846,7 @@ public class AuthenticationActivity extends Activity {
                 appIdList = "";
             } else {
                 try {
-                    appIdList = mHelper.decrypt(appIdList);
+                    appIdList = mStorageHelper.decrypt(appIdList);
                 } catch (GeneralSecurityException | IOException ex) {
                     Logger.e(TAG, "appUIDList failed to decrypt", "appIdList:" + appIdList,
                             ADALError.ENCRYPTION_FAILED, ex);
@@ -860,7 +859,7 @@ public class AuthenticationActivity extends Activity {
             if (!appIdList.contains(AuthenticationConstants.Broker.USERDATA_UID_KEY
                     + mAppCallingUID)) {
                 Logger.i(TAG, "Account has new calling UID:" + mAppCallingUID, "");
-                String encryptedValue = mHelper.encrypt(appIdList
+                String encryptedValue = mStorageHelper.encrypt(appIdList
                         + AuthenticationConstants.Broker.USERDATA_UID_KEY
                         + mAppCallingUID);
                 mAccountManager
@@ -937,7 +936,7 @@ public class AuthenticationActivity extends Activity {
 
             TokenCacheItem item = new TokenCacheItem(mRequest, result.taskResult, false);
             String json = gson.toJson(item);
-            String encrypted = mHelper.encrypt(json);
+            String encrypted = mStorageHelper.encrypt(json);
 
             // Single user and cache is stored per account
             String key = CacheKey.createCacheKey(mRequest, null);
@@ -951,7 +950,7 @@ public class AuthenticationActivity extends Activity {
                 // ADAL stores MRRT refresh token separately
                 TokenCacheItem itemMRRT = new TokenCacheItem(mRequest, result.taskResult, true);
                 json = gson.toJson(itemMRRT);
-                encrypted = mHelper.encrypt(json);
+                encrypted = mStorageHelper.encrypt(json);
                 key = CacheKey.createMultiResourceRefreshTokenKey(mRequest, null);
                 saveCacheKey(key, newaccount, mAppCallingUID);
                 mAccountManager.setUserData(

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -105,6 +105,7 @@ public class AuthenticationActivity extends Activity {
     private String mQueryParameters;
 
     private boolean mPkeyAuthRedirect = false;
+    private StorageHelper mHelper;
 
     // Broadcast receiver is needed to cancel outstanding AuthenticationActivity
     // for this AuthenticationContext since each instance of context can have
@@ -282,6 +283,8 @@ public class AuthenticationActivity extends Activity {
         } else {
             Logger.v(TAG, "Reuse webview");
         }
+
+        mHelper = new StorageHelper(getApplicationContext());
     }
 
     private boolean isCallerBrokerInstaller() {
@@ -814,7 +817,7 @@ public class AuthenticationActivity extends Activity {
                 // Record account in the AccountManager service
                 try {
                     setAccount(result);
-                } catch (GeneralSecurityException | UnsupportedEncodingException exc) {
+                } catch (GeneralSecurityException | IOException exc) {
                     Logger.e(TAG, "Error in setting the account" + mRequest.getLogInfo(), "",
                             ADALError.BROKER_ACCOUNT_SAVE_FAILED, exc);
                     result.taskException = exc;
@@ -824,7 +827,7 @@ public class AuthenticationActivity extends Activity {
             return result;
         }
 
-        private String getBrokerAppCacheKey(StorageHelper cryptoHelper, String cacheKey)
+        private String getBrokerAppCacheKey(String cacheKey)
             throws NoSuchAlgorithmException, UnsupportedEncodingException {
             // include UID in the key for broker to store caches for different
             // apps under same account entry
@@ -836,15 +839,15 @@ public class AuthenticationActivity extends Activity {
             return digestKey;
         }
 
-        private void appendAppUIDToAccount(StorageHelper cryptoHelper, Account account)
-            throws GeneralSecurityException, UnsupportedEncodingException {
+        private void appendAppUIDToAccount(Account account)
+            throws GeneralSecurityException, IOException {
             String appIdList = mAccountManager.getUserData(account,
                     AuthenticationConstants.Broker.ACCOUNT_UID_CACHES);
             if (appIdList == null) {
                 appIdList = "";
             } else {
                 try {
-                    appIdList = cryptoHelper.decrypt(appIdList);
+                    appIdList = mHelper.decrypt(appIdList);
                 } catch (GeneralSecurityException | IOException ex) {
                     Logger.e(TAG, "appUIDList failed to decrypt", "appIdList:" + appIdList,
                             ADALError.ENCRYPTION_FAILED, ex);
@@ -857,18 +860,19 @@ public class AuthenticationActivity extends Activity {
             if (!appIdList.contains(AuthenticationConstants.Broker.USERDATA_UID_KEY
                     + mAppCallingUID)) {
                 Logger.i(TAG, "Account has new calling UID:" + mAppCallingUID, "");
+                String encryptedValue = mHelper.encrypt(appIdList
+                        + AuthenticationConstants.Broker.USERDATA_UID_KEY
+                        + mAppCallingUID);
                 mAccountManager
                         .setUserData(
-                                account,
-                                AuthenticationConstants.Broker.ACCOUNT_UID_CACHES,
-                                cryptoHelper.encrypt(appIdList
-                                        + AuthenticationConstants.Broker.USERDATA_UID_KEY
-                                        + mAppCallingUID));
+                        account,
+                        AuthenticationConstants.Broker.ACCOUNT_UID_CACHES,
+                        encryptedValue);
             }
         }
 
         private void setAccount(final TokenTaskResult result)
-                throws GeneralSecurityException, UnsupportedEncodingException {
+                throws GeneralSecurityException, IOException {
             // TODO Add token logging
             // TODO update for new cache logic
 
@@ -927,38 +931,40 @@ public class AuthenticationActivity extends Activity {
             Logger.i(TAG, "app context:" + getApplicationContext().getPackageName()
                     + " context:" + AuthenticationActivity.this.getPackageName()
                     + " calling packagename:" + getCallingPackage(), "");
-            StorageHelper cryptoHelper = new StorageHelper(getApplicationContext());
-
             if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
                 Logger.i(TAG, "setAccount: user key is null", "");
             }
 
             TokenCacheItem item = new TokenCacheItem(mRequest, result.taskResult, false);
             String json = gson.toJson(item);
-            String encrypted = cryptoHelper.encrypt(json);
+            String encrypted = mHelper.encrypt(json);
 
             // Single user and cache is stored per account
             String key = CacheKey.createCacheKey(mRequest, null);
             saveCacheKey(key, newaccount, mAppCallingUID);
-            mAccountManager.setUserData(newaccount, getBrokerAppCacheKey(cryptoHelper, key),
+            mAccountManager.setUserData(
+                    newaccount,
+                    getBrokerAppCacheKey(key),
                     encrypted);
 
             if (result.taskResult.getIsMultiResourceRefreshToken()) {
                 // ADAL stores MRRT refresh token separately
                 TokenCacheItem itemMRRT = new TokenCacheItem(mRequest, result.taskResult, true);
                 json = gson.toJson(itemMRRT);
-                encrypted = cryptoHelper.encrypt(json);
+                encrypted = mHelper.encrypt(json);
                 key = CacheKey.createMultiResourceRefreshTokenKey(mRequest, null);
                 saveCacheKey(key, newaccount, mAppCallingUID);
-                mAccountManager.setUserData(newaccount,
-                        getBrokerAppCacheKey(cryptoHelper, key), encrypted);
+                mAccountManager.setUserData(
+                        newaccount,
+                        getBrokerAppCacheKey(key),
+                        encrypted);
             }
 
             // Record calling UID for this account so that app can get token
             // in the background call without requiring server side
             // validation
             Logger.i(TAG, "Set calling uid:" + mAppCallingUID, "");
-            appendAppUIDToAccount(cryptoHelper, newaccount);
+            appendAppUIDToAccount(newaccount);
         }
 
         private void saveCacheKey(String key, Account cacheAccount, int callingUID) {

--- a/src/src/com/microsoft/aad/adal/AuthenticationSettings.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationSettings.java
@@ -18,6 +18,8 @@
 
 package com.microsoft.aad.adal;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Settings to be used in AuthenticationContext.
  */
@@ -29,7 +31,7 @@ public enum AuthenticationSettings {
 
     private static final int SECRET_RAW_KEY_LENGTH = 32;
 
-    private byte[] mSecretKeyData = null;
+    private AtomicReference<byte[]> mSecretKeyData = new AtomicReference<>();
 
     private String mBrokerPackageName = AuthenticationConstants.Broker.PACKAGE_NAME;
 
@@ -66,7 +68,7 @@ public enum AuthenticationSettings {
      * @return byte[] secret data
      */
     public byte[] getSecretKeyData() {
-        return mSecretKeyData;
+        return mSecretKeyData.get();
     }
 
     /**
@@ -80,7 +82,7 @@ public enum AuthenticationSettings {
             throw new IllegalArgumentException("rawKey");
         }
 
-        mSecretKeyData = rawKey;
+        mSecretKeyData.set(rawKey);
     }
 
     /**

--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -60,7 +60,6 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     .registerTypeAdapter(Date.class, new DateTimeAdapter())
     .create();
     private static StorageHelper sHelper;
-    private static Object sLock = new Object();
     /**
      * @param context {@link Context}
      * @throws NoSuchAlgorithmException
@@ -103,13 +102,11 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
      * Method that allows to mock StorageHelper class and use custom encryption in UTs
      * @return
      */
-    protected StorageHelper getStorageHelper() {
-        synchronized (sLock) {
-            if (sHelper == null) {
-                Logger.v(TAG, "Started to initialize storage helper");
-                sHelper = new StorageHelper(mContext);
-                Logger.v(TAG, "Finished to initialize storage helper");
-            }
+    protected synchronized StorageHelper getStorageHelper() {
+        if (sHelper == null) {
+            Logger.v(TAG, "Started to initialize storage helper");
+            sHelper = new StorageHelper(mContext);
+            Logger.v(TAG, "Finished to initialize storage helper");
         }
         return sHelper;
     }

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -43,6 +43,7 @@ import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
@@ -55,6 +56,7 @@ import javax.security.auth.x500.X500Principal;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.security.KeyPairGeneratorSpec;
 import android.util.Base64;
 
 /**
@@ -132,40 +134,45 @@ public class StorageHelper {
     /**
      * Get Secret Key based on API level to use in encryption. Decryption key
      * depends on version# since user can migrate to new Android.OS
-     * 
+     *
      * @return
      * @throws NoSuchAlgorithmException
      */
-    final private void loadSecretKeyForAPI() throws NoSuchAlgorithmException {
+    public synchronized SecretKey loadSecretKeyForAPI() throws IOException, GeneralSecurityException {
         // Loading key only once for performance. If API is upgraded, it will
-        // restart the device anyway. It will load the correct key for new API. 
+        // restart the device anyway. It will load the correct key for new API.
         if (mKey != null && mMacKey != null)
-            return;
+            return mKey;
 
-        synchronized (LOCK_OBJ) {
-            if (Build.VERSION.SDK_INT >= 18
-                    && AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
-                try {
-                    // androidKeyStore can store app specific self signed cert.
-                    // Asymmetric cryptography is used to protect the session
-                    // key for Encryption and HMac.
-                    // If user specifies secret key, it will use the provided
-                    // key.
-                    mKey = getSecretKeyFromAndroidKeyStore();
-                    mMacKey = getMacKey(mKey);
-                    mBlobVersion = VERSION_ANDROID_KEY_STORE;
-                    return;
-                } catch (IOException | GeneralSecurityException e) {
-                    Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
-                            ADALError.ANDROIDKEYSTORE_FAILED, e);
-                }
-            }
+        final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
+        if(secretKeyData == null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            throw new IllegalStateException("Secret key must be provided for API < 18. " +
+                    "Use AuthenticationSettings.INSTANCE.setSecretKey()");
+        }
 
+        if (secretKeyData != null) {
             Logger.v(TAG, "Encryption will use secret key from Settings");
-            mKey = getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
+            mKey = getSecretKey(secretKeyData);
             mMacKey = getMacKey(mKey);
             mBlobVersion = VERSION_USER_DEFINED;
+        } else {
+            try {
+                // androidKeyStore can store app specific self signed cert.
+                // Asymmetric cryptography is used to protect the session
+                // key for Encryption and HMac.
+                // If user specifies secret key, it will use the provided
+                // key.
+                mKey = getSecretKeyFromAndroidKeyStore();
+                mMacKey = getMacKey(mKey);
+                mBlobVersion = VERSION_ANDROID_KEY_STORE;
+            } catch (IOException | GeneralSecurityException e) {
+                Logger.e(TAG, "Failed to get private key from AndroidKeyStore", "",
+                        ADALError.ANDROIDKEYSTORE_FAILED, e);
+                throw e;
+            }
         }
+
+        return mKey;
     }
 
     /**
@@ -201,7 +208,7 @@ public class StorageHelper {
             }
         }
 
-        throw new IllegalArgumentException("keyVersion");
+        throw new IllegalArgumentException("keyVersion = " + keyVersion);
     }
 
     private SecretKey getSecretKey(byte[] rawBytes) {
@@ -307,7 +314,7 @@ public class StorageHelper {
      * @throws UnsupportedEncodingException
      */
     public String encrypt(String clearText)
-            throws GeneralSecurityException, UnsupportedEncodingException {
+            throws GeneralSecurityException, IOException {
 
         Logger.v(TAG, "Starting encryption");
 
@@ -383,7 +390,6 @@ public class StorageHelper {
      * 
      * @return
      * @throws NoSuchAlgorithmException
-     * @throws InvalidKeySpecException
      */
     final private SecretKey generateSecretKey() throws NoSuchAlgorithmException {
         KeyGenerator keygen = KeyGenerator.getInstance(KEYSPEC_ALGORITHM);
@@ -399,7 +405,7 @@ public class StorageHelper {
      * @throws IOException
      * @throws GeneralSecurityException
      */
-    @TargetApi(18)
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     final synchronized private SecretKey getSecretKeyFromAndroidKeyStore() throws IOException,
             GeneralSecurityException {
 
@@ -466,7 +472,7 @@ public class StorageHelper {
      * @throws GeneralSecurityException
      * @throws IOException
      */
-    @TargetApi(18)
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private synchronized KeyPair getKeyPairFromAndroidKeyStore() throws GeneralSecurityException, IOException {
         KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
         keyStore.load(null);
@@ -478,15 +484,11 @@ public class StorageHelper {
 
             // self signed cert stored in AndroidKeyStore to asym. encrypt key
             // to a file
-            String certInfo = String.format("CN=%s, OU=%s", KEY_STORE_CERT_ALIAS,
-                    mContext.getPackageName());
-            final AlgorithmParameterSpec spec = (AlgorithmParameterSpec)getKeyPairGeneratorSpec(
-                    new X500Principal(certInfo), start.getTime(), end.getTime());
             final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA",
                     "AndroidKeyStore");
-            generator.initialize(spec);
+            generator.initialize(getKeyPairGeneratorSpec(mContext, start.getTime(), end.getTime()));
             generator.generateKeyPair();
-            Logger.v(TAG, "Key entry is generated for cert " + certInfo);
+            Logger.v(TAG, "Key entry is generated");
         } else {
             Logger.v(TAG, "Key entry is available");
         }
@@ -507,56 +509,22 @@ public class StorageHelper {
             throw new KeyStoreException(e);
         }
     }
-    
-    @TargetApi(18)
-    private Object getKeyPairGeneratorSpec(X500Principal subj, Date start, Date end) {
-        // TODO: use real Spec.Builder instead of reflective methods
-        Class<?> clazz;
-        try {
-            clazz = Class.forName("android.security.KeyPairGeneratorSpec$Builder");
 
-            Constructor<?> constructor = clazz.getDeclaredConstructor(Context.class);
-            constructor.setAccessible(true);
-            Object builder = constructor.newInstance(mContext);
-            Method setAlias = clazz.getDeclaredMethod("setAlias", String.class);
-            Method setSubject = clazz.getDeclaredMethod("setSubject", X500Principal.class);
-            Method setSerialNumber = clazz.getDeclaredMethod("setSerialNumber", BigInteger.class);
-            Method setStartDate = clazz.getDeclaredMethod("setStartDate", Date.class);
-            Method setEndDate = clazz.getDeclaredMethod("setEndDate", Date.class);
-            Method build = clazz.getDeclaredMethod("build");
-            builder = setAlias.invoke(builder, KEY_STORE_CERT_ALIAS);
-            builder = setSubject.invoke(builder, subj);
-            builder = setSerialNumber.invoke(builder, BigInteger.ONE);
-            builder = setStartDate.invoke(builder, start);
-            builder = setEndDate.invoke(builder, end);
-            return build.invoke(builder);
-        } catch (ClassNotFoundException e) {
-            Logger.e(TAG, "android.security.KeyPairGeneratorSpec.Builder is not found", "",
-                    ADALError.ANDROIDKEYSTORE_KEYPAIR_GENERATOR_FAILED, e);
-        } catch (IllegalArgumentException e) {
-            Logger.e(TAG, "android.security.KeyPairGeneratorSpec.Builder argument is not valid",
-                    "", ADALError.ANDROIDKEYSTORE_KEYPAIR_GENERATOR_FAILED, e);
-        } catch (InstantiationException e) {
-            Logger.e(TAG, "android.security.KeyPairGeneratorSpec.Builder is not instantiated", "",
-                    ADALError.ANDROIDKEYSTORE_KEYPAIR_GENERATOR_FAILED, e);
-        } catch (IllegalAccessException e) {
-            Logger.e(TAG, "android.security.KeyPairGeneratorSpec.Builder is not accessible", "",
-                    ADALError.ANDROIDKEYSTORE_KEYPAIR_GENERATOR_FAILED, e);
-        } catch (InvocationTargetException e) {
-            Logger.e(TAG, "android.security.KeyPairGeneratorSpec.Builder's method invoke failed",
-                    "", ADALError.ANDROIDKEYSTORE_KEYPAIR_GENERATOR_FAILED, e);
-            if (e.getCause() instanceof RuntimeException) {
-                throw (RuntimeException) e.getCause();
-            }
-        } catch (NoSuchMethodException e) {
-            Logger.e(TAG, "android.security.KeyPairGeneratorSpec.Builder is not found", "",
-                    ADALError.ANDROIDKEYSTORE_KEYPAIR_GENERATOR_FAILED, e);
-        }
-
-        return null;
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+    private AlgorithmParameterSpec getKeyPairGeneratorSpec(Context context, Date start, Date end) {
+        String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s", KEY_STORE_CERT_ALIAS,
+                context.getPackageName());
+        return new KeyPairGeneratorSpec.Builder(context)
+                .setAlias(KEY_STORE_CERT_ALIAS)
+                .setSubject(new X500Principal(certInfo))
+                .setSerialNumber(BigInteger.ONE)
+                .setStartDate(start)
+                .setEndDate(end)
+                .build();
     }
 
-    @TargetApi(18)
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private synchronized void resetKeyPairFromAndroidKeyStore() throws KeyStoreException,
             NoSuchAlgorithmException, CertificateException, IOException {
         KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
@@ -564,13 +532,13 @@ public class StorageHelper {
         keyStore.deleteEntry(KEY_STORE_CERT_ALIAS);
     }
 
-    @TargetApi(18)
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private byte[] wrap(Cipher wrapCipher, SecretKey key) throws GeneralSecurityException {
         wrapCipher.init(Cipher.WRAP_MODE, mKeyPair.getPublic());
         return wrapCipher.wrap(key);
     }
 
-    @TargetApi(18)
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private SecretKey unwrap(Cipher wrapCipher, byte[] keyBlob) throws GeneralSecurityException {
         wrapCipher.init(Cipher.UNWRAP_MODE, mKeyPair.getPrivate());
         return (SecretKey)wrapCipher.unwrap(keyBlob, KEYSPEC_ALGORITHM, Cipher.SECRET_KEY);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AndroidTestHelper.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AndroidTestHelper.java
@@ -82,8 +82,8 @@ public class AndroidTestHelper extends InstrumentationTestCase {
             }
 
             if (hasMessage != null && !hasMessage.isEmpty()) {
-                assertTrue("Message has the text",
-                        (result.getMessage().toLowerCase(Locale.US).contains(hasMessage)));
+                assertTrue("Message has the text " + result.getMessage(),
+                        (result.getMessage().toLowerCase(Locale.US).contains(hasMessage.toLowerCase())));
             }
         }
     }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/StorageHelperTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/StorageHelperTests.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.DigestException;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -46,7 +47,7 @@ import android.util.Log;
 
 import com.microsoft.aad.adal.AuthenticationSettings;
 
-public class StorageHelperTests extends AndroidTestCase {
+public class StorageHelperTests extends AndroidTestHelper {
 
     private static final String TAG = "StorageHelperTests";
 
@@ -66,9 +67,7 @@ public class StorageHelperTests extends AndroidTestCase {
         }
     }
 
-    public void testEncryptDecrypt() throws IllegalArgumentException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException {
+    public void testEncryptDecrypt() throws GeneralSecurityException, IOException {
         String clearText = "SomeValue1234";
         encryptDecrypt(clearText);
     }
@@ -77,33 +76,83 @@ public class StorageHelperTests extends AndroidTestCase {
             ClassNotFoundException, NoSuchMethodException, InstantiationException,
             IllegalAccessException, InvocationTargetException {
 
-        Object storageHelper = getStorageHelper();
-        Method mDecrypt = ReflectionUtils.getTestMethod(storageHelper, "decrypt", String.class);
-        Method mEncrypt = ReflectionUtils.getTestMethod(storageHelper, "encrypt", String.class);
-        assertThrows(mDecrypt, storageHelper, null, "Input is empty or null");
-        assertThrows(mDecrypt, storageHelper, "", "Input is empty or null");
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+        assertThrowsException(
+                IllegalArgumentException.class,
+                "Input is empty or null",
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.encrypt(null);
+                    }
+                });
+        assertThrowsException(
+                IllegalArgumentException.class,
+                "Input is empty or null",
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.encrypt("");
+                    }
+                });
 
-        assertThrows(mEncrypt, storageHelper, null, "Input is empty or null");
-        assertThrows(mEncrypt, storageHelper, "", "Input is empty or null");
+        assertThrowsException(
+                IllegalArgumentException.class,
+                "Input is empty or null",
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.decrypt(null);
+                    }
+                });
+
+        assertThrowsException(
+                IllegalArgumentException.class,
+                "Input is empty or null",
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.decrypt("");
+                    }
+                });
     }
 
-    public void testDecrypt_InvalidInput() throws NoSuchMethodException, ClassNotFoundException,
-            InstantiationException, IllegalAccessException, InvocationTargetException,
-            UnsupportedEncodingException {
-        Object storageHelper = getStorageHelper();
-        Method mDecrypt = ReflectionUtils.getTestMethod(storageHelper, "decrypt", String.class);
-        Method mEncrypt = ReflectionUtils.getTestMethod(storageHelper, "encrypt", String.class);
-        assertThrows(mDecrypt, storageHelper, "E1bad64", "is not valid, it must be greater of equal to 0");
-        assertThrows(mDecrypt, storageHelper, "cE1bad64", "bad base-64");
-        assertThrowsType(
-                mDecrypt,
-                storageHelper,
-                "cE1"
-                        + new String(Base64.encode(
-                                "U001thatShouldFail1234567890123456789012345678901234567890"
-                                        .getBytes("UTF-8"), Base64.NO_WRAP), "UTF-8"),
-                DigestException.class);
+    public void testDecrypt_InvalidInput() throws
+            IOException, GeneralSecurityException {
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+        assertThrowsException(
+                IllegalArgumentException.class,
+                "is not valid, it must be greater of equal to 0",
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.decrypt("E1bad64");
+                    }
+                });
 
+        assertThrowsException(
+                IllegalArgumentException.class,
+                "bad base-64",
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.decrypt("cE1bad64");
+                    }
+                });
+
+        assertThrowsException(
+                DigestException.class,
+                null,
+                new AndroidTestHelper.ThrowableRunnable() {
+                    @Override
+                    public void run() throws GeneralSecurityException, IOException {
+                        storageHelper.decrypt("cE1" + new String(Base64.encode(
+                                "U001thatShouldFail1234567890123456789012345678901234567890"
+                                        .getBytes("UTF-8"), Base64.NO_WRAP), "UTF-8"));
+                    }
+                });
     }
 
     /**
@@ -117,9 +166,7 @@ public class StorageHelperTests extends AndroidTestCase {
      * @throws InvocationTargetException
      * @throws UnsupportedEncodingException
      */
-    public void testEncryptDecrypt_DifferentSizes() throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, UnsupportedEncodingException {
+    public void testEncryptDecrypt_DifferentSizes() throws GeneralSecurityException, IOException {
         Log.d(TAG, "Starting testEncryptDecrypt_differentSizes");
         // try different block sizes
         StringBuilder buf = new StringBuilder(1000);
@@ -129,31 +176,25 @@ public class StorageHelperTests extends AndroidTestCase {
         Log.d(TAG, "Finished testEncryptDecrypt_differentSizes");
     }
 
-    private void encryptDecrypt(String clearText) throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
-        Object storageHelper = getStorageHelper();
-        Method mEncrypt = ReflectionUtils.getTestMethod(storageHelper, "encrypt", String.class);
-        Method mDecrypt = ReflectionUtils.getTestMethod(storageHelper, "decrypt", String.class);
-        String encrypted = (String)mEncrypt.invoke(storageHelper, clearText);
+    private void encryptDecrypt(String clearText) throws GeneralSecurityException, IOException {
+        Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+        String encrypted = storageHelper.encrypt(clearText);
         assertNotNull("encrypted string is not null", encrypted);
         assertFalse("encrypted string is not same as cleartex", encrypted.equals(clearText));
-        String decrypted = (String)mDecrypt.invoke(storageHelper, encrypted);
+        String decrypted = storageHelper.decrypt(encrypted);
         assertEquals("Same as initial text", clearText, decrypted);
     }
 
-    public void testEncryptSameText() throws IllegalArgumentException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException {
+    public void testEncryptSameText() throws GeneralSecurityException, IOException {
         // access code
+        Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
         String clearText = "AAAAAAAA2pILN0mn3wlYIlWk7lqOZ5qjRWXHRnqDdzsq0s4aaUVgnMQo6oXfEUYL4fAxqVQ6dXh9sMAieFDjXVhTkp3mnL2gHSnAHJFwmj9mnlgaU7kVcoujXRA3Je23PEtoqEQMQPaurakVcEl7jOsjUGWD7JdaAHsYTujd1KHoTUdBJQQ-jz4t6Cish25zn9BPocJzN56rLUqgX3dnoA1z-hY4FS_EIn_Xdvqnil29t4etVHLDZD5RJbc5R3p5MaUKqPBF8sAQvJcgW-f9ebPHzO8L87RrsVNu4keagKmOnP139KSuORBhNaD57nmEvecJWtWTIAA&redirect_uri=https%3a%2f%2fworkaad.com%2fdemoclient1&client_id=dba19db4-53de-441d-9c63-da8d6f229e5a";
         Log.d(TAG, "Starting testEncryptSameText");
-        Object storageHelper = getStorageHelper();
-        Method mEncrypt = ReflectionUtils.getTestMethod(storageHelper, "encrypt", String.class);
-        Method mDecrypt = ReflectionUtils.getTestMethod(storageHelper, "decrypt", String.class);
-        String encrypted = (String)mEncrypt.invoke(storageHelper, clearText);
-        String encrypted2 = (String)mEncrypt.invoke(storageHelper, clearText);
-        String encrypted3 = (String)mEncrypt.invoke(storageHelper, clearText);
+        String encrypted = storageHelper.encrypt(clearText);
+        String encrypted2 = storageHelper.encrypt(clearText);
+        String encrypted3 = storageHelper.encrypt(clearText);
 
         assertNotNull("encrypted string is not null", encrypted);
         assertFalse("encrypted string is not same as cleartex", encrypted.equals(clearText));
@@ -162,59 +203,48 @@ public class StorageHelperTests extends AndroidTestCase {
         assertFalse("encrypted string is not same as another encrypted call",
                 encrypted.equals(encrypted3));
 
-        String decrypted = (String)mDecrypt.invoke(storageHelper, encrypted);
-        String decrypted2 = (String)mDecrypt.invoke(storageHelper, encrypted2);
-        String decrypted3 = (String)mDecrypt.invoke(storageHelper, encrypted3);
+        String decrypted = storageHelper.decrypt(encrypted);
+        String decrypted2 = storageHelper.decrypt(encrypted);
+        String decrypted3 = storageHelper.decrypt(encrypted);
         assertEquals("Same as initial text", clearText, decrypted);
         assertEquals("Same as initial text", decrypted, decrypted2);
         assertEquals("Same as initial text", decrypted, decrypted3);
         Log.d(TAG, "Finished testEncryptSameText");
     }
 
-    public void testTampering() throws IllegalArgumentException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException, UnsupportedEncodingException {
+    public void testTampering() throws GeneralSecurityException, IOException {
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
         String clearText = "AAAAAAAA2pILN0mn3wlYIlWk7lqOZ5qjRWXH";
-        Object storageHelper = getStorageHelper();
-        Method mEncrypt = ReflectionUtils.getTestMethod(storageHelper, "encrypt", String.class);
-        Method mDecrypt = ReflectionUtils.getTestMethod(storageHelper, "decrypt", String.class);
-        String encrypted = (String)mEncrypt.invoke(storageHelper, clearText);
+        String encrypted =  storageHelper.encrypt(clearText);
         assertNotNull("encrypted string is not null", encrypted);
         assertFalse("encrypted string is not same as cleartex", encrypted.equals(clearText));
 
-        String decrypted = (String)mDecrypt.invoke(storageHelper, encrypted);
+        String decrypted =  storageHelper.decrypt(encrypted);
         assertTrue("Same without Tampering", decrypted.equals(clearText));
-        String flagVersion = encrypted.substring(0, 3);
+        final String flagVersion = encrypted.substring(0, 3);
         final byte[] bytes = Base64.decode(encrypted.substring(3), Base64.DEFAULT);
         bytes[15]++;
-        String modified = new String(Base64.encode(bytes, Base64.NO_WRAP), "UTF-8");
-
-        assertThrowsType(mDecrypt, storageHelper, flagVersion + modified, DigestException.class);
+        final String modified = new String(Base64.encode(bytes, Base64.NO_WRAP), "UTF-8");
+        assertThrowsException(DigestException.class, null, new ThrowableRunnable() {
+            @Override
+            public void run() throws Exception {
+                storageHelper.decrypt(flagVersion + modified);
+            }
+        });
     }
 
     /**
      * Make sure that version sets correctly. It needs to be tested at different
      * emulator(18 and before 18).
      * 
-     * @throws InvocationTargetException
-     * @throws IllegalArgumentException
-     * @throws IllegalAccessException
-     * @throws InstantiationException
-     * @throws NoSuchMethodException
-     * @throws ClassNotFoundException
-     * @throws UnsupportedEncodingException
-     * @throws NoSuchFieldException
      */
-    public void testVersion() throws IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, ClassNotFoundException, NoSuchMethodException,
-            InstantiationException, UnsupportedEncodingException, NoSuchFieldException {
+    public void testVersion() throws GeneralSecurityException, IOException {
 
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
         String value = "anvaERSgvhdfgkhrebgagagfdgadfgaadfgadfgadfg435gerhawdeADFGb #$%#gf3$%1234";
-        Object storageHelper = getStorageHelper();
-        ReflectionUtils.setFieldValue(storageHelper, "mKey", null);
-        ReflectionUtils.setFieldValue(storageHelper, "mMacKey", null);
-        Method m = ReflectionUtils.getTestMethod(storageHelper, "encrypt", String.class);
-        String encrypted = (String)m.invoke(storageHelper, value);
+        String encrypted = storageHelper.encrypt(value);
         String encodeVersion = encrypted.substring(1, 3);
         assertEquals("Encode version is same", "E1", encodeVersion);
         final byte[] bytes = Base64.decode(encrypted.substring(3), Base64.DEFAULT);
@@ -231,37 +261,17 @@ public class StorageHelperTests extends AndroidTestCase {
     }
 
     @TargetApi(18)
-    public void testMigration() throws ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException, KeyStoreException, NoSuchAlgorithmException,
-            CertificateException, IOException {
+    public void testKeyPair() throws
+            GeneralSecurityException, IOException {
         if (Build.VERSION.SDK_INT < 18) {
             return;
         }
 
-        String expectedDecrypted = "SomeValue1234";
-        String encryptedInAPI17 = "cE1VTAwMb4ChefrTHHblCg0DYaK1UR456nW3q6+hqA9Cs2uB+bqcfsLzukiI+KOCdBGJV+JqhRJHBIDCOl68TYkLQAz65g=";
-        Object storageHelper = getStorageHelper();
-        Method decrypt = ReflectionUtils.getTestMethod(storageHelper, "decrypt", String.class);
-        String decrypted = (String)decrypt.invoke(storageHelper, encryptedInAPI17);
-        assertEquals("Expected clear text as same", expectedDecrypted, decrypted);
-    }
-
-    @TargetApi(18)
-    public void testKeyPair() throws ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException, KeyStoreException, NoSuchAlgorithmException,
-            CertificateException, IOException {
-        if (Build.VERSION.SDK_INT < 18) {
-            return;
-        }
-
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
         KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
         keyStore.load(null);
-        Object storageHelper = getStorageHelper();
-        Method m = ReflectionUtils.getTestMethod(storageHelper, "getKeyPairFromAndroidKeyStore");
-
-        KeyPair kp = (KeyPair)m.invoke(storageHelper);
+        SecretKey kp = storageHelper.loadSecretKeyForAPI();
 
         assertNotNull("Keypair is not null", kp);
         keyStore.load(null);
@@ -270,62 +280,41 @@ public class StorageHelperTests extends AndroidTestCase {
     }
 
     @TargetApi(18)
-    public void testGetSecretKeyFromAndroidKeyStore() throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
+    public void testMigration() throws
+            GeneralSecurityException, IOException {
+        if (Build.VERSION.SDK_INT < 18) {
+            return;
+        }
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+        String expectedDecrypted = "SomeValue1234";
+        String encryptedInAPI17 = "cE1VTAwMb4ChefrTHHblCg0DYaK1UR456nW3q6+hqA9Cs2uB+bqcfsLzukiI+KOCdBGJV+JqhRJHBIDCOl68TYkLQAz65g=";
+        String decrypted = storageHelper.decrypt(encryptedInAPI17);
+        assertEquals("Expected clear text as same", expectedDecrypted, decrypted);
+    }
+
+    @TargetApi(18)
+    public void testGetSecretKeyFromAndroidKeyStore() throws IOException, GeneralSecurityException {
 
         if (Build.VERSION.SDK_INT < 18) {
             return;
         }
 
-        File keyFile = new File(getContext().getDir(getContext().getPackageName(),
+        final Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+
+        File keyFile = new File(context.getDir(context.getPackageName(),
                 Context.MODE_PRIVATE), "adalks");
         if (keyFile.exists()) {
             keyFile.delete();
         }
 
-        Object storageHelper = getStorageHelper();
-        Method m = ReflectionUtils.getTestMethod(storageHelper, "getSecretKeyFromAndroidKeyStore");
-
-        SecretKey key = (SecretKey)m.invoke(storageHelper);
+        SecretKey key = storageHelper.loadSecretKeyForAPI();
         assertNotNull("Key is not null", key);
 
-        SecretKey key2 = (SecretKey)m.invoke(storageHelper);
+        SecretKey key2 = storageHelper.loadSecretKeyForAPI();
         Log.d(TAG, "Key1:" + key.toString());
         Log.d(TAG, "Key1:" + key2.toString());
         assertTrue("Key info is same", key.toString().equals(key2.toString()));
-    }
-
-    private Object getStorageHelper() throws NoSuchMethodException, ClassNotFoundException,
-            InstantiationException, IllegalAccessException, InvocationTargetException {
-        Constructor<?> constructorParams = Class.forName("com.microsoft.aad.adal.StorageHelper")
-                .getDeclaredConstructor(Context.class);
-        constructorParams.setAccessible(true);
-        Object storageHelper = constructorParams.newInstance(getContext());
-        return storageHelper;
-    }
-
-    private void assertThrows(Method m, Object obj, String input, String msg) {
-        try {
-            m.invoke(obj, input);
-            Assert.fail("Supposed to throw");
-        } catch (Exception e) {
-            if (e.getMessage() == null) {
-                assertTrue("Exception message", e.getCause().getMessage().contains(msg));
-            } else {
-                assertTrue("Exception message", e.getMessage().contains(msg));
-
-            }
-        }
-    }
-
-    private void assertThrowsType(Method m, Object obj, String input,
-            final Class<? extends Exception> expected) {
-        try {
-            m.invoke(obj, input);
-            Assert.fail("Supposed to throw");
-        } catch (Exception e) {
-            assertTrue(expected.isInstance(e) || expected.isInstance(e.getCause()));
-        }
     }
 }


### PR DESCRIPTION
If SecretKey is null or failed to generate throw IlligalStateException
(we should not allow null secret keys)
Rewrote all tests around encryption to use real methods instead of reflective ones