### PR TITLE
Don't crash if keystore reset current records

### DIFF
--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -493,9 +493,19 @@ public class StorageHelper {
 
         // Read key pair again
         Logger.v(TAG, "Reading Key entry");
-        final KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(
-                KEY_STORE_CERT_ALIAS, null);
-        return new KeyPair(entry.getCertificate().getPublicKey(), entry.getPrivateKey());
+        try {
+            final KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(
+                    KEY_STORE_CERT_ALIAS, null);
+            return new KeyPair(entry.getCertificate().getPublicKey(), entry.getPrivateKey());
+        } catch (RuntimeException e) {
+            // There is an issue in android keystore that resets keystore
+            // Issue 61989:  AndroidKeyStore deleted after changing screen lock type
+            // https://code.google.com/p/android/issues/detail?id=61989
+            // in this case getEntry throws
+            // java.lang.RuntimeException: error:0D07207B:asn1 encoding routines:ASN1_get_object:header too long
+            // handle it as regular KeyStoreException
+            throw new KeyStoreException(e);
+        }
     }
     
     @TargetApi(18)


### PR DESCRIPTION
There is an issue in android keystore that resets keystore
Issue 61989:  AndroidKeyStore deleted after changing screen lock type
https://code.google.com/p/android/issues/detail?id=61989

We don't really have anything left as just claim that key for encryption got lost and token can't be decrypted. Force user to sign out.

Stack trace:
Fatal Exception: java.lang.RuntimeException: error:0D07207B:asn1 encoding routines:ASN1_get_object:header too long
       at com.android.org.conscrypt.NativeCrypto.ENGINE_load_private_key(NativeCrypto.java)
       at com.android.org.conscrypt.OpenSSLEngine.getPrivateKeyById(OpenSSLEngine.java:66)
       at android.security.AndroidKeyStore.engineGetKey(AndroidKeyStore.java:86)
       at java.security.KeyStoreSpi.engineGetEntry(KeyStoreSpi.java:372)
       at java.security.KeyStore.getEntry(KeyStore.java:645)
       at com.microsoft.aad.adal.StorageHelper.getKeyPairFromAndroidKeyStore(Unknown Source)
       at com.microsoft.aad.adal.StorageHelper.getSecretKeyFromAndroidKeyStore(Unknown Source)
       at com.microsoft.aad.adal.StorageHelper.getKeyForVersion(Unknown Source)
       at com.microsoft.aad.adal.StorageHelper.decrypt(Unknown Source)
       at com.microsoft.aad.adal.DefaultTokenCacheStore.decrypt(Unknown Source)
       at com.microsoft.aad.adal.DefaultTokenCacheStore.getItem(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.getItemFromCache(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.localFlow(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.acquireTokenAfterValidation(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.acquireTokenLocalCall(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.access$600(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext$6.run(Unknown Source)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)