### PR TITLE
Family client id feature is disabled for now, tests for token acquisition with family item should be disabled

### DIFF
--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -82,6 +82,7 @@ import android.test.AndroidTestCase;
 import android.test.UiThreadTest;
 import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.SmallTest;
+import android.test.suitebuilder.annotation.Suppress;
 import android.util.Base64;
 import android.util.Log;
 import android.util.SparseArray;
@@ -1290,6 +1291,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
      * @throws NoSuchAlgorithmException
      * @throws NoSuchPaddingException
      */
+    @Suppress
     @SmallTest
     public void testRefreshTokenRequestWithFamilyIdSuccess() throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,
@@ -1334,6 +1336,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
      * @throws NoSuchAlgorithmException
      * @throws NoSuchPaddingException
      */
+    @Suppress
     @SmallTest
     public void testRefreshTokenRequestWithFamilyIdFailed() throws InterruptedException, IllegalArgumentException,
             NoSuchFieldException, IllegalAccessException, ClassNotFoundException,


### PR DESCRIPTION
Now the family client id feature is disabled, the logic for looking into cache with "FoCI" flag won't be hit, corresponding tests should also be suppressed. 

Still keep the test for 'FoCI' flag is correctly stored into cache. Server is still returning the "FoCI" flag for first party apps. Those tests don't needs to be suppressed for the sake for making sure the "FoCI" flag is correctly stored for token cache item. 