### PR TITLE
do not remove token in case of Server Error without body in response

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1867,7 +1867,7 @@ public class AuthenticationContext {
         if (useCache) {
             if (result == null || StringExtensions.IsNullOrBlank(result.getAccessToken())) {
                 String errLogInfo = result == null ? "" : result.getErrorLogInfo();
-                Logger.w(TAG, "Refresh token did not return accesstoken.", request.getLogInfo()
+                Logger.e(TAG, "Refresh token did not return accesstoken.", request.getLogInfo()
                         + errLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
 
                 // remove item from cache to avoid same usage of

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -62,7 +62,6 @@ import com.microsoft.aad.adal.IWebRequestHandler;
 import com.microsoft.aad.adal.PromptBehavior;
 
 import android.annotation.SuppressLint;
-import android.test.AndroidTestCase;
 import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Base64;
 
@@ -590,7 +589,7 @@ public class OauthTests extends AndroidTestCase {
         headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, invalidHeaders);
         mockResponse = new HttpWebResponse(200, json.getBytes(Charset.defaultCharset()), headers);
         TestLogResponse logResponse2 = new TestLogResponse();
-        logResponse2.listenLogForMessageSegments(null, "Wrong format of the correlation ID:");
+        logResponse2.listenLogForMessageSegments("Wrong format of the correlation ID:");
 
         // send call with mocks
         m.invoke(oauth, mockResponse);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/TestLogResponse.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/TestLogResponse.java
@@ -74,10 +74,9 @@ public class TestLogResponse {
 
     /**
      * Check log message for segments since some of the responses include server generated traceid, timeStamp etc.
-     * @param signal
      * @param msgs
      */
-    public void listenLogForMessageSegments(final CountDownLatch signal, final String... msgs) {
+    public void listenLogForMessageSegments(final String... msgs) {
         final TestLogResponse response = this;
 
         Logger.getInstance().setExternalLogger(new ILogger() {
@@ -85,22 +84,16 @@ public class TestLogResponse {
             @Override
             public void Log(String tag, String message, String additionalMessage, LogLevel level,
                     ADALError errorCode) {
-                boolean hasAll = true;
                 for (String msg : msgs) {
-                    if (message.contains(msg)) {
+                    if (message.contains(msg) || additionalMessage.contains(msg)) {
                         response.tag = tag;
                         response.message = message;
                         response.additionalMessage = additionalMessage;
                         response.level = level;
                         response.errorCode = errorCode;
                     } else {
-                        hasAll = false;
                         break;
                     }
-                }
-
-                if (signal != null && hasAll) {
-                    signal.countDown();
                 }
             }
         });


### PR DESCRIPTION
I've got sign out with some log that clearly says that I've got my token wiped because of some server error.
There is some unit test (testRefreshTokenWebRequestHasError) that shows that it's not expected behavior (we should not wipe token when we've got server error without any body in response). But this UT had an error, it checked whether it has token in cache before the aquireToken call was finished and didn't catch that token was actually wiped (And this UT actually should fail)
Here is my proposal how to fix the bug and the test.

And here is the log:
SERVER_ERROR:2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-IOException:https://login.windows.net/common/oauth2/token ver:1.1.16 
03-26 00:27:35.609 9276-9484/? V/HttpWebRequest: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Status code:504 ver:1.1.16
03-26 00:27:35.610 9276-9484/? V/HttpWebRequest: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Response is received ver:1.1.16
03-26 00:27:35.611 9276-9484/? V/Oauth: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Token request does not have exception ver:1.1.16
03-26 00:27:35.612 9276-9484/? V/Oauth: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Server error message: ver:1.1.16
03-26 00:27:35.613 9276-9484/? V/AuthenticationContext: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Refresh token is not returned or empty ver:1.1.16
03-26 00:27:35.613 9276-9484/? W/AuthenticationContext: AUTH_FAILED_NO_TOKEN:2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Refresh token did not return accesstoken. ver:1.1.16 Request authority:https://login.windows.net/common resource:https://officeapps.live.com clientid:b26aadf8-566f-4478-926f-589f601d9c74 ErrorCode:504 ErrorDescription:
03-26 00:27:35.614 9276-9484/? V/AuthenticationContext: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Remove refresh item from cache:https://login.windows.net/common$https://officeapps.live.com$b26aadf8-566f-4478-926f-589f601d9c74$n$26d2c960-2104-4fc4-84c8-b64b442841c6 ver:1.1.16
03-26 00:27:35.626 9276-9484/? V/AuthenticationContext: 2016-03-26 07:27:35-74175305-f579-4212-8f49-d552fd095f8d-Refresh token is not available or refresh
