### PR TITLE
update datetime format for pasing datestring if it does not contaim A…

### DIFF
--- a/src/src/com/microsoft/aad/adal/DateTimeAdapter.java
+++ b/src/src/com/microsoft/aad/adal/DateTimeAdapter.java
@@ -84,6 +84,16 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
             JsonDeserializationContext context) throws JsonParseException {
         String jsonString = json.getAsString();
 
+        // Datetime string is serialized with iso8601 format by default, should
+        // always try to deserialize with iso8601. But to support the backward
+        // compatibility, we also need to deserialize with old format if failing
+        // with iso8601. 
+        try {
+            return iso8601Format.parse(jsonString);
+        } catch (final ParseException ignored) {
+        }
+        
+        // fallback logic for old date format parsing. 
         try {
             return localFormat.parse(jsonString);
         } catch (final ParseException ignored) {
@@ -101,12 +111,7 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
 
         try {
             return enUs24HourFormat.parse(jsonString);
-        } catch (final ParseException ignored) {
-        }
-
-        try {
-            return iso8601Format.parse(jsonString);
-        } catch (ParseException e) {
+        } catch (final ParseException e) {
             Logger.e(TAG, "Could not parse date: " + e.getMessage(), "",
                     ADALError.DATE_PARSING_FAILURE, e);
         }

--- a/src/src/com/microsoft/aad/adal/DateTimeAdapter.java
+++ b/src/src/com/microsoft/aad/adal/DateTimeAdapter.java
@@ -50,11 +50,30 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
             DateFormat.DEFAULT);
 
     private final DateFormat iso8601Format = buildIso8601Format();
+    private final DateFormat enUs24HourFormat = buildEnUs24HourDateFormat();
+    private final DateFormat local24HourFormat = buildLocal24HourDateFormat();
 
     private static DateFormat buildIso8601Format() {
         DateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
         return iso8601Format;
+    }
+    
+    /**
+     * Add new en-us date format for parsing date string if it doesn't contain AM/PM.
+     */
+    private static DateFormat buildEnUs24HourDateFormat() {
+        DateFormat newformat = new SimpleDateFormat("MMM dd, yyyy HH:mm:ss", Locale.US);
+        return newformat;
+    }
+    
+    /**
+     * Add new local date format when parsing date string if it doesn't contain AM/PM.
+     * @return
+     */
+    private static DateFormat buildLocal24HourDateFormat() {
+        DateFormat newformat = new SimpleDateFormat("MMM dd, yyyy HH:mm:ss", Locale.getDefault());
+        return newformat;
     }
 
     public DateTimeAdapter() {
@@ -67,12 +86,22 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
 
         try {
             return localFormat.parse(jsonString);
-        } catch (ParseException ignored) {
+        } catch (final ParseException ignored) {
+        }
+        
+        try {
+            return local24HourFormat.parse(jsonString);
+        } catch (final ParseException ignored) {
         }
 
         try {
             return enUsFormat.parse(jsonString);
-        } catch (ParseException ignored) {
+        } catch (final ParseException ignored) {
+        }
+
+        try {
+            return enUs24HourFormat.parse(jsonString);
+        } catch (final ParseException ignored) {
         }
 
         try {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/DefaultTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/DefaultTokenCacheStoreTests.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
@@ -40,6 +39,8 @@ import java.util.TimeZone;
 
 import javax.crypto.NoSuchPaddingException;
 
+import org.mockito.Mockito;
+
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.CacheKey;
 import com.microsoft.aad.adal.DefaultTokenCacheStore;
@@ -51,9 +52,6 @@ import com.microsoft.aad.adal.TokenCacheItem;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager.NameNotFoundException;
-
-import org.mockito.Mockito;
 
 public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
 
@@ -73,7 +71,7 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         super.tearDown();
     }
 
-    public void testSharedCache() throws GeneralSecurityException, IOException {
+    public void testCacheItemRetrieval() throws GeneralSecurityException, IOException {
         TokenCacheItem item = mockDefaultCacheStore("Apr 28, 2015 1:09:57 PM").getItem("testkey");
 
         // Verify returned item
@@ -104,7 +102,7 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         assertNotNull(item.getExpiresOn().after(new Date()));
     }
     
-    public void testDateTimeFormatterOldFormatWithoutAMOrPm() throws GeneralSecurityException, IOException {
+    public void testDateTimeFormatterOldFormat24hourFormat() throws GeneralSecurityException, IOException {
         TokenCacheItem item = mockDefaultCacheStore("Apr 28, 2015 13:09:57").getItem("testkey");
 
         // Verify returned item

--- a/tests/Functional/src/com/microsoft/aad/adal/test/DefaultTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/DefaultTokenCacheStoreTests.java
@@ -74,7 +74,7 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
     }
 
     public void testSharedCache() throws GeneralSecurityException, IOException {
-        TokenCacheItem item = mockDefaultCacheStore().getItem("testkey");
+        TokenCacheItem item = mockDefaultCacheStore("Apr 28, 2015 1:09:57 PM").getItem("testkey");
 
         // Verify returned item
         assertEquals("Same item as mock", "clientId23", item.getClientId());
@@ -96,15 +96,23 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         assertEquals(2, users.size());
     }
 
-    public void testDateTimeFormatterOldFormat() throws GeneralSecurityException, IOException {
-        TokenCacheItem item = mockDefaultCacheStore().getItem("testkey");
+    public void testDateTimeFormatterOldFormatWithAMOrPM() throws GeneralSecurityException, IOException {
+        TokenCacheItem item = mockDefaultCacheStore("Apr 28, 2015 1:09:57 PM").getItem("testkey");
+
+        // Verify returned item
+        assertNotNull(item.getExpiresOn());
+        assertNotNull(item.getExpiresOn().after(new Date()));
+    }
+    
+    public void testDateTimeFormatterOldFormatWithoutAMOrPm() throws GeneralSecurityException, IOException {
+        TokenCacheItem item = mockDefaultCacheStore("Apr 28, 2015 13:09:57").getItem("testkey");
 
         // Verify returned item
         assertNotNull(item.getExpiresOn());
         assertNotNull(item.getExpiresOn().after(new Date()));
     }
 
-    private DefaultTokenCacheStore mockDefaultCacheStore() throws GeneralSecurityException, IOException {
+    private DefaultTokenCacheStore mockDefaultCacheStore(final String dateTimeString) throws GeneralSecurityException, IOException {
         final StorageHelper mockSecure = Mockito.mock(StorageHelper.class);
         Context mockContext = mock(Context.class);
         SharedPreferences prefs = mock(SharedPreferences.class);
@@ -112,7 +120,7 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         when(prefs.getString("testkey", "")).thenReturn("test_encrypted");
         when(mockSecure.loadSecretKeyForAPI()).thenReturn(null);
         when(mockSecure.decrypt("test_encrypted"))
-                .thenReturn("{\"mClientId\":\"clientId23\",\"mExpiresOn\":\"Apr 28, 2015 1:09:57 PM\"}");
+                .thenReturn("{\"mClientId\":\"clientId23\",\"mExpiresOn\":\"" + dateTimeString + "\"}");
         when(
                 mockContext.getSharedPreferences("com.microsoft.aad.adal.cache",
                         Activity.MODE_PRIVATE)).thenReturn(prefs);
@@ -123,9 +131,9 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
             }
         };
         return cache;
-
     }
 
+    
     public void testDateTimeFormatterLocaleChange() {
         DefaultTokenCacheStore store = (DefaultTokenCacheStore)setupItems();
         List<TokenCacheItem> tokens = store.getTokensForResource("resource");

--- a/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
@@ -29,6 +29,9 @@ import java.net.URL;
 import java.util.Map;
 import java.util.UUID;
 
+import com.microsoft.aad.adal.HttpWebResponse;
+import com.microsoft.aad.adal.IWebRequestHandler;
+
 import junit.framework.Assert;
 
 /**
@@ -68,9 +71,8 @@ class MockWebRequestHandler implements IWebRequestHandler {
             try {
                 mRequestContent = new String(content, "UTF-8");
             } catch (UnsupportedEncodingException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
-                Assert.fail("Encoding");                
+                Assert.fail("Encoding");
             }
         }
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/MockWebRequestHandler.java
@@ -24,7 +24,6 @@
 package com.microsoft.aad.adal.test;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.Map;
 import java.util.UUID;
@@ -70,9 +69,8 @@ class MockWebRequestHandler implements IWebRequestHandler {
         if (content != null) {
             try {
                 mRequestContent = new String(content, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
-                Assert.fail("Encoding");
+            } catch (final IOException e) {
+                Assert.fail("IOException");
             }
         }
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/WebRequestHandlerTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/WebRequestHandlerTests.java
@@ -41,7 +41,6 @@ import com.microsoft.aad.adal.WebRequestHandler;
 
 import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Log;
-import junit.framework.Assert;
 
 /**
  * webrequest tests related to get, put, post, delete requests
@@ -165,6 +164,7 @@ public class WebRequestHandlerTests extends AndroidTestHelper {
         try {
             request.sendGet(
                     getUrl("http://www.somethingabcddnotexists.com"), null);
+            fail("Unreachable host, should throw IOException");
         } catch (final IOException e) {
             assertTrue(e instanceof UnknownHostException);
             assertTrue(e.getMessage().toLowerCase(Locale.US).contains("unable to resolve host"));
@@ -186,12 +186,8 @@ public class WebRequestHandlerTests extends AndroidTestHelper {
         WebRequestHandler request = new WebRequestHandler();
         String json = new Gson().toJson(message);
 
-        try {
-            httpResponse = request.sendPost(getUrl(TEST_WEBAPI_URL), null,
-                    json.getBytes(ENCODING_UTF8), "application/json");
-        } catch (final IOException e) {
-            Assert.fail("Encounter unexpected IOException.");
-        }
+        httpResponse = request.sendPost(getUrl(TEST_WEBAPI_URL), null,
+                json.getBytes(ENCODING_UTF8), "application/json");
 
         assertTrue("status is 200", httpResponse.getStatusCode() == 200);
         String responseMsg = new String(httpResponse.getBody());

--- a/tests/Functional/src/com/microsoft/aad/adal/test/WebRequestHandlerTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/WebRequestHandlerTests.java
@@ -24,7 +24,6 @@
 package com.microsoft.aad.adal.test;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -98,33 +97,25 @@ public class WebRequestHandlerTests extends AndroidTestHelper {
             headers = new HashMap<String, String>();
             headers.put("Accept", "application/json");
         }
-        return request
-                .sendPost(getUrl(message), headers, null, "application/x-www-form-urlencoded");
+        return request.sendPost(getUrl(message), headers, null, 
+                "application/x-www-form-urlencoded");
     }
 
     public void testNullUrl() {
-        assertThrowsException(IllegalArgumentException.class, "url", new Runnable() {
-            public void run() {
+        assertThrowsException(IllegalArgumentException.class, "url", new ThrowableRunnable() {
+            public void run() throws IOException {
                 WebRequestHandler request = new WebRequestHandler();
-                try {
-                    request.sendGet(null, null);
-                } catch (IOException e) {
-                    fail();
-                }
+                request.sendGet(null, null);
             }
         });
     }
 
     public void testWrongSchemeUrl() {
 
-        assertThrowsException(IllegalArgumentException.class, "url", new Runnable() {
-            public void run() {
+        assertThrowsException(IllegalArgumentException.class, "url", new ThrowableRunnable() {
+            public void run() throws IOException {
                 WebRequestHandler request = new WebRequestHandler();
-                try {
-                    request.sendGet(getUrl("ftp://test.com"), null);
-                } catch (IOException e) {
-                    fail();
-                }
+                request.sendGet(getUrl("ftp://test.com"), null);
             }
         });
     }
@@ -161,7 +152,7 @@ public class WebRequestHandlerTests extends AndroidTestHelper {
 
         assertNotNull(httpResponse != null);
         assertTrue("status is 200", httpResponse.getStatusCode() == 200);
-        String responseMsg = new String(httpResponse.getBody());
+        String responseMsg = httpResponse.getBody();
         assertTrue("request header check", responseMsg.contains(AAD.ADAL_ID_PLATFORM + "-Android"));
         assertTrue(
                 "request header check",
@@ -174,7 +165,7 @@ public class WebRequestHandlerTests extends AndroidTestHelper {
         try {
             request.sendGet(
                     getUrl("http://www.somethingabcddnotexists.com"), null);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             assertTrue(e instanceof UnknownHostException);
             assertTrue(e.getMessage().toLowerCase(Locale.US).contains("unable to resolve host"));
         }
@@ -198,8 +189,8 @@ public class WebRequestHandlerTests extends AndroidTestHelper {
         try {
             httpResponse = request.sendPost(getUrl(TEST_WEBAPI_URL), null,
                     json.getBytes(ENCODING_UTF8), "application/json");
-        } catch (UnsupportedEncodingException e) {
-            Assert.fail("Encoding exception is not expected");
+        } catch (final IOException e) {
+            Assert.fail("Encounter unexpected IOException.");
         }
 
         assertTrue("status is 200", httpResponse.getStatusCode() == 200);

--- a/tests/testapp/src/com/microsoft/aad/adal/testapp/TestScriptRunner.java
+++ b/tests/testapp/src/com/microsoft/aad/adal/testapp/TestScriptRunner.java
@@ -18,19 +18,13 @@
 
 package com.microsoft.aad.adal.testapp;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import android.app.Activity;
-import android.os.AsyncTask;
-import android.os.Handler;
-import android.util.Log;
 
 import com.google.gson.Gson;
 import com.microsoft.aad.adal.AuthenticationCallback;
@@ -39,6 +33,11 @@ import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.HttpWebResponse;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.WebRequestHandler;
+
+import android.app.Activity;
+import android.os.AsyncTask;
+import android.os.Handler;
+import android.util.Log;
 
 public class TestScriptRunner {
     static final String TAG = "TestScriptRunner";
@@ -568,10 +567,7 @@ public class TestScriptRunner {
             try {
                 response = request.sendPost(new URL(mUrl), headers, mData.getBytes("UTF-8"),
                         "application/json");
-            } catch (MalformedURLException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            } catch (UnsupportedEncodingException e) {
+            } catch (IOException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }
@@ -607,14 +603,11 @@ public class TestScriptRunner {
             HttpWebResponse response = null;
             try {
                 response = request.sendGet(new URL(mUrl), headers);
-                String body = new String(response.getBody(), "UTF-8");
+                String body = response.getBody();
                 Log.v(TAG, "testScript:" + body);
                 ScriptInfo scriptInfo = gson.fromJson(body, ScriptInfo.class);
                 return scriptInfo;
-            } catch (MalformedURLException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            } catch (UnsupportedEncodingException e) {
+            } catch (IOException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }


### PR DESCRIPTION
1. Current datetime string parsing fails when it date string doesn't contain AM or PM
2. fix the test compilation with recent changes in dev