### PR TITLE
handle java.lang.IllegalArgumentException: key.length == 0

### DIFF
--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -44,6 +44,7 @@ import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
@@ -261,6 +262,7 @@ public class StorageHelper {
         // API level, data needs to be updated
         String keyVersionCheck = new String(bytes, 0, KEY_VERSION_BLOB_LENGTH,
                 AuthenticationConstants.ENCODING_UTF8);
+        Logger.v(TAG, "Encrypt version:" + keyVersionCheck);
 
         SecretKey versionKey = getKeyForVersion(keyVersionCheck);
         SecretKey versionMacKey = getMacKey(versionKey);
@@ -439,6 +441,9 @@ public class StorageHelper {
         Logger.v(TAG, "Reading SecretKey");
         try {
             final byte[] encryptedKey = readKeyData(keyFile);
+            if (encryptedKey == null || encryptedKey.length == 0) {
+                throw new UnrecoverableKeyException("Couldn't find encrypted key in file");
+            }
             sSecretKeyFromAndroidKeyStore = unwrap(wrapCipher, encryptedKey);
             Logger.v(TAG, "Finished reading SecretKey");
         } catch (GeneralSecurityException | IOException ex) {


### PR DESCRIPTION
I can't figure out how this can happen that we have empty array in file.
If there is an error in writing/reading to this file I couldn't find it. 

Here is the stack trace.
Fatal Exception: java.lang.IllegalArgumentException: key.length == 0
       at javax.crypto.spec.SecretKeySpec.(SecretKeySpec.java:62)
       at com.android.org.conscrypt.OpenSSLCipherRSA.engineUnwrap(OpenSSLCipherRSA.java:333)
       at javax.crypto.Cipher.unwrap(Cipher.java:1545)
       at com.microsoft.aad.adal.StorageHelper.unwrap(Unknown Source)
       at com.microsoft.aad.adal.StorageHelper.getSecretKeyFromAndroidKeyStore(Unknown Source)
       at com.microsoft.aad.adal.StorageHelper.getKeyForVersion(Unknown Source)
       at com.microsoft.aad.adal.StorageHelper.decrypt(Unknown Source)
       at com.microsoft.aad.adal.DefaultTokenCacheStore.decrypt(Unknown Source)
       at com.microsoft.aad.adal.DefaultTokenCacheStore.getAll(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.findFamilyItemForUser(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.getRefreshToken(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.localFlow(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.acquireTokenAfterValidation(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.acquireTokenLocalCall(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext.access$600(Unknown Source)
       at com.microsoft.aad.adal.AuthenticationContext$6.run(Unknown Source)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)