### PR TITLE
bugfix: Set correct key for multifamily refresh token

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1794,16 +1794,6 @@ public class AuthenticationContext {
         }
     }
 
-    private void removeItemFromCache(final RefreshItem refreshItem) {
-        if (mTokenCacheStore != null) {
-            Logger.v(TAG, "Remove refresh item from cache:" + refreshItem.mKey);
-            mTokenCacheStore.removeItem(refreshItem.mKey);
-            // clean up keys related to userid/displayableid for same request
-            mTokenCacheStore.removeItem(refreshItem.mKeyWithUserId);
-            mTokenCacheStore.removeItem(refreshItem.mKeyWithDisplayableId);
-        }
-    }
-
     /**
      * refresh token if possible. if it fails, it calls acquire token after
      * removing refresh token from cache.
@@ -1862,12 +1852,8 @@ public class AuthenticationContext {
         if (useCache) {
             if (result == null || StringExtensions.IsNullOrBlank(result.getAccessToken())) {
                 String errLogInfo = result == null ? "" : result.getErrorLogInfo();
-                Logger.w(TAG, "Refresh token did not return accesstoken.", request.getLogInfo()
+                Logger.e(TAG, "Refresh token did not return accesstoken.", request.getLogInfo()
                         + errLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
-
-                // remove item from cache to avoid same usage of
-                // refresh token in next acquireToken call
-                removeItemFromCache(refreshItem);
                 return result;
             } else {
                 Logger.v(TAG, "It finished refresh token request:" + request.getLogInfo());

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -1491,8 +1491,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
         try {
             context.acquireTokenSilentSync("resource", "clientid", TEST_IDTOKEN_UPN);
         } catch (AuthenticationException e) {
-            assertEquals("Token is not exchanged",
-                    ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, e.getCode());
+            assertEquals("Token is not exchanged, use only unique id for token silent request",
+                    ADALError.AUTH_FAILED_USER_MISMATCH, e.getCode());
         }
         
         clearCache(context);


### PR DESCRIPTION
1)  Set correct key for multifamily refresh token so it will save it by correct key in cache
2) For family tokens do not take key for the same client (otherwise we might try just another token for this clientId)
3) Never remove Item from cache, because sometimes we've got server errors which can remove good token
