### PR TITLE
Checking private key before doing unwrap

### DIFF
--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -40,6 +40,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
@@ -452,7 +453,8 @@ public class StorageHelper {
             // the key data is wiped, if this is the case, the retrieved keypair will
             // be empty, and when we use the private key to do unwrap, we'll encounter 
             // IllegalArgumentException
-            if (mKeyPair.getPrivate() == null || mKeyPair.getPrivate().getEncoded().length == 0) {
+            final PrivateKey privateKey = mKeyPair.getPrivate();
+            if (privateKey == null || privateKey.getEncoded() == null || privateKey.getEncoded().length == 0) {
                 throw new UnrecoverableKeyException("Retrieved private key is empty.");
             }
             

--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -31,9 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.GeneralSecurityException;
@@ -47,7 +44,6 @@ import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -450,6 +446,16 @@ public class StorageHelper {
             if (encryptedKey == null || encryptedKey.length == 0) {
                 throw new UnrecoverableKeyException("Couldn't find encrypted key in file");
             }
+            
+            // Check if the retrieved keypair is empty. With the current limitation of 
+            // AndroidKeyStore, there is possibility that the alias is not wiped but 
+            // the key data is wiped, if this is the case, the retrieved keypair will
+            // be empty, and when we use the private key to do unwrap, we'll encounter 
+            // IllegalArgumentException
+            if (mKeyPair.getPrivate() == null || mKeyPair.getPrivate().getEncoded().length == 0) {
+                throw new UnrecoverableKeyException("Retrieved private key is empty.");
+            }
+            
             sSecretKeyFromAndroidKeyStore = unwrap(wrapCipher, encryptedKey);
             Logger.v(TAG, "Finished reading SecretKey");
         } catch (GeneralSecurityException | IOException ex) {


### PR DESCRIPTION
When key data is wiped by android keystore but alias is not, we may get InvalidArgumentException thrown, to avoid crashing the app, check if private key used to do unwrap is empty or now. If it's already empty, shouldn't bother continuing with unwrap.