### PR TITLE
Refresh token removal

### DIFF
--- a/src/src/com/microsoft/aad/adal/ADALError.java
+++ b/src/src/com/microsoft/aad/adal/ADALError.java
@@ -515,7 +515,12 @@ public enum ADALError {
     /**
      * Resource authentication challenge failure
      */
-    RESOURCE_AUTHENTICATION_CHALLENGE_FAILURE("Resource authentication challenge failure");
+    RESOURCE_AUTHENTICATION_CHALLENGE_FAILURE("Resource authentication challenge failure"),
+    
+    /**
+     * Represents a general OAUTH Error
+     */
+    OAUTH_ERROR("Oauth Error");
 
     private String mDescription;
 

--- a/src/src/com/microsoft/aad/adal/ADALError.java
+++ b/src/src/com/microsoft/aad/adal/ADALError.java
@@ -520,7 +520,7 @@ public enum ADALError {
     /**
      * Represents a general OAUTH Error
      */
-    OAUTH_ERROR("Oauth Error");
+    OAUTH2_ERROR("Oauth2 Error");
 
     private String mDescription;
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -829,7 +829,7 @@ public class AuthenticationActivity extends Activity {
             try {
                 result.taskResult = oauthRequest.getToken(urlItems[0]);
                 Logger.v(TAG, "TokenTask processed the result. " + mRequest.getLogInfo());
-            } catch (IOException | AuthenticationException exc) {
+            } catch (IOException | AuthenticationException | HttpResponseException exc) {
                 Logger.e(TAG, "Error in processing code to get a token. " + mRequest.getLogInfo(),
                         "Request url:" + urlItems[0],
                         ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, exc);

--- a/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -149,6 +149,13 @@ public class AuthenticationConstants {
         
         static final String ADAL_CLIENT_FAMILY_ID = "foci";
     }
+    
+    public static final class OAuth2ErrorCode {
+        /**
+         * Oauth2 error code invalid_grant. 
+         */
+        static final String INVALID_GRANT = "invalid_grant";
+    }
 
     public static final class AAD {
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1875,7 +1875,6 @@ public class AuthenticationContext {
                         request.getLogInfo() + errorLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
                 
                 // check error code, only remove token from cache if receive invalid_grant from server
-                Logger.v(TAG + "tessting", "error_code:" + result.getErrorCode());
                 if (result.getErrorCode().equalsIgnoreCase(AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT)) {
                     Logger.v(TAG, "Removing token cache for invalid_grant error returned from server.");
                     removeItemFromCache(refreshItem);

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1472,7 +1472,7 @@ public class AuthenticationContext {
                         ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
                 if (authResult != null && authResult.getErrorCode() != null) {
                     callbackHandle.onError(new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, 
-                            request.getLogInfo() + " " + errorInfo, new AuthenticationServerProtocolException(ADALError.OAUTH_ERROR,
+                            request.getLogInfo() + " " + errorInfo, new AuthenticationServerProtocolException(ADALError.OAUTH2_ERROR,
                                     authResult.getErrorCode(), authResult.getErrorDescription())));
                 } else {
                     callbackHandle.onError(new AuthenticationException(

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1441,10 +1441,14 @@ public class AuthenticationContext {
                 callbackHandle.onError(authenticationException);
                 return null;
             } catch (HttpResponseException httpResponseException) {
-                final AuthenticationException authenticationException = new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, 
-                        httpResponseException.getMessage() + request.getLogInfo());
-                callbackHandle.onError(authenticationException);
-                return null;
+                // Return back the http error for silent request
+                // Try interactive flow for non-silent request.
+                if (request.isSilent()) {
+                    final AuthenticationException authenticationException = new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, 
+                            httpResponseException.getMessage() + request.getLogInfo());
+                    callbackHandle.onError(authenticationException);
+                    return null;
+                }
             }
             
             if (authResult != null && !StringExtensions.IsNullOrBlank(authResult.getAccessToken())) {
@@ -2106,6 +2110,7 @@ public class AuthenticationContext {
                 } catch (final HttpResponseException httpResponseException) {
                     final AuthenticationException authenticationException = new AuthenticationException(
                             ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, httpResponseException.getMessage());
+                    callbackHandle.onError(authenticationException);
                     return;
                 }
                 

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1871,11 +1871,11 @@ public class AuthenticationContext {
                 return result;
             } else if (StringExtensions.IsNullOrBlank(result.getAccessToken())) {
                 final String errorLogInfo = result.getErrorLogInfo();
-                Logger.w(TAG, "Refresh token request failed to return accesstoken.", 
+                Logger.e(TAG, "Refresh token request failed to return accesstoken.", 
                         request.getLogInfo() + errorLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
                 
                 // check error code, only remove token from cache if receive invalid_grant from server
-                if (result.getErrorCode().equalsIgnoreCase(AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT)) {
+                if (AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(result.getErrorCode())) {
                     Logger.v(TAG, "Removing token cache for invalid_grant error returned from server.");
                     removeItemFromCache(refreshItem);
                 }

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1866,12 +1866,12 @@ public class AuthenticationContext {
         // the error through callback. If true, just return the result back to localflow. 
         if (useCache) {
             if (result == null) {
-                Logger.w(TAG, "Receive empty response from refresh token request.", request.getLogInfo(), 
+                Logger.w(TAG, "Received empty response from refresh token request.", request.getLogInfo(), 
                         ADALError.AUTH_FAILED_NO_TOKEN);
                 return result;
             } else if (StringExtensions.IsNullOrBlank(result.getAccessToken())) {
                 final String errorLogInfo = result.getErrorLogInfo();
-                Logger.w(TAG, "Refresh token request does not successfully return accesstoken.", 
+                Logger.w(TAG, "Refresh token request failed to return accesstoken.", 
                         request.getLogInfo() + errorLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
                 
                 // check error code, only remove token from cache if receive invalid_grant from server

--- a/src/src/com/microsoft/aad/adal/AuthenticationServerProtocolException.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationServerProtocolException.java
@@ -32,7 +32,7 @@ public class AuthenticationServerProtocolException extends AuthenticationExcepti
     
     private String mProtocolCode;
 
-    protected AuthenticationServerProtocolException(final ADALError adalError, String detailMessage) {
+    protected AuthenticationServerProtocolException(final ADALError adalError, final String detailMessage) {
         super(adalError, detailMessage);
     }
     

--- a/src/src/com/microsoft/aad/adal/ChallengeResponseBuilder.java
+++ b/src/src/com/microsoft/aad/adal/ChallengeResponseBuilder.java
@@ -189,7 +189,7 @@ class ChallengeResponseBuilder {
         final String methodName = ":getChallengeRequestFromHeader";
         
         if (StringExtensions.IsNullOrBlank(headerValue)) {
-            throw new AuthenticationServerProtocolException("headerValue");
+            throw new AuthenticationServerProtocolException(ADALError.DEVICE_CHALLENGE_FAILURE, "headerValue");
         }
 
         // Header value should start with correct challenge type
@@ -291,7 +291,7 @@ class ChallengeResponseBuilder {
     private ChallengeRequest getChallengeRequest(final String redirectUri)
             throws AuthenticationException {
         if (StringExtensions.IsNullOrBlank(redirectUri)) {
-            throw new AuthenticationServerProtocolException("redirectUri");
+            throw new AuthenticationServerProtocolException(ADALError.DEVICE_CHALLENGE_FAILURE, "redirectUri");
         }
 
         ChallengeRequest challenge = new ChallengeRequest();

--- a/src/src/com/microsoft/aad/adal/HttpResponseException.java
+++ b/src/src/com/microsoft/aad/adal/HttpResponseException.java
@@ -22,27 +22,30 @@
 // THE SOFTWARE.
 
 package com.microsoft.aad.adal;
-//
+
 /**
- * Represents server returned exception. 
+ * Represents HTTP error response. 
  */
-public class AuthenticationServerProtocolException extends AuthenticationException {
+class HttpResponseException extends Exception {
 
-    static final long serialVersionUID = 1;
+    /**
+     * Default serialized version
+     */
+    private static final long serialVersionUID = 1L;
     
-    private String mProtocolCode;
-
-    protected AuthenticationServerProtocolException(final ADALError adalError, String detailMessage) {
-        super(adalError, detailMessage);
+    private String mErrorCode;
+    
+    protected HttpResponseException(final String errorCode) {
+        super();
+        this.mErrorCode = errorCode;
     }
     
-    protected AuthenticationServerProtocolException(final ADALError adalError, final String protocolErrorCode, final String detailMessage) {
-        super(adalError, detailMessage);
-        this.mProtocolCode = protocolErrorCode;
+    protected HttpResponseException(final String errorCode, final String errorMessage) {
+        super(errorMessage);
+        this.mErrorCode = errorCode;
     }
     
-    public String getProtocolErrorCode(){
-        return mProtocolCode;
+    public String getErrorCode() {
+        return mErrorCode;
     }
 }
-

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -635,7 +635,7 @@ class Oauth2 {
         return result;
     }
     
-    private AuthenticationResult parseJsonResponse(byte[] responseBody) throws JSONException {
+    private AuthenticationResult parseJsonResponse(final byte[] responseBody) throws JSONException {
         HashMap<String, String> responseItems = new HashMap<String, String>();
         
         final String jsonStringResult = new String(responseBody);

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -522,7 +522,7 @@ class Oauth2 {
 
             if (result == null) {
                 // non-protocol related error
-                final String errMessage = response.getBody() == null ? 
+                final String errMessage = (response.getBody() == null || response.getBody().length == 0) ? 
                         "Status code:" + String.valueOf(response.getStatusCode()) : new String(response.getBody());
 
                 Logger.e(TAG, "Server error message", errMessage, ADALError.SERVER_ERROR);
@@ -608,11 +608,11 @@ class Oauth2 {
                     final String message = "Status code: " + statusCode + ". Cannot parse response as JSON " 
                             + ex.getMessage();
                     Logger.e(TAG, message, "", ADALError.SERVER_INVALID_JSON_RESPONSE, ex);
-                    result = new AuthenticationResult(String.valueOf(statusCode), webResponse.getBody().toString(), null);
+                    result = new AuthenticationResult(String.valueOf(statusCode), new String(webResponse.getBody()), null);
                 }
                 break;
             default:
-                result = new AuthenticationResult(String.valueOf(statusCode), webResponse.getBody().toString(), null);
+                result = new AuthenticationResult(String.valueOf(statusCode), new String(webResponse.getBody()), null);
             }
         }
 

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -349,7 +349,7 @@ class Oauth2 {
         }
     }
 
-    public AuthenticationResult refreshToken(String refreshToken) throws IOException, AuthenticationException, HttpResponseException {
+    public AuthenticationResult refreshToken(final String refreshToken) throws IOException, AuthenticationException, HttpResponseException {
         String requestMessage = null;
         if (mWebRequestHandler == null) {
             Logger.v(TAG, "Web request is not set correctly");

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -515,8 +515,15 @@ class Oauth2 {
             // Protocol related errors will read the error stream and report
             // the error and error description
             result = processTokenResponse(response);
-            ClientMetrics.INSTANCE.setLastError(result.getErrorCode());
-            ClientMetrics.INSTANCE.setLastErrorCodes(result.getErrorCodes());
+            
+            if (result == null) {
+                ClientMetrics.INSTANCE.setLastError(null);
+                if (response.getResponseException() != null) {
+                    throw response.getResponseException();
+                }
+            } else {
+                ClientMetrics.INSTANCE.setLastErrorCodes(result.getErrorCodes());
+            }
         } catch (UnsupportedEncodingException e) {
             ClientMetrics.INSTANCE.setLastError(null);
             Logger.e(TAG, e.getMessage(), "", ADALError.ENCODING_IS_NOT_SUPPORTED, e);
@@ -580,7 +587,7 @@ class Oauth2 {
             Logger.v(TAG, "Token request returned an empty response body.");
             throw new HttpResponseException(String.valueOf(statusCode));
         } else {
-            Logger.v(TAG, "Token request does not have exception.");
+            Logger.v(TAG, "Start parsing response body from token request.");
             switch(statusCode) {
             case HttpURLConnection.HTTP_OK:
             case HttpURLConnection.HTTP_BAD_REQUEST:

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -590,11 +590,11 @@ class Oauth2 {
             }
         }
         
-        final boolean isResponseBodyEmpty = webResponse.getBody() == null || webResponse.getBody().length == 0;
+        final boolean isResponseBodyEmpty = (webResponse.getBody() == null) || (webResponse.getBody().length == 0);
         final int statusCode = webResponse.getStatusCode();
         if (isResponseBodyEmpty) {
             // Empty response body, return the status code as error code back
-            Logger.v(TAG, "Token request return an empty response body.");
+            Logger.v(TAG, "Token request returned an empty response body.");
             result = new AuthenticationResult(String.valueOf(statusCode), "", null);
         } else {
             switch(statusCode) {
@@ -605,7 +605,9 @@ class Oauth2 {
                     result = parseJsonResponse(webResponse.getBody());
                 } catch (final JSONException ex) {
                     // Cannot parse response as JSON, then return the raw response as error description
-                    Logger.e(TAG, "Cannot parse response as JSON" + ex.getMessage(), "", ADALError.SERVER_INVALID_JSON_RESPONSE, ex);
+                    final String message = "Status code: " + statusCode + ". Cannot parse response as JSON " 
+                            + ex.getMessage();
+                    Logger.e(TAG, message, "", ADALError.SERVER_INVALID_JSON_RESPONSE, ex);
                     result = new AuthenticationResult(String.valueOf(statusCode), webResponse.getBody().toString(), null);
                 }
                 break;

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -522,15 +522,10 @@ class Oauth2 {
 
             if (result == null) {
                 // non-protocol related error
-                String errMessage = null;
-                byte[] message = response.getBody();
-                if (message != null) {
-                    errMessage = new String(message);
-                } else {
-                    errMessage = "Status code:" + String.valueOf(response.getStatusCode());
-                }
+                final String errMessage = response.getBody() == null ? 
+                        "Status code:" + String.valueOf(response.getStatusCode()) : new String(response.getBody());
 
-                Logger.v(TAG, "Server error message:" + errMessage);
+                Logger.e(TAG, "Server error message", errMessage, ADALError.SERVER_ERROR);
                 if (response.getResponseException() != null) {
                     throw response.getResponseException();
                 }
@@ -583,7 +578,6 @@ class Oauth2 {
      */
     private AuthenticationResult processTokenResponse(HttpWebResponse webResponse) {
         AuthenticationResult result = new AuthenticationResult();
-        HashMap<String, String> responseItems = new HashMap<String, String>();
         String correlationIdInHeader = null;
         if (webResponse.getResponseHeaders() != null
                 && webResponse.getResponseHeaders().containsKey(
@@ -595,33 +589,29 @@ class Oauth2 {
                 correlationIdInHeader = listOfHeaders.get(0);
             }
         }
-
-        if (webResponse.getStatusCode() == HttpURLConnection.HTTP_OK
-                && webResponse.getBody() != null && webResponse.getBody().length > 0) {
-            // invalid refresh token calls has error related items in the body.
-            // Status is 400 for those.
-            try {
-                String jsonStr = new String(webResponse.getBody());
-                extractJsonObjects(responseItems, jsonStr);
-                result = processUIResponseParams(responseItems);
-            } catch (final JSONException ex) {
-                // There is no recovery possible here, so
-                // catch the
-                // generic Exception
-                Logger.e(TAG, ex.getMessage(), "", ADALError.SERVER_INVALID_JSON_RESPONSE, ex);
-                result = new AuthenticationResult(JSON_PARSING_ERROR, ex.getMessage(), null);
-            }
+        
+        final boolean isResponseBodyEmpty = webResponse.getBody() == null || webResponse.getBody().length == 0;
+        final int statusCode = webResponse.getStatusCode();
+        if (isResponseBodyEmpty) {
+            // Empty response body, return the status code as error code back
+            Logger.v(TAG, "Token request return an empty response body.");
+            result = new AuthenticationResult(String.valueOf(statusCode), "", null);
         } else {
-            String errMessage = null;
-            byte[] message = webResponse.getBody();
-            if (message != null) {
-                errMessage = new String(message);
-            } else {
-                errMessage = "Status code:" + String.valueOf(webResponse.getStatusCode());
+            switch(statusCode) {
+            case HttpURLConnection.HTTP_OK:
+            case HttpURLConnection.HTTP_BAD_REQUEST:
+            case HttpURLConnection.HTTP_UNAUTHORIZED: 
+                try {
+                    result = parseJsonResponse(webResponse.getBody());
+                } catch (final JSONException ex) {
+                    // Cannot parse response as JSON, then return the raw response as error description
+                    Logger.e(TAG, "Cannot parse response as JSON" + ex.getMessage(), "", ADALError.SERVER_INVALID_JSON_RESPONSE, ex);
+                    result = new AuthenticationResult(String.valueOf(statusCode), webResponse.getBody().toString(), null);
+                }
+                break;
+            default:
+                result = new AuthenticationResult(String.valueOf(statusCode), webResponse.getBody().toString(), null);
             }
-            Logger.v(TAG, "Server error message:" + errMessage);
-            result = new AuthenticationResult(String.valueOf(webResponse.getStatusCode()),
-                    errMessage, null);
         }
 
         // Set correlationId in the result
@@ -641,5 +631,13 @@ class Oauth2 {
         }
 
         return result;
+    }
+    
+    private AuthenticationResult parseJsonResponse(byte[] responseBody) throws JSONException {
+        HashMap<String, String> responseItems = new HashMap<String, String>();
+        
+        final String jsonStringResult = new String(responseBody);
+        extractJsonObjects(responseItems, jsonStringResult);
+        return processUIResponseParams(responseItems);
     }
 }

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -592,7 +592,7 @@ class Oauth2 {
                     final String message = "Status code: " + statusCode + ". Cannot parse response as JSON " 
                             + ex.getMessage();
                     Logger.e(TAG, message, "", ADALError.SERVER_INVALID_JSON_RESPONSE, ex);
-                    result = new AuthenticationResult(String.valueOf(statusCode), new String(webResponse.getBody()), null);
+                    throw new HttpResponseException(String.valueOf(statusCode), new String(webResponse.getBody()));
                 }
                 break;
             default:

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -983,15 +983,17 @@ public class AuthenticationContextTest extends AndroidTestCase {
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         webrequest.setReturnResponse(new HttpWebResponse(500, null, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
-        final TestLogResponse response = new TestLogResponse();
-        response.listenLogForMessageSegments(signal, "Server error message");
 
         context.acquireTokenSilentAsync("resource", "clientid", TEST_IDTOKEN_USERID, callback);
 
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
+        assertNotNull(callback.mException);
+        assertTrue(callback.mException instanceof AuthenticationException);
+        AuthenticationException authenticationException = (AuthenticationException)callback.mException;
+        assertEquals(authenticationException.getCode(), ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
+
         // Check response in callback result
-        assertTrue("Log message has same webstatus code", response.errorCode.equals(ADALError.SERVER_ERROR));
         assertNotNull("Cache item is not removed for this item", mockCache.getItem(CacheKey.createCacheKey(
                 VALID_AUTHORITY, "resource", "clientId", false, TEST_IDTOKEN_USERID)));
         clearCache(context);
@@ -1381,6 +1383,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
         
         try {
             context.acquireTokenSilentSync("resource", "clientid", TEST_IDTOKEN_USERID);
+            // Exception should be thrown for acquireTokenSilentSync, should never reach the fail check.
+            fail();
         } catch (AuthenticationException e) {
             assertEquals("Token is not exchanged",
                     ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, e.getCode());
@@ -1410,6 +1414,8 @@ public class AuthenticationContextTest extends AndroidTestCase {
         
         try {
             context.acquireTokenSilentSync("resource", "clientid", TEST_IDTOKEN_USERID);
+            // Exception should be thrown for acquireTokenSilentSync, should never reach the fail check.
+            fail();
         } catch (AuthenticationException e) {
             assertEquals("Token is not exchanged",
                     ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, e.getCode());

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -1501,7 +1501,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
     }
     
     @SmallTest
-    public void testAutoFlow_RefreshTokenRequestFailed_WithHTTError() throws NoSuchFieldException, IllegalAccessException, 
+    public void testAutoFlow_RefreshTokenRequestFailed_WithHTTPError() throws NoSuchFieldException, IllegalAccessException, 
             InterruptedException, IllegalArgumentException, ClassNotFoundException, NoSuchMethodException, InstantiationException, InvocationTargetException {
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);


### PR DESCRIPTION
1. Only remove token when receiving invalid grant
2. update parsing token response: if receiving 200, 400, 401, also try to read json response, if failed, creating AuthenticationResult with statusCode as errorCode, and raw response as error description