### PR TITLE
HOTFIX: revert Checking private key before doing unwrap #593

### DIFF
--- a/src/src/com/microsoft/aad/adal/StorageHelper.java
+++ b/src/src/com/microsoft/aad/adal/StorageHelper.java
@@ -448,16 +448,6 @@ public class StorageHelper {
                 throw new UnrecoverableKeyException("Couldn't find encrypted key in file");
             }
             
-            // Check if the retrieved keypair is empty. With the current limitation of 
-            // AndroidKeyStore, there is possibility that the alias is not wiped but 
-            // the key data is wiped, if this is the case, the retrieved keypair will
-            // be empty, and when we use the private key to do unwrap, we'll encounter 
-            // IllegalArgumentException
-            final PrivateKey privateKey = mKeyPair.getPrivate();
-            if (privateKey == null || privateKey.getEncoded() == null || privateKey.getEncoded().length == 0) {
-                throw new UnrecoverableKeyException("Retrieved private key is empty.");
-            }
-            
             sSecretKeyFromAndroidKeyStore = unwrap(wrapCipher, encryptedKey);
             Logger.v(TAG, "Finished reading SecretKey");
         } catch (GeneralSecurityException | IOException ex) {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/StorageHelperTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/StorageHelperTests.java
@@ -54,7 +54,7 @@ public class StorageHelperTests extends AndroidTestHelper {
         super.setUp();
 
         Log.d(TAG, "setup key at settings");
-        if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
+        if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null && Build.VERSION.SDK_INT < 18) {
             // use same key for tests
             SecretKeyFactory keyFactory = SecretKeyFactory
                     .getInstance("PBEWithSHA256And256BitAES-CBC-BC");
@@ -264,7 +264,6 @@ public class StorageHelperTests extends AndroidTestHelper {
         if (Build.VERSION.SDK_INT < 18) {
             return;
         }
-
         final Context context = getInstrumentation().getTargetContext();
         final StorageHelper storageHelper = new StorageHelper(context);
         KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");


### PR DESCRIPTION
This exception happens too frequently.
I fixed UTs for keyStore and test around keystore actually fails because of this exception, so 
privateKey.getEncoded() might be null, but  unwrap method works just fine with that
It means that we currently removing good tokens that were encrypted with keystore key
I think we need to revert and hotfix it