### PR TITLE
Minor refactoring of RefreshItem, HttpWebResponse and HttpWebRequest  classes

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1436,7 +1436,7 @@ public class AuthenticationContext {
                 && !StringExtensions.IsNullOrBlank(refreshItem.mRefreshToken)) {
             Logger.v(TAG, "Refresh token is available and it will attempt to refresh token");
             try {
-                authResult = getTokenWithRefreshToken(activity, useDialog, request, refreshItem, true);
+                authResult = getTokenWithRefreshTokenAndUpdateCache(request, refreshItem);
             } catch (AuthenticationException authenticationException) {
                 callbackHandle.onError(authenticationException);
                 return null;
@@ -1573,45 +1573,33 @@ public class AuthenticationContext {
      * another call to acquireToken. It may try multi resource refresh token for
      * second attempt.
      */
-    private class RefreshItem {
-        String mRefreshToken;
-
-        String mKey;
-
-        boolean mMultiResource;
-
-        UserInfo mUserInfo;
-
-        String mRawIdToken;
-
+    private static class RefreshItem {
+        final String mRefreshToken;
+        final String mKey;
+        final boolean mMultiResource;
+        final UserInfo mUserInfo;
+        final String mRawIdToken;
+        final String mTenantId;
         String mKeyWithUserId;
-
         String mKeyWithDisplayableId;
-        
-        String mTenantId;
 
         public RefreshItem(String keyInCache, AuthenticationRequest request, TokenCacheItem item,
                 boolean multiResource) {
+            if (item == null) {
+                throw new IllegalArgumentException("item");
+            }
             mKey = keyInCache;
             mMultiResource = multiResource;
-
-            if (item != null) {
-                mRefreshToken = item.getRefreshToken();
-                mUserInfo = item.getUserInfo();
-                mRawIdToken = item.getRawIdToken();
-                mTenantId = item.getTenantId();
-                if (item.getUserInfo() != null) {
-                    mKeyWithUserId = CacheKey.createCacheKey(request, item.getUserInfo()
-                            .getUserId());
-                    mKeyWithDisplayableId = CacheKey.createCacheKey(request, item.getUserInfo()
-                            .getDisplayableId());
-                }
+            mRefreshToken = item.getRefreshToken();
+            mUserInfo = item.getUserInfo();
+            mRawIdToken = item.getRawIdToken();
+            mTenantId = item.getTenantId();
+            if (item.getUserInfo() != null) {
+                mKeyWithUserId = CacheKey.createCacheKey(request, item.getUserInfo()
+                        .getUserId());
+                mKeyWithDisplayableId = CacheKey.createCacheKey(request, item.getUserInfo()
+                        .getDisplayableId());
             }
-        }
-
-        public RefreshItem(String refreshToken) {
-            mMultiResource = false;
-            mRefreshToken = refreshToken;
         }
     }
 
@@ -1810,23 +1798,66 @@ public class AuthenticationContext {
     }
 
     /**
-     * refresh token if possible. if it fails, it calls acquire token after
-     * removing refresh token from cache.
-     * 
-     * @param activity Activity to use in case refresh token does not succeed
-     *            and prompt is not set to never.
+     * refresh token if possible and update cache with new token value
+     *
      * @param request incoming request
      * @param refreshItem refresh item info to remove this refresh token from
      *            cache
-     * @param useCache refresh request can be explicit without cache usage.
-     *            Error message should return without trying prompt.
      * @return
      */
-    private AuthenticationResult getTokenWithRefreshToken(final IWindowComponent activity, final boolean useDialog,
-            final AuthenticationRequest request, final RefreshItem refreshItem, final boolean useCache) 
+    private AuthenticationResult getTokenWithRefreshTokenAndUpdateCache(
+            final AuthenticationRequest request, final RefreshItem refreshItem)
+            throws AuthenticationException {
+        AuthenticationResult result = getTokenWithRefreshToken(request, refreshItem.mRefreshToken);
+
+        if (result == null || StringExtensions.IsNullOrBlank(result.getAccessToken())) {
+            String errLogInfo = result == null ? "" : result.getErrorLogInfo();
+            Logger.e(TAG, "Refresh token did not return accesstoken.", request.getLogInfo()
+                    + errLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
+
+            // Check error code, only remove token from cache if receiving invalid_grant from server
+            if (AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT.equals(result.getErrorCode())) {
+                Logger.v(TAG, "Removing token cache for invalid_grant error returned from server.");
+                // remove item from cache to avoid same usage of
+                // refresh token in next acquireToken call
+                removeItemFromCache(refreshItem);
+            }
+
+            return result;
+        } else {
+            Logger.v(TAG, "It finished refresh token request:" + request.getLogInfo());
+            if (result.getUserInfo() == null && refreshItem.mUserInfo != null) {
+                Logger.v(TAG, "UserInfo is updated from cached result:" + request.getLogInfo());
+                result.setUserInfo(refreshItem.mUserInfo);
+                result.setIdToken(refreshItem.mRawIdToken);
+                result.setTenantId(refreshItem.mTenantId);
+            }
+
+            // it replaces multi resource refresh token as
+            // well with the new one since it is not stored
+            // with resource.
+            Logger.v(TAG, "Cache is used. It will set item to cache" + request.getLogInfo());
+            setItemToCacheFromRefresh(refreshItem, request, result);
+
+            // return result obj which has error code and
+            // error description that is returned from
+            // server response
+            return result;
+        }
+    }
+
+    /**
+     * refresh token if possible.
+     * 
+     * @param request incoming request
+     * @param refreshToken refresh token
+     * @return
+     */
+    private AuthenticationResult getTokenWithRefreshToken(
+            final AuthenticationRequest request, final String refreshToken)
             throws AuthenticationException {
         Logger.v(TAG, "Process refreshToken for " + request.getLogInfo() + " refreshTokenId:"
-                + getTokenHash(refreshItem.mRefreshToken));
+                + getTokenHash(refreshToken));
 
         // Removes refresh token from cache, when this call is complete. Request
         // may be interrupted, if app is shutdown by user. Detect connection
@@ -1845,10 +1876,10 @@ public class AuthenticationContext {
         AuthenticationResult result = null;
         try {
             Oauth2 oauthRequest = new Oauth2(request, mWebRequest, mJWSBuilder);
-            result = oauthRequest.refreshToken(refreshItem.mRefreshToken);
+            result = oauthRequest.refreshToken(refreshToken);
             if (result != null && StringExtensions.IsNullOrBlank(result.getRefreshToken())) {
                 Logger.v(TAG, "Refresh token is not returned or empty");
-                result.setRefreshToken(refreshItem.mRefreshToken);
+                result.setRefreshToken(refreshToken);
             }
         } catch (IOException | AuthenticationException exc) {
             // Server side error or similar
@@ -1862,49 +1893,7 @@ public class AuthenticationContext {
             throw authException;
         }
 
-        // useCache will be false when calling from acquireTokenUsingRefreshToken, and if false, need to return
-        // the error through callback. If true, just return the result back to localflow. 
-        if (useCache) {
-            if (result == null || StringExtensions.IsNullOrBlank(result.getAccessToken())) {
-                String errLogInfo = result == null ? "" : result.getErrorLogInfo();
-                Logger.e(TAG, "Refresh token did not return accesstoken.", request.getLogInfo()
-                        + errLogInfo, ADALError.AUTH_FAILED_NO_TOKEN);
-
-                // Check error code, only remove token from cache if receiving invalid_grant from server
-                if (AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT.equals(result.getErrorCode())) {
-                    Logger.v(TAG, "Removing token cache for invalid_grant error returned from server.");
-                    removeItemFromCache(refreshItem);
-                }
-
-                return result;
-            } else {
-                Logger.v(TAG, "It finished refresh token request:" + request.getLogInfo());
-                if (result.getUserInfo() == null && refreshItem.mUserInfo != null) {
-                    Logger.v(TAG, "UserInfo is updated from cached result:" + request.getLogInfo());
-                    result.setUserInfo(refreshItem.mUserInfo);
-                    result.setIdToken(refreshItem.mRawIdToken);
-                    result.setTenantId(refreshItem.mTenantId);
-                }
-
-                // it replaces multi resource refresh token as
-                // well with the new one since it is not stored
-                // with resource.
-                Logger.v(TAG, "Cache is used. It will set item to cache" + request.getLogInfo());
-                setItemToCacheFromRefresh(refreshItem, request, result);
-
-                // return result obj which has error code and
-                // error description that is returned from
-                // server response
-                return result;
-            }
-        } else {
-            // User is not using cache and explicitly
-            // calling with refresh token. User should received
-            // error code and error description in
-            // Authentication result for Oauth errors
-            Logger.v(TAG, "Cache is not used for Request:" + request.getLogInfo());
-            return result;
-        }
+        return result;
     }
 
     private boolean validateAuthority(final URL authorityUrl) {
@@ -2061,8 +2050,6 @@ public class AuthenticationContext {
                 // It is not using cache and refresh is not expected to
                 // show authentication activity.
                 request.setSilent(true);
-                final RefreshItem refreshItem = new RefreshItem(refreshToken);
-
                 if (mValidateAuthority) {
                     Logger.v(TAG, "Validating authority");
 
@@ -2084,7 +2071,7 @@ public class AuthenticationContext {
                 final AuthenticationResult authResult;
                 try
                 {
-                    authResult = getTokenWithRefreshToken(null, false, request, refreshItem, false);
+                    authResult = getTokenWithRefreshToken(request, refreshToken);
                 }
                 catch (final AuthenticationException authException)
                 {

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -166,17 +167,17 @@ public class AuthenticationParameters {
             public void run() {
                 HashMap<String, String> headers = new HashMap<String, String>();
                 headers.put(WebRequestHandler.HEADER_ACCEPT, WebRequestHandler.HEADER_ACCEPT_JSON);
-                HttpWebResponse webResponse = sWebRequest.sendGet(resourceUrl, headers);
 
-                if (webResponse != null) {
-                    if(webResponse.getResponseException() != null) {
-                        onCompleted(webResponse.getResponseException(), null);
-                    }
+                HttpWebResponse webResponse = null;
+                try {
+                    webResponse = sWebRequest.sendGet(resourceUrl, headers);
                     try {
                         onCompleted(null, parseResponse(webResponse));
                     } catch (ResourceAuthenticationChallengeException exc) {
                         onCompleted(exc, null);
                     }
+                } catch (IOException e) {
+                    onCompleted(e, null);
                 }
             }
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -168,7 +168,7 @@ public class AuthenticationParameters {
                 HashMap<String, String> headers = new HashMap<String, String>();
                 headers.put(WebRequestHandler.HEADER_ACCEPT, WebRequestHandler.HEADER_ACCEPT_JSON);
 
-                HttpWebResponse webResponse = null;
+                final HttpWebResponse webResponse;
                 try {
                     webResponse = sWebRequest.sendGet(resourceUrl, headers);
                     try {

--- a/src/src/com/microsoft/aad/adal/ClientMetrics.java
+++ b/src/src/com/microsoft/aad/adal/ClientMetrics.java
@@ -25,6 +25,7 @@ package com.microsoft.aad.adal;
 
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 class ClientMetricsEndpointType {
@@ -63,7 +64,7 @@ enum ClientMetrics {
     private URL mQueryUrl;
 
     public void beginClientMetricsRecord(URL queryUrl, UUID correlationId,
-            HashMap<String, String> headers) {
+            Map<String, String> headers) {
         if (UrlExtensions.isADFSAuthority(queryUrl)) {
             // Don't add for ADFS endpoint
             return;
@@ -104,7 +105,7 @@ enum ClientMetrics {
         mLastError = (errorCodes != null) ? android.text.TextUtils.join(",", errorCodes) : null;
     }
 
-    private void addClientMetricsHeadersToRequest(HashMap<String, String> headers) {
+    private void addClientMetricsHeadersToRequest(Map<String, String> headers) {
 
         if (mLastError != null) {
             headers.put(CLIENT_METRICS_HEADER_LAST_ERROR, mLastError);

--- a/src/src/com/microsoft/aad/adal/Discovery.java
+++ b/src/src/com/microsoft/aad/adal/Discovery.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -179,7 +180,7 @@ final class Discovery implements IDiscovery {
     private boolean sendRequest(final URL queryUrl) throws IOException, JSONException {
 
         Logger.v(TAG, "Sending discovery request to:" + queryUrl);
-        HashMap<String, String> headers = new HashMap<String, String>();
+        Map<String, String> headers = new HashMap<String, String>();
         headers.put(WebRequestHandler.HEADER_ACCEPT, WebRequestHandler.HEADER_ACCEPT_JSON);
 
         // CorrelationId is used to track the request at the Azure services
@@ -187,7 +188,7 @@ final class Discovery implements IDiscovery {
             headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, mCorrelationId.toString());
             headers.put(AuthenticationConstants.AAD.RETURN_CLIENT_REQUEST_ID, "true");
         }
-               
+
         HttpWebResponse webResponse = null;
         String errorCodes = "";
         try {
@@ -201,7 +202,7 @@ final class Discovery implements IDiscovery {
             }
 
             // parse discovery response to find tenant info
-            HashMap<String, String> discoveryResponse = parseResponse(webResponse);
+            final Map<String, String> discoveryResponse = parseResponse(webResponse);
             if(discoveryResponse.containsKey(AuthenticationConstants.OAuth2.ERROR_CODES))
             {
                 errorCodes = discoveryResponse.get(AuthenticationConstants.OAuth2.ERROR_CODES);
@@ -222,7 +223,7 @@ final class Discovery implements IDiscovery {
      * @return true if tenant discovery endpoint is reported. false otherwise.
      * @throws JSONException
      */
-    private HashMap<String, String> parseResponse(HttpWebResponse webResponse) throws JSONException {
+    private Map<String, String> parseResponse(HttpWebResponse webResponse) throws JSONException {
         return HashMapExtensions.getJsonResponse(webResponse);
     }
 
@@ -234,7 +235,9 @@ final class Discovery implements IDiscovery {
      * @return https://hostname/common
      */
     private String getAuthorizationCommonEndpoint(final URL authorizationEndpointUrl) {
-        return String.format("https://%s%s", authorizationEndpointUrl.getHost(), AUTHORIZATION_COMMON_ENDPOINT);
+        return new Uri.Builder().scheme("https")
+                .authority(authorizationEndpointUrl.getHost())
+                .appendPath(AUTHORIZATION_COMMON_ENDPOINT).build().toString();
     }
 
     /**

--- a/src/src/com/microsoft/aad/adal/Discovery.java
+++ b/src/src/com/microsoft/aad/adal/Discovery.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -189,13 +190,13 @@ final class Discovery implements IDiscovery {
         String errorCodes = "";
         try {
             ClientMetrics.INSTANCE.beginClientMetricsRecord(queryUrl, mCorrelationId, headers);
-            webResponse = mWebrequestHandler.sendGet(queryUrl, headers);
-            if (webResponse.getResponseException() == null) {
+            try {
+                webResponse = mWebrequestHandler.sendGet(queryUrl, headers);
                 ClientMetrics.INSTANCE.setLastError(null);
-            } else {
+            } catch (IOException e) {
                 ClientMetrics.INSTANCE.setLastError(String.valueOf(webResponse.getStatusCode()));
             }
-            
+
             // parse discovery response to find tenant info
             HashMap<String, String> discoveryResponse = parseResponse(webResponse);
             if(discoveryResponse.containsKey(AuthenticationConstants.OAuth2.ERROR_CODES))

--- a/src/src/com/microsoft/aad/adal/HashMapExtensions.java
+++ b/src/src/com/microsoft/aad/adal/HashMapExtensions.java
@@ -26,6 +26,7 @@ package com.microsoft.aad.adal;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import org.json.JSONException;
@@ -95,8 +96,8 @@ final class HashMapExtensions {
      * @return
      * @throws JSONException
      */
-    static final HashMap<String, String> getJsonResponse(HttpWebResponse webResponse) throws JSONException{
-        HashMap<String, String> response = new HashMap<>();
+    static final Map<String, String> getJsonResponse(HttpWebResponse webResponse) throws JSONException{
+        Map<String, String> response = new HashMap<>();
         if(webResponse != null && !TextUtils.isEmpty(webResponse.getBody())) {
             JSONObject jsonObject = new JSONObject(webResponse.getBody());
             Iterator<?> i = jsonObject.keys();

--- a/src/src/com/microsoft/aad/adal/HashMapExtensions.java
+++ b/src/src/com/microsoft/aad/adal/HashMapExtensions.java
@@ -31,6 +31,7 @@ import java.util.StringTokenizer;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 final class HashMapExtensions {
@@ -95,17 +96,13 @@ final class HashMapExtensions {
      * @throws JSONException
      */
     static final HashMap<String, String> getJsonResponse(HttpWebResponse webResponse) throws JSONException{
-        HashMap<String, String> response = new HashMap<String, String>();
-        if(webResponse != null && webResponse.getBody() != null && webResponse.getBody().length != 0){
-            JSONObject jsonObject = new JSONObject(
-                    new String(webResponse.getBody()));
-
+        HashMap<String, String> response = new HashMap<>();
+        if(webResponse != null && !TextUtils.isEmpty(webResponse.getBody())) {
+            JSONObject jsonObject = new JSONObject(webResponse.getBody());
             Iterator<?> i = jsonObject.keys();
-
             while (i.hasNext()) {
                 String key = (String) i.next();
-                response.put(key,
-                        jsonObject.getString(key));
+                response.put(key, jsonObject.getString(key));
             }
         }
         return response;

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -116,7 +116,7 @@ class HttpWebRequest {
         connection.setRequestMethod(mRequestMethod);
         connection.setDoInput(true); // it will at least read status
                                      // code. Default is true.
-        setRequestBody(connection);
+        setRequestBody(connection, mRequestContent, mRequestContentType);
 
         return connection;
     }
@@ -231,22 +231,22 @@ class HttpWebRequest {
         return statusCode;
     }
 
-    private void setRequestBody(HttpURLConnection connection) throws IOException {
-        if (null != mRequestContent) {
+    private static void setRequestBody(HttpURLConnection connection, byte[] contentRequest, String requestContentType) throws IOException {
+        if (null != contentRequest) {
             connection.setDoOutput(true);
 
-            if (null != mRequestContentType && !mRequestContentType.isEmpty()) {
-                connection.setRequestProperty("Content-Type", mRequestContentType);
+            if (null != requestContentType && !requestContentType.isEmpty()) {
+                connection.setRequestProperty("Content-Type", requestContentType);
             }
 
             connection.setRequestProperty("Content-Length",
-                    Integer.toString(mRequestContent.length));
-            connection.setFixedLengthStreamingMode(mRequestContent.length);
+                    Integer.toString(contentRequest.length));
+            connection.setFixedLengthStreamingMode(contentRequest.length);
 
             OutputStream out = null;
             try {
                 out = connection.getOutputStream();
-                out.write(mRequestContent);
+                out.write(contentRequest);
             } finally {
                 safeCloseStream(out);
             }
@@ -258,7 +258,7 @@ class HttpWebRequest {
      *
      * @param stream stream to be closed
      */
-    private void safeCloseStream(Closeable stream) {
+    private static void safeCloseStream(Closeable stream) {
         if (stream != null) {
             try {
                 stream.close();

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -34,6 +34,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import android.os.*;
 import android.os.Process;
@@ -56,16 +57,16 @@ class HttpWebRequest {
     private final URL mUrl;
     private final byte[] mRequestContent;
     private final String mRequestContentType;
-    private final HashMap<String, String> mRequestHeaders;
+    private final Map<String, String> mRequestHeaders;
 
-    public HttpWebRequest(URL requestURL, String requestMethod, HashMap<String, String> headers) {
+    public HttpWebRequest(URL requestURL, String requestMethod, Map<String, String> headers) {
         this(requestURL, requestMethod, headers, null, null);
     }
 
     public HttpWebRequest(
             URL requestURL,
             String requestMethod,
-            HashMap<String, String> headers,
+            Map<String, String> headers,
             byte[] requestContent,
             String requestContentType) {
         mUrl = requestURL;

--- a/src/src/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebRequest.java
@@ -32,72 +32,54 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import android.os.Build;
+import android.os.*;
+import android.os.Process;
 
 /**
  * Webrequest are called in background thread from API level. HttpWebRequest
  * does not create another thread.
  */
 class HttpWebRequest {
-    private static final String UNAUTHORIZED_ERROR_MESSAGE_PRE18 = "Received authentication challenge is null";
-
-    private static final String TAG = "HttpWebRequest";
-
     static final String REQUEST_METHOD_POST = "POST";
-
     static final String REQUEST_METHOD_GET = "GET";
-
-    static final String REQUEST_METHOD_PUT = "PUT";
-
-    static final String REQUEST_METHOD_DELETE = "DELETE";
-
-    static int CONNECT_TIME_OUT = AuthenticationSettings.INSTANCE.getConnectTimeOut();
-
-    private static int READ_TIME_OUT = AuthenticationSettings.INSTANCE.getReadTimeOut();
-
+    private static final String UNAUTHORIZED_ERROR_MESSAGE_PRE18 = "Received authentication challenge is null";
+    private static final String TAG = "HttpWebRequest";
+    private static final int CONNECT_TIME_OUT = AuthenticationSettings.INSTANCE.getConnectTimeOut();
+    private static final int READ_TIME_OUT = AuthenticationSettings.INSTANCE.getReadTimeOut();
     private static int sDebugSimulateDelay = 0;
-
     private boolean mUseCaches = false;
-
     private boolean mInstanceRedirectsFollow = true;
+    private final String mRequestMethod;
+    private final URL mUrl;
+    private final byte[] mRequestContent;
+    private final String mRequestContentType;
+    private final HashMap<String, String> mRequestHeaders;
 
-    private String mRequestMethod;
-
-    URL mUrl;
-
-    HttpURLConnection mConnection = null;
-
-    byte[] mRequestContent = null;
-
-    private String mRequestContentType = null;
-
-    int mTimeOut = CONNECT_TIME_OUT;
-
-    private IOException mException = null;
-
-    HashMap<String, String> mRequestHeaders = null;
-
-    public HttpWebRequest(URL requestURL) {
-        mUrl = requestURL;
-        mRequestHeaders = new HashMap<String, String>();
-        if (mUrl != null) {
-            mRequestHeaders.put("Host", getURLAuthority(mUrl));
-        }
+    public HttpWebRequest(URL requestURL, String requestMethod, HashMap<String, String> headers) {
+        this(requestURL, requestMethod, headers, null, null);
     }
 
-    public HttpWebRequest(URL requestURL, int timeout) {
+    public HttpWebRequest(
+            URL requestURL,
+            String requestMethod,
+            HashMap<String, String> headers,
+            byte[] requestContent,
+            String requestContentType) {
         mUrl = requestURL;
+        mRequestMethod = requestMethod;
         mRequestHeaders = new HashMap<String, String>();
         if (mUrl != null) {
             mRequestHeaders.put("Host", getURLAuthority(mUrl));
         }
-        mTimeOut = timeout;
+        mRequestHeaders.putAll(headers);
+        mRequestContent = requestContent;
+        mRequestContentType = requestContentType;
     }
 
     /**
      * setupConnection before sending the request.
      */
-    private void setupConnection() {
+    private HttpURLConnection setupConnection() throws IOException {
         Logger.v(TAG, "HttpWebRequest setupConnection thread:" + android.os.Process.myTid());
         if (mUrl == null) {
             throw new IllegalArgumentException("requestURL");
@@ -107,107 +89,103 @@ class HttpWebRequest {
             throw new IllegalArgumentException("requestURL");
         }
         HttpURLConnection.setFollowRedirects(true);
-        mConnection = openConnection();
+        final HttpURLConnection connection = (HttpURLConnection)mUrl.openConnection();
+        connection.setConnectTimeout(CONNECT_TIME_OUT);
         // To prevent EOF exception.
         if (Build.VERSION.SDK_INT > 13) {
-            mConnection.setRequestProperty("Connection", "close");
+            connection.setRequestProperty("Connection", "close");
         }
+
+        // Apply the request headers
+        final Iterator<String> headerKeys = mRequestHeaders.keySet().iterator();
+
+        while (headerKeys.hasNext()) {
+            String header = headerKeys.next();
+            Logger.v(TAG, "Setting header: " + header);
+            connection.setRequestProperty(header, mRequestHeaders.get(header));
+        }
+
+        // Avoid reuse of existing sockets to avoid random EOF errors
+        System.setProperty("http.keepAlive", "false");
+        connection.setReadTimeout(READ_TIME_OUT);
+        connection.setInstanceFollowRedirects(mInstanceRedirectsFollow);
+        connection.setUseCaches(mUseCaches);
+        connection.setRequestMethod(mRequestMethod);
+        connection.setDoInput(true); // it will at least read status
+                                     // code. Default is true.
+        setRequestBody(connection);
+
+        return connection;
     }
 
     /**
      * send the request.
-     * 
-     * @param contentType
      */
-    public HttpWebResponse send() {
-
-        Logger.v(TAG, "HttpWebRequest send thread:" + android.os.Process.myTid());
-        setupConnection();
-        HttpWebResponse response = new HttpWebResponse();
-
-        if (mConnection != null) {
-            try {
-                // Apply the request headers
-                final Iterator<String> headerKeys = mRequestHeaders.keySet().iterator();
-
-                while (headerKeys.hasNext()) {
-                    String header = headerKeys.next();
-                    Logger.v(TAG, "Setting header: " + header);
-                    mConnection.setRequestProperty(header, mRequestHeaders.get(header));
-                }
-
-                // Avoid reuse of existing sockets to avoid random EOF errors
-                System.setProperty("http.keepAlive", "false");
-                mConnection.setReadTimeout(READ_TIME_OUT);
-                mConnection.setInstanceFollowRedirects(mInstanceRedirectsFollow);
-                mConnection.setUseCaches(mUseCaches);
-                mConnection.setRequestMethod(mRequestMethod);
-                mConnection.setDoInput(true); // it will at least read status
-                                              // code. Default is true.
-                setRequestBody();
-
-                byte[] responseBody = null;
-                InputStream responseStream = null;
-
-                try {
-                    responseStream = mConnection.getInputStream();
-                } catch (IOException ex) {
-                    Logger.e(TAG, "IOException:" + ex.getMessage(), "", ADALError.SERVER_ERROR);
-                    // If it does not get the error stream, it will return
-                    // exception in the httpresponse
-                    responseStream = mConnection.getErrorStream();
-                    mException = ex;
-                }
-
-                // GET request should read status after getInputStream to make
-                // this work for different SDKs
-                getStatusCode(response);
-
-                if (responseStream != null) {
-
-                    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-                    byte[] buffer = new byte[4096];
-                    int bytesRead = -1;
-
-                    // Continue to read from stream if not cancelled and not EOF
-                    while ((bytesRead = responseStream.read(buffer)) > 0) {
-                        byteStream.write(buffer, 0, bytesRead);
-                    }
-
-                    responseBody = byteStream.toByteArray();
-                }
-
-                // It will only run in debugger and set from outside for testing
-                if (android.os.Debug.isDebuggerConnected() && sDebugSimulateDelay > 0) {
-                    // sleep background thread in debugging mode
-                    Logger.v(TAG, "Sleeping to simulate slow network response");
-                    Thread.sleep(sDebugSimulateDelay);
-                }
-
-                Logger.v(TAG, "Response is received");
-                response.setBody(responseBody);
-                response.setResponseHeaders(mConnection.getHeaderFields());
-            } catch (InterruptedException e) {
-                Logger.v(TAG, "Thread.sleep got interrupted exception " + e);
-            } catch (IOException e ) {
-                Logger.e(TAG, "IOException:" + e.getMessage(), " Method:" + mRequestMethod,
-                        ADALError.SERVER_ERROR, e);
-                mException = e;
-            } finally {
-                mConnection.disconnect();
-                mConnection = null;
-            }
+    public HttpWebResponse send() throws IOException {
+        Logger.v(TAG, "HttpWebRequest send thread:" + Process.myTid());
+        final HttpURLConnection connection = setupConnection();
+        if (connection == null) {
+            return null;
         }
 
-        response.setResponseException(mException);
+        final HttpWebResponse response;
+        try {
+            InputStream responseStream = null;
+            try {
+                responseStream = connection.getInputStream();
+            } catch (IOException ex) {
+                Logger.e(TAG, "IOException:" + ex.getMessage(), "", ADALError.SERVER_ERROR);
+                // If it does not get the error stream, it will return
+                // exception in the httpresponse
+                responseStream = connection.getErrorStream();
+                if (responseStream == null) {
+                    throw ex;
+                }
+            }
+
+            // GET request should read status after getInputStream to make
+            // this work for different SDKs
+            final int statusCode = getStatusCode(connection);
+            byte[] responseBody = null;
+            if (responseStream != null) {
+
+                ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+                byte[] buffer = new byte[4096];
+                int bytesRead = -1;
+
+                // Continue to read from stream if not cancelled and not EOF
+                while ((bytesRead = responseStream.read(buffer)) > 0) {
+                    byteStream.write(buffer, 0, bytesRead);
+                }
+
+                responseBody = byteStream.toByteArray();
+            }
+
+            // It will only run in debugger and set from outside for testing
+            if (Debug.isDebuggerConnected() && sDebugSimulateDelay > 0) {
+                // sleep background thread in debugging mode
+                Logger.v(TAG, "Sleeping to simulate slow network response");
+                try {
+                    Thread.sleep(sDebugSimulateDelay);
+                } catch (InterruptedException e) {
+                    Logger.v(TAG, "Thread.sleep got interrupted exception " + e);
+                }
+            }
+
+            Logger.v(TAG, "Response is received");
+            response = new HttpWebResponse(statusCode, responseBody, connection.getHeaderFields());
+        } finally {
+            connection.disconnect();
+        }
+
         return response;
     }
 
-    private void getStatusCode(HttpWebResponse response) throws IOException {
+    private int getStatusCode(HttpURLConnection connection) throws IOException {
         int statusCode = HttpURLConnection.HTTP_BAD_REQUEST;
 
         try {
-            statusCode = mConnection.getResponseCode();
+            statusCode = connection.getResponseCode();
         } catch (IOException ex) {
 
             if (Build.VERSION.SDK_INT < 16) {
@@ -223,7 +201,7 @@ class HttpWebRequest {
                 // Second time query will get the correct status.
                 // it will throw, if it is a different status related to
                 // connection problem
-                statusCode = mConnection.getResponseCode();
+                statusCode = connection.getResponseCode();
             }
 
             // if status is 200 or 401 after reading again, it can read the
@@ -233,42 +211,23 @@ class HttpWebRequest {
                 throw ex;
             }
         }
-        response.setStatusCode(statusCode);
         Logger.v(TAG, "Status code:" + statusCode);
+        return statusCode;
     }
 
-    /**
-     * open connection. If there is any error, set exception inside the response
-     * 
-     * @param _response
-     * @return
-     */
-    private HttpURLConnection openConnection() {
-        HttpURLConnection connection = null;
-        try {
-
-            connection = (HttpURLConnection)mUrl.openConnection();
-            connection.setConnectTimeout(mTimeOut);
-
-        } catch (IOException e) {
-            mException = e;
-        }
-        return connection;
-    }
-
-    private void setRequestBody() throws IOException {
+    private void setRequestBody(HttpURLConnection connection) throws IOException {
         if (null != mRequestContent) {
-            mConnection.setDoOutput(true);
+            connection.setDoOutput(true);
 
-            if (null != getRequestContentType() && !getRequestContentType().isEmpty()) {
-                mConnection.setRequestProperty("Content-Type", getRequestContentType());
+            if (null != mRequestContentType && !mRequestContentType.isEmpty()) {
+                connection.setRequestProperty("Content-Type", mRequestContentType);
             }
 
-            mConnection.setRequestProperty("Content-Length",
+            connection.setRequestProperty("Content-Length",
                     Integer.toString(mRequestContent.length));
-            mConnection.setFixedLengthStreamingMode(mRequestContent.length);
+            connection.setFixedLengthStreamingMode(mRequestContent.length);
 
-            OutputStream out = mConnection.getOutputStream();
+            OutputStream out = connection.getOutputStream();
             out.write(mRequestContent);
             out.close();
         }
@@ -291,35 +250,5 @@ class HttpWebRequest {
         }
 
         return authority;
-    }
-
-    /**
-     * The requests target URL.
-     */
-    URL getURL() {
-        return mUrl;
-    }
-
-    /**
-     * The request headers.
-     */
-    public HashMap<String, String> getRequestHeaders() {
-        return mRequestHeaders;
-    }
-
-    void setRequestMethod(String requestMethod) {
-        this.mRequestMethod = requestMethod;
-    }
-
-    String getRequestContentType() {
-        return mRequestContentType;
-    }
-
-    void setRequestContentType(String requestContentType) {
-        this.mRequestContentType = requestContentType;
-    }
-
-    void setRequestContent(byte[] data) {
-        this.mRequestContent = data;
     }
 }

--- a/src/src/com/microsoft/aad/adal/HttpWebResponse.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebResponse.java
@@ -33,12 +33,10 @@ import java.util.Map;
  */
 public class HttpWebResponse {
     private final int mStatusCode;
-    private final byte[] mResponseBody;
+    private final String mResponseBody;
     private final Map<String, List<String>> mResponseHeaders;
-    private final IOException mResponseException = null;
 
-    public HttpWebResponse(int statusCode, byte[] responseBody,
-            Map<String, List<String>> responseHeaders) {
+    public HttpWebResponse(int statusCode, String responseBody, Map<String, List<String>> responseHeaders) {
         mStatusCode = statusCode;
         mResponseBody = responseBody;
         mResponseHeaders = responseHeaders;
@@ -52,7 +50,7 @@ public class HttpWebResponse {
         return mResponseHeaders;
     }
 
-    public byte[] getBody() {
+    public String getBody() {
         return mResponseBody;
     }
 }

--- a/src/src/com/microsoft/aad/adal/HttpWebResponse.java
+++ b/src/src/com/microsoft/aad/adal/HttpWebResponse.java
@@ -32,15 +32,10 @@ import java.util.Map;
  * Web response to keep status, response body, headers and related exceptions.
  */
 public class HttpWebResponse {
-    private int mStatusCode;
-    private byte[] mResponseBody;
-    private Map<String, List<String>> mResponseHeaders;
-    private IOException mResponseException = null;
-
-    public HttpWebResponse() {
-        mStatusCode = HttpURLConnection.HTTP_OK;
-        mResponseBody = null;
-    }
+    private final int mStatusCode;
+    private final byte[] mResponseBody;
+    private final Map<String, List<String>> mResponseHeaders;
+    private final IOException mResponseException = null;
 
     public HttpWebResponse(int statusCode, byte[] responseBody,
             Map<String, List<String>> responseHeaders) {
@@ -49,39 +44,15 @@ public class HttpWebResponse {
         mResponseHeaders = responseHeaders;
     }
 
-    public IOException getResponseException() {
-        return mResponseException;
-    }
-
-    public void setResponseException(IOException responseException) {
-        this.mResponseException = responseException;
-    }
-
-    HttpWebResponse(int statusCode) {
-        mStatusCode = statusCode;
-    }
-
     public int getStatusCode() {
         return mStatusCode;
-    }
-
-    public void setStatusCode(int status) {
-        mStatusCode = status;
     }
 
     public Map<String, List<String>> getResponseHeaders() {
         return mResponseHeaders;
     }
 
-    public void setResponseHeaders(Map<String, List<String>> headers) {
-        mResponseHeaders = headers;
-    }
-
     public byte[] getBody() {
         return mResponseBody;
-    }
-
-    public void setBody(byte[] body) {
-        mResponseBody = body;
     }
 }

--- a/src/src/com/microsoft/aad/adal/IWebRequestHandler.java
+++ b/src/src/com/microsoft/aad/adal/IWebRequestHandler.java
@@ -25,16 +25,16 @@ package com.microsoft.aad.adal;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
  * Webrequest interface to send web requests.
  */
 public interface IWebRequestHandler {
-    HttpWebResponse sendGet(URL url, HashMap<String, String> headers) throws IOException;
+    HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException;
 
-    HttpWebResponse sendPost(URL url, HashMap<String, String> headers, byte[] content,
+    HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
             String contentType) throws IOException;
 
     public void setRequestCorrelationId(UUID mRequestCorrelationId);

--- a/src/src/com/microsoft/aad/adal/IWebRequestHandler.java
+++ b/src/src/com/microsoft/aad/adal/IWebRequestHandler.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.UUID;
@@ -31,10 +32,10 @@ import java.util.UUID;
  * Webrequest interface to send web requests.
  */
 public interface IWebRequestHandler {
-    HttpWebResponse sendGet(URL url, HashMap<String, String> headers);
+    HttpWebResponse sendGet(URL url, HashMap<String, String> headers) throws IOException;
 
     HttpWebResponse sendPost(URL url, HashMap<String, String> headers, byte[] content,
-            String contentType);
+            String contentType) throws IOException;
 
     public void setRequestCorrelationId(UUID mRequestCorrelationId);
 }

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -572,7 +572,7 @@ class Oauth2 {
      * @param webResponse
      * @return
      */
-    private AuthenticationResult processTokenResponse(HttpWebResponse webResponse) throws AuthenticationException {
+    private AuthenticationResult processTokenResponse(HttpWebResponse webResponse){
         AuthenticationResult result;
         String correlationIdInHeader = null;
         if (webResponse.getResponseHeaders() != null
@@ -593,13 +593,16 @@ class Oauth2 {
         case HttpURLConnection.HTTP_UNAUTHORIZED:
             try {
                 result = parseJsonResponse(webResponse.getBody());
-            } catch (JSONException e) {
-                throw new AuthenticationException(ADALError.SERVER_INVALID_JSON_RESPONSE, "Can't parse server response " + webResponse.getBody(), e);
+            } catch (JSONException jsonException) {
+                Logger.e(TAG, jsonException.getMessage(), "", ADALError.SERVER_INVALID_JSON_RESPONSE, jsonException);
+                result = new AuthenticationResult(JSON_PARSING_ERROR, jsonException.getMessage(), null);
             }
 
         break;
-        default: 
-            throw new AuthenticationException(ADALError.SERVER_ERROR, "Unexpected server response " + webResponse.getBody());
+        default:
+            Logger.e(TAG, "Server response", webResponse.getBody(), ADALError.SERVER_ERROR);
+            result = new AuthenticationResult(String.valueOf(webResponse.getStatusCode()),
+                    webResponse.getBody(), null);
         }
 
         // Set correlationId in the result

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -193,7 +193,7 @@ class Oauth2 {
 
     public static AuthenticationResult processUIResponseParams(HashMap<String, String> response) {
 
-        AuthenticationResult result = null;
+        final AuthenticationResult result;
 
         // Protocol error related
         if (response.containsKey(AuthenticationConstants.OAuth2.ERROR)) {
@@ -272,6 +272,8 @@ class Oauth2 {
             
             //Set family client id on authentication result for TokenCacheItem to pick up
             result.setFamilyClientId(familyClientId);
+        } else {
+            result = null;
         }
 
         return result;
@@ -454,9 +456,8 @@ class Oauth2 {
 
     private AuthenticationResult postMessage(String requestMessage, HashMap<String, String> headers)
             throws IOException, AuthenticationException {
-        URL authority = null;
         AuthenticationResult result = null;
-        authority = StringExtensions.getUrl(getTokenEndpoint());
+        final URL authority = StringExtensions.getUrl(getTokenEndpoint());
         if (authority == null) {
             throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL);
         }
@@ -504,7 +505,6 @@ class Oauth2 {
                                 "Challenge header is empty");
                     }
                 } else {
-
                     // AAD server returns 401 response for wrong request
                     // messages
                     Logger.v(TAG, "401 http status code is returned without authorization header");
@@ -514,7 +514,6 @@ class Oauth2 {
             byte[] bodyMessage = response.getBody();
             boolean isBodyEmpty = bodyMessage == null || bodyMessage.length == 0;
             if (!isBodyEmpty) {
-
                 // Protocol related errors will read the error stream and report
                 // the error and error description
                 Logger.v(TAG, "Token request does not have exception");
@@ -525,11 +524,7 @@ class Oauth2 {
                 // non-protocol related error
                 String errMessage = isBodyEmpty ? "Status code:" + response.getStatusCode() : new String(bodyMessage);
                 Logger.e(TAG, "Server error message", errMessage, ADALError.SERVER_ERROR);
-                if (response.getResponseException() != null) {
-                    throw response.getResponseException();
-                } else {
-                    throw new AuthenticationException(ADALError.SERVER_ERROR, errMessage);
-                }
+                throw new AuthenticationException(ADALError.SERVER_ERROR, errMessage);
             } else {
                 ClientMetrics.INSTANCE.setLastErrorCodes(result.getErrorCodes());
             }

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -593,7 +593,7 @@ class Oauth2 {
         case HttpURLConnection.HTTP_UNAUTHORIZED:
             try {
                 result = parseJsonResponse(webResponse.getBody());
-            } catch (JSONException jsonException) {
+            } catch (final JSONException jsonException) {
                 Logger.e(TAG, jsonException.getMessage(), "", ADALError.SERVER_INVALID_JSON_RESPONSE, jsonException);
                 result = new AuthenticationResult(JSON_PARSING_ERROR, jsonException.getMessage(), null);
             }

--- a/src/src/com/microsoft/aad/adal/WebRequestHandler.java
+++ b/src/src/com/microsoft/aad/adal/WebRequestHandler.java
@@ -26,6 +26,7 @@ package com.microsoft.aad.adal;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import com.microsoft.aad.adal.AuthenticationConstants.AAD;
@@ -61,19 +62,19 @@ public class WebRequestHandler implements IWebRequestHandler {
     }
 
     @Override
-    public HttpWebResponse sendGet(URL url, HashMap<String, String> headers) throws IOException {
+    public HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException {
         Logger.v(TAG, "WebRequestHandler thread" + android.os.Process.myTid());
 
-        HttpWebRequest request = new HttpWebRequest(url, HttpWebRequest.REQUEST_METHOD_GET, updateHeaders(headers));
+        final HttpWebRequest request = new HttpWebRequest(url, HttpWebRequest.REQUEST_METHOD_GET, updateHeaders(headers));
         return request.send();
     }
 
     @Override
-    public HttpWebResponse sendPost(URL url, HashMap<String, String> headers, byte[] content,
+    public HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
             String contentType) throws IOException {
         Logger.v(TAG, "WebRequestHandler thread" + android.os.Process.myTid());
 
-        HttpWebRequest request = new HttpWebRequest(
+        final HttpWebRequest request = new HttpWebRequest(
                 url,
                 HttpWebRequest.REQUEST_METHOD_POST,
                 updateHeaders(headers),
@@ -82,7 +83,7 @@ public class WebRequestHandler implements IWebRequestHandler {
         return request.send();
     }
 
-    private HashMap<String, String> updateHeaders(HashMap<String, String> headers) {
+    private Map<String, String> updateHeaders(Map<String, String> headers) {
 
         if (headers == null) {
             headers = new HashMap<>();

--- a/src/src/com/microsoft/aad/adal/WebRequestHandler.java
+++ b/src/src/com/microsoft/aad/adal/WebRequestHandler.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.UUID;
@@ -60,40 +61,31 @@ public class WebRequestHandler implements IWebRequestHandler {
     }
 
     @Override
-    public HttpWebResponse sendGet(URL url, HashMap<String, String> headers) {
+    public HttpWebResponse sendGet(URL url, HashMap<String, String> headers) throws IOException {
         Logger.v(TAG, "WebRequestHandler thread" + android.os.Process.myTid());
 
-        HttpWebRequest request = new HttpWebRequest(url);
-        request.setRequestMethod(HttpWebRequest.REQUEST_METHOD_GET);
-        headers = updateHeaders(headers);
-        addHeadersToRequest(headers, request);
+        HttpWebRequest request = new HttpWebRequest(url, HttpWebRequest.REQUEST_METHOD_GET, updateHeaders(headers));
         return request.send();
     }
 
     @Override
     public HttpWebResponse sendPost(URL url, HashMap<String, String> headers, byte[] content,
-            String contentType) {
+            String contentType) throws IOException {
         Logger.v(TAG, "WebRequestHandler thread" + android.os.Process.myTid());
 
-        HttpWebRequest request = new HttpWebRequest(url);
-        request.setRequestMethod(HttpWebRequest.REQUEST_METHOD_POST);
-        request.setRequestContentType(contentType);
-        request.setRequestContent(content);
-        headers = updateHeaders(headers);
-        addHeadersToRequest(headers, request);
+        HttpWebRequest request = new HttpWebRequest(
+                url,
+                HttpWebRequest.REQUEST_METHOD_POST,
+                updateHeaders(headers),
+                content,
+                contentType);
         return request.send();
-    }
-
-    private void addHeadersToRequest(HashMap<String, String> headers, HttpWebRequest request) {
-        if (headers != null && !headers.isEmpty()) {
-            request.getRequestHeaders().putAll(headers);
-        }
     }
 
     private HashMap<String, String> updateHeaders(HashMap<String, String> headers) {
 
         if (headers == null) {
-            headers = new HashMap<String, String>();
+            headers = new HashMap<>();
         }
 
         if (mRequestCorrelationId != null) {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationActivityUnitTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationActivityUnitTest.java
@@ -459,9 +459,8 @@ public class AuthenticationActivityUnitTest extends ActivityUnitTestCase<Authent
         String json = "{\"id_token\":"
                 + idToken
                 + ",\"access_token\":\"TokentestBroker\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
         ReflectionUtils.setFieldValue(activity, "mWebRequestHandler", webrequest);
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         return webrequest;
     }
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -762,8 +762,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
                 + id
                 + "\",\"token_type\":\"Bearer\",\"expires_in\":\"29344\",\"expires_on\":\"1368768616\",\"refresh_token\":\""
                 + refreshToken + "\",\"scope\":\"*\",\"id_token\":\"" + TEST_IDTOKEN + "\"}";
-        mockWebRequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        mockWebRequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", mockWebRequest);
         return mockWebRequest;
     }
@@ -1032,8 +1031,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         String json = "{\"id_token\":\""
                 + TEST_IDTOKEN
                 + "\",\"access_token\":\"TokenFortestRefreshTokenPositive\",\"token_type\":\"Bearer\",\"expires_in\":\"-10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
         // Call acquire token which will try refresh token based on cache
@@ -1048,8 +1046,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         json = "{\"id_token\":\""
                 + TEST_IDTOKEN
                 + "\",\"access_token\":\"TokenReturnsWithIdToken\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refreshABC\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         AuthenticationResult result = context.acquireTokenSilentSync("resource", "clientid",
                 TEST_IDTOKEN_USERID);
@@ -1090,8 +1087,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         String json = "{\"id_token\":\""
                 + idtoken.getIdToken()
                 + "\",\"access_token\":\"TokenUserIdTest\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         Intent intent = getResponseIntent(callback, "resource", "clientid", "redirectUri",
                 responseIntentHint);
@@ -1151,8 +1147,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         String json = "{\"id_token\":\""
                 + idtoken.getIdToken()
                 + "\",\"access_token\":\"TokenUserIdTest\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         Intent intent = getResponseIntent(callback, "resource", "clientid", "redirectUri",
                 loginHint);
@@ -1196,8 +1191,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         MockAuthenticationCallback callback = new MockAuthenticationCallback(signalCallback);
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String json = "{\"access_token\":\"TokenUserIdTest\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         Intent intent = getResponseIntent(callback, "resource", "clientid", "redirectUri", null);
 
@@ -1247,8 +1241,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         String json = "{\"id_token\":\""
                 + TEST_IDTOKEN
                 + "\",\"access_token\":\"TokenFortestRefreshTokenPositive\",\"token_type\":\"Bearer\",\"expires_in\":\"-10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\",\"foci\":\"familyClientId\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
         // Call acquire token which will try refresh token based on cache
@@ -1265,8 +1258,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         json = "{\"id_token\":\""
                 + TEST_IDTOKEN
                 + "\",\"access_token\":\"I am a new access token\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"I am a new refresh token\",\"scope\":\"*\",\"foci\":\"familyClientId\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         AuthenticationResult result = context.acquireTokenSilentSync("resource", "clientid",
                 TEST_IDTOKEN_USERID);
@@ -1310,8 +1302,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         final String json = "{\"id_token\":\""
                 + TEST_IDTOKEN
                 + "\",\"access_token\":\"I am a new access token\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"I am a new refresh token\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         
         final String anotherClientId = "clientId2";
@@ -1353,7 +1344,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         
         // Do silent token request and return idtoken in the result
         String responseBody = "{\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70000: Authentication failed. Refresh Token is not valid.\r\nTrace ID: bb27293d-74e4-4390-882b-037a63429026\r\nCorrelation ID: b73106d5-419b-4163-8bc6-d2c18f1b1a13\r\nTimestamp: 2014-11-06 18:39:47Z\",\"error_codes\":[70000],\"timestamp\":\"2014-11-06 18:39:47Z\",\"trace_id\":\"bb27293d-74e4-4390-882b-037a63429026\",\"correlation_id\":\"b73106d5-419b-4163-8bc6-d2c18f1b1a13\",\"submit_url\":null,\"context\":null}";
-        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody.getBytes(), null));
+        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
         
         final String anotherClientId = "clientId2";
@@ -1439,8 +1430,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         testActivity.mSignal = signal;
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String json = "{\"access_token\":\"TokenFortestRefreshTokenPositive\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
         // Call refresh token in silent API method
@@ -1464,7 +1454,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         testActivity.mSignal = signal;
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String responseBody = "{\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70000: Authentication failed. Refresh Token is not valid.\r\nTrace ID: bb27293d-74e4-4390-882b-037a63429026\r\nCorrelation ID: b73106d5-419b-4163-8bc6-d2c18f1b1a13\r\nTimestamp: 2014-11-06 18:39:47Z\",\"error_codes\":[70000],\"timestamp\":\"2014-11-06 18:39:47Z\",\"trace_id\":\"bb27293d-74e4-4390-882b-037a63429026\",\"correlation_id\":\"b73106d5-419b-4163-8bc6-d2c18f1b1a13\",\"submit_url\":null,\"context\":null}";
-        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody.getBytes(), null));
+        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
         // Call refresh token in silent API method
@@ -2182,7 +2172,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String responseBody = getErrorResponseBody("invalid_grant");
-        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody.getBytes(), null));
+        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);        
 
         try {     
@@ -2211,7 +2201,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String responseBody = getErrorResponseBody(null);
-        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody.getBytes(), null));
+        webrequest.setReturnResponse(new HttpWebResponse(400, responseBody, null));
         ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
         try {
@@ -2242,7 +2232,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
 
          MockWebRequestHandler webrequest = new MockWebRequestHandler();
          String responseBody = getErrorResponseBody("interaction_required");
-         webrequest.setReturnResponse(new HttpWebResponse(400, responseBody.getBytes(), null));
+         webrequest.setReturnResponse(new HttpWebResponse(400, responseBody, null));
          ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
          try {
@@ -2276,7 +2266,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
          MockAuthenticationCallback callback = new MockAuthenticationCallback(signalCallback);
          MockWebRequestHandler webrequest = new MockWebRequestHandler();
          String responseBody = getErrorResponseBody("interaction_required");
-         webrequest.setReturnResponse(new HttpWebResponse(400, responseBody.getBytes(), null));
+         webrequest.setReturnResponse(new HttpWebResponse(400, responseBody, null));
          ReflectionUtils.setFieldValue(context, "mWebRequest", webrequest);
 
          context.acquireToken(testActivity, "resource", "clientId", "redirect", TEST_IDTOKEN_UPN,

--- a/tests/Functional/src/com/microsoft/aad/adal/test/DiscoveryTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/DiscoveryTests.java
@@ -120,8 +120,7 @@ public class DiscoveryTests extends AndroidTestHelper {
     private IWebRequestHandler getMockRequest(String json, int statusCode) {
         MockWebRequestHandler mockWebRequest = new MockWebRequestHandler();
 
-        mockWebRequest.setReturnResponse(new HttpWebResponse(statusCode, json.getBytes(Charset
-                .defaultCharset()), null));
+        mockWebRequest.setReturnResponse(new HttpWebResponse(statusCode, json, null));
         return mockWebRequest;
     }
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
@@ -26,11 +26,8 @@ package com.microsoft.aad.adal.test;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
-
-import com.microsoft.aad.adal.HttpWebResponse;
-import com.microsoft.aad.adal.IWebRequestHandler;
 
 import junit.framework.Assert;
 
@@ -45,14 +42,14 @@ class MockWebRequestHandler implements IWebRequestHandler {
 
     private UUID mCorrelationId;
 
-    private HashMap<String, String> mRequestHeaders;
+    private Map<String, String> mRequestHeaders;
 
     private HttpWebResponse mReturnResponse;
 
     private String mReturnException;
 
     @Override
-    public HttpWebResponse sendGet(URL url, HashMap<String, String> headers) throws IOException {
+    public HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException {
         mRequestUrl = url;
         mRequestHeaders = headers;
         if (mReturnException != null) {
@@ -63,7 +60,7 @@ class MockWebRequestHandler implements IWebRequestHandler {
     }
 
     @Override
-    public HttpWebResponse sendPost(URL url, HashMap<String, String> headers, byte[] content,
+    public HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
             String contentType) throws IOException {
         mRequestUrl = url;
         mRequestHeaders = headers;
@@ -88,7 +85,7 @@ class MockWebRequestHandler implements IWebRequestHandler {
         return mRequestUrl;
     }
 
-    public HashMap<String, String> getRequestHeaders() {
+    public Map<String, String> getRequestHeaders() {
         return mRequestHeaders;
     }
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal.test;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.HashMap;
@@ -51,7 +52,7 @@ class MockWebRequestHandler implements IWebRequestHandler {
     private String mReturnException;
 
     @Override
-    public HttpWebResponse sendGet(URL url, HashMap<String, String> headers) {
+    public HttpWebResponse sendGet(URL url, HashMap<String, String> headers) throws IOException {
         mRequestUrl = url;
         mRequestHeaders = headers;
         if (mReturnException != null) {
@@ -63,7 +64,7 @@ class MockWebRequestHandler implements IWebRequestHandler {
 
     @Override
     public HttpWebResponse sendPost(URL url, HashMap<String, String> headers, byte[] content,
-            String contentType) {
+            String contentType) throws IOException {
         mRequestUrl = url;
         mRequestHeaders = headers;
         if (content != null) {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -454,7 +455,7 @@ public class OauthTests extends AndroidTestCase {
     public void testRefreshTokenWebResponse_DeviceChallenge_Positive()
             throws IllegalArgumentException, ClassNotFoundException, NoSuchMethodException,
             InstantiationException, IllegalAccessException, InvocationTargetException,
-            NoSuchAlgorithmException, MalformedURLException, AuthenticationException {
+            NoSuchAlgorithmException, IOException, AuthenticationException {
         getContext().getCacheDir();
         System.setProperty("dexmaker.dexcache", getContext().getCacheDir().getPath());
         
@@ -509,7 +510,7 @@ public class OauthTests extends AndroidTestCase {
     public void testRefreshTokenWebResponse_DeviceChallenge_Header_Empty()
             throws IllegalArgumentException, ClassNotFoundException, NoSuchMethodException,
             InstantiationException, IllegalAccessException, InvocationTargetException,
-            NoSuchAlgorithmException, MalformedURLException {
+            NoSuchAlgorithmException, IOException {
         IWebRequestHandler mockWebRequest = mock(IWebRequestHandler.class);
         HashMap<String, List<String>> headers = getHeader(
                 AuthenticationConstants.Broker.CHALLENGE_REQUEST_HEADER, " ");

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -67,6 +67,10 @@ import android.test.AndroidTestCase;
 import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Base64;
 
+import junit.framework.Assert;
+
+import org.json.JSONException;
+
 @SuppressLint("TrulyRandom")
 public class OauthTests extends AndroidTestCase {
 
@@ -90,7 +94,7 @@ public class OauthTests extends AndroidTestCase {
         assertEquals("idpProvider", ReflectionUtils.getFieldValue(actual, "mIdentityProvider"));
         assertEquals("53c6acf2-2742-4538-918d-e78257ec8516",
                 ReflectionUtils.getFieldValue(actual, "mObjectId"));
-        assertTrue(1387227772 == (Long)ReflectionUtils.getFieldValue(actual, "mPasswordExpiration"));
+        assertTrue(1387227772 == (Long) ReflectionUtils.getFieldValue(actual, "mPasswordExpiration"));
         assertEquals("pwdUrl", ReflectionUtils.getFieldValue(actual, "mPasswordChangeUrl"));
     }
 
@@ -435,8 +439,7 @@ public class OauthTests extends AndroidTestCase {
             IllegalAccessException, InvocationTargetException {
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String json = "{\"access_token\":\"sometokenhere\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refreshfasdfsdf435\",\"scope\":\"*\"}";
-        webrequest.setReturnResponse(new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null));
+        webrequest.setReturnResponse(new HttpWebResponse(200, json, null));
 
         // send request
         MockAuthenticationCallback testResult = refreshToken(getValidAuthenticationRequest(),
@@ -484,8 +487,7 @@ public class OauthTests extends AndroidTestCase {
         HashMap<String, List<String>> headers = getHeader(
                 AuthenticationConstants.Broker.CHALLENGE_REQUEST_HEADER, challengeHeaderValue);
         HttpWebResponse responeChallenge = new HttpWebResponse(401, null, headers);
-        HttpWebResponse responseValid = new HttpWebResponse(200,
-                tokenPositiveResponse.getBytes(Charset.defaultCharset()), null);
+        HttpWebResponse responseValid = new HttpWebResponse(200, tokenPositiveResponse, null);
         // first call returns 401 and second call returns token
         when(
                 mockWebRequest.sendPost(eq(new URL(TEST_AUTHORITY + "/oauth2/token")),
@@ -545,8 +547,7 @@ public class OauthTests extends AndroidTestCase {
         String json = "{\"id_token\":\""
                 + idToken
                 + "\",\"access_token\":\"sometokenhere2343=\",\"token_type\":\"Bearer\",\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refreshfasdfsdf435=\",\"scope\":\"*\"}";
-        HttpWebResponse mockResponse = new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null);
+        HttpWebResponse mockResponse = new HttpWebResponse(200, json, null);
 
         // send call with mocks
         AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
@@ -572,8 +573,7 @@ public class OauthTests extends AndroidTestCase {
         listOfHeaders.add(UUID.randomUUID().toString());
         HashMap<String, List<String>> headers = new HashMap<String, List<String>>();
         headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, listOfHeaders);
-        HttpWebResponse mockResponse = new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), headers);
+        HttpWebResponse mockResponse = new HttpWebResponse(200, json, headers);
         TestLogResponse logResponse = new TestLogResponse();
         logResponse.listenForLogMessage("CorrelationId is not matching", null);
 
@@ -589,7 +589,7 @@ public class OauthTests extends AndroidTestCase {
         List<String> invalidHeaders = new ArrayList<String>();
         invalidHeaders.add("invalid-UUID");
         headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, invalidHeaders);
-        mockResponse = new HttpWebResponse(200, json.getBytes(Charset.defaultCharset()), headers);
+        mockResponse = new HttpWebResponse(200, json, headers);
         TestLogResponse logResponse2 = new TestLogResponse();
         logResponse2.listenLogForMessageSegments("Wrong format of the correlation ID:");
 
@@ -611,15 +611,18 @@ public class OauthTests extends AndroidTestCase {
         Method m = ReflectionUtils.getTestMethod(oauth, "processTokenResponse",
                 Class.forName("com.microsoft.aad.adal.HttpWebResponse"));
         String json = "{invalid";
-        HttpWebResponse mockResponse = new HttpWebResponse(200, json.getBytes(Charset
-                .defaultCharset()), null);
+        HttpWebResponse mockResponse = new HttpWebResponse(200, json, null);
 
         // send call with mocks
-        AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
-
-        // verify same token
-        assertEquals("Same token in parsed result", "It failed to parse response as json",
-                result.getErrorCode());
+        try {
+            AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
+            fail("must throw exception");
+        } catch (InvocationTargetException e) {
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof AuthenticationException);
+            AuthenticationException cause = (AuthenticationException)e.getCause();
+            assertEquals(cause.getCode(), ADALError.SERVER_INVALID_JSON_RESPONSE);
+        }
     }
 
     @SmallTest

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -614,15 +614,12 @@ public class OauthTests extends AndroidTestCase {
         HttpWebResponse mockResponse = new HttpWebResponse(200, json, null);
 
         // send call with mocks
-        try {
-            AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
-            fail("must throw exception");
-        } catch (InvocationTargetException e) {
-            assertNotNull(e.getCause());
-            assertTrue(e.getCause() instanceof AuthenticationException);
-            AuthenticationException cause = (AuthenticationException)e.getCause();
-            assertEquals(cause.getCode(), ADALError.SERVER_INVALID_JSON_RESPONSE);
-        }
+        AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
+
+        // verify same token
+        assertEquals("Same token in parsed result", "It failed to parse response as json",
+                result.getErrorCode());
+
     }
 
     @SmallTest


### PR DESCRIPTION
There is no functionality changes, but I think it adds readability to code:
make private variable final when it initialized in constructor and won't be changed
remove extra setters and getters
separates function that refreshes token and updates cache
extract logic that sets up http connection
throw IO exception in send method instead of storing it in response and throwing later (as practice shows this type logic can cause bugs by forgetting to throw this exception)
fix leaks in unclosed streams