### PR TITLE
remove allowBackup from manifest

### DIFF
--- a/src/AndroidManifest.xml
+++ b/src/AndroidManifest.xml
@@ -8,8 +8,7 @@
         android:minSdkVersion="14"
         android:targetSdkVersion="21" />
 
-    <application
-        android:allowBackup="true">
+    <application>
         <activity android:name="com.microsoft.aad.adal.AuthenticationActivity" >
         </activity>
     </application>


### PR DESCRIPTION
issue #472 
As a library, we shouldn't care setting this. It should be up to the application itself for allowing backup or not. 