### PR TITLE
Thread Safety fix

### DIFF
--- a/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -65,6 +65,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     .registerTypeAdapter(Date.class, new DateTimeAdapter())
     .create();
     private static StorageHelper sHelper;
+    private static Object sLock = new Object();
     /**
      * @param context {@link Context}
      * @throws NoSuchAlgorithmException
@@ -107,11 +108,13 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
      * Method that allows to mock StorageHelper class and use custom encryption in UTs
      * @return
      */
-    protected synchronized StorageHelper getStorageHelper() {
-        if (sHelper == null) {
-            Logger.v(TAG, "Started to initialize storage helper");
-            sHelper = new StorageHelper(mContext);
-            Logger.v(TAG, "Finished to initialize storage helper");
+    protected StorageHelper getStorageHelper() {
+        synchronized (sLock) {
+            if (sHelper == null) {
+                Logger.v(TAG, "Started to initialize storage helper");
+                sHelper = new StorageHelper(mContext);
+                Logger.v(TAG, "Finished to initialize storage helper");
+            }
         }
         return sHelper;
     }


### PR DESCRIPTION
I switched thread safety for StorageHelper to synchronize on DefaultCacheStore, but it actually incorrect, we might create multiple instances of DefaultCacheStore, better to revert back synchronization on static lock.
Another option is make getStorageHelper method static, but it will require context as input argument.