### PR TITLE
If server responded with some unknown error do not force user to sign…

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1458,6 +1458,9 @@ public class AuthenticationContext {
             if (!request.isSilent() && (activity != null || useDialog)) {
                 acquireTokenInteractively(callbackHandle, activity, request, useDialog);
             } else {
+                // TODO: investigate which server response actually should force user to sign in again
+                // and which error actually should just notify user that some resource require extra steps
+
                 final String errorInfo = authResult == null ? "" : authResult.getErrorLogInfo();
                 // User does not want to launch activity
                 Logger.e(TAG, "Prompt is not allowed and failed to get token:", request.getLogInfo() + " " + errorInfo,

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -572,7 +572,7 @@ class Oauth2 {
      * @param webResponse
      * @return
      */
-    private AuthenticationResult processTokenResponse(HttpWebResponse webResponse){
+    private AuthenticationResult processTokenResponse(HttpWebResponse webResponse) throws AuthenticationException {
         AuthenticationResult result;
         String correlationIdInHeader = null;
         if (webResponse.getResponseHeaders() != null
@@ -594,15 +594,12 @@ class Oauth2 {
             try {
                 result = parseJsonResponse(webResponse.getBody());
             } catch (final JSONException jsonException) {
-                Logger.e(TAG, jsonException.getMessage(), "", ADALError.SERVER_INVALID_JSON_RESPONSE, jsonException);
-                result = new AuthenticationResult(JSON_PARSING_ERROR, jsonException.getMessage(), null);
+                throw new AuthenticationException(ADALError.SERVER_INVALID_JSON_RESPONSE, "Can't parse server response " + webResponse.getBody(), jsonException);
             }
 
         break;
-        default:
-            Logger.e(TAG, "Server response", webResponse.getBody(), ADALError.SERVER_ERROR);
-            result = new AuthenticationResult(String.valueOf(webResponse.getStatusCode()),
-                    webResponse.getBody(), null);
+        default: 
+            throw new AuthenticationException(ADALError.SERVER_ERROR, "Unexpected server response " + webResponse.getBody());
         }
 
         // Set correlationId in the result

--- a/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/OauthTests.java
@@ -614,12 +614,15 @@ public class OauthTests extends AndroidTestCase {
         HttpWebResponse mockResponse = new HttpWebResponse(200, json, null);
 
         // send call with mocks
-        AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
-
-        // verify same token
-        assertEquals("Same token in parsed result", "It failed to parse response as json",
-                result.getErrorCode());
-
+        try {
+            AuthenticationResult result = (AuthenticationResult)m.invoke(oauth, mockResponse);
+            fail("must throw exception");
+        } catch (InvocationTargetException e) {
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof AuthenticationException);
+            AuthenticationException cause = (AuthenticationException)e.getCause();
+            assertEquals(cause.getCode(), ADALError.SERVER_INVALID_JSON_RESPONSE);
+        }
     }
 
     @SmallTest


### PR DESCRIPTION
… in again

All unknown server responses should be recoverable and we shouldn't require UI prompt in case of server failures

What about specific server responses it's questionable how library should behave. Added todo as we need to discuss it with server team and decide what we want to do.