### PR TITLE
Fixing_SSLException_Handling

### DIFF
--- a/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -162,6 +162,7 @@ public class AuthenticationActivity extends Activity {
                     AuthenticationConstants.Browser.WEBVIEW_INVALID_REQUEST);
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE,
                     "Intent does not have request details");
+            resultIntent.putExtra(AuthenticationConstants.ADAL_ERROR_CODE, ADALError.ERROR_WEBVIEW);
             returnToCaller(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);
             return;
         }
@@ -414,6 +415,7 @@ public class AuthenticationActivity extends Activity {
         resultIntent
                 .putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE, errorCode.name());
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE, argument);
+        resultIntent.putExtra(AuthenticationConstants.ADAL_ERROR_CODE, errorCode);
         if (mAuthRequest != null) {
             resultIntent.putExtra(AuthenticationConstants.Browser.REQUEST_ID, mWaitingRequestId);
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,

--- a/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -330,4 +330,6 @@ public class AuthenticationConstants {
     public static final int DEFAULT_EXPIRATION_TIME_SEC = 3600;
 
     public static final String AUTHENTICATION_FILE_DIRECTORY = "com.microsoft.aad.adal.authentication";
+    
+    public static final String ADAL_ERROR_CODE = "ADALErrorCode";
 }

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -51,6 +51,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.SparseArray;
+import android.webkit.WebViewClient;
 
 /**
  * ADAL context to get access token, refresh token, and lookup from cache.
@@ -755,8 +756,14 @@ public class AuthenticationContext {
                             .getString(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE);
                     Logger.v(TAG, "Error info:" + errCode + " " + errMessage + " for requestId: "
                             + requestId + correlationInfo);
+                    
+                    ADALError adalError = ADALError.SERVER_INVALID_REQUEST;
+                    if (errCode.equalsIgnoreCase("Code:" + String.valueOf(WebViewClient.ERROR_FAILED_SSL_HANDSHAKE))) {
+                    	adalError = ADALError.ERROR_FAILED_SSL_HANDSHAKE;
+                    }
+                    
                     waitingRequestOnError(waitingRequest, requestId, new AuthenticationException(
-                            ADALError.SERVER_INVALID_REQUEST, errCode + " " + errMessage));
+                            adalError, errCode + " " + errMessage));
                 } else if (resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE) {
                     final AuthenticationRequest authenticationRequest = (AuthenticationRequest)extras
                             .getSerializable(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO);

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -756,15 +756,8 @@ public class AuthenticationContext {
                             .getString(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE);
                     Logger.v(TAG, "Error info:" + errCode + " " + errMessage + " for requestId: "
                             + requestId + correlationInfo);
-                    
-                    ADALError adalError = ADALError.SERVER_INVALID_REQUEST;
-                    Serializable resultADALErrorCode = data.getSerializableExtra(AuthenticationConstants.ADAL_ERROR_CODE);
-                    if (null != resultADALErrorCode) {                            
-                    	adalError = (ADALError)resultADALErrorCode;
-                    }
-                    
                     waitingRequestOnError(waitingRequest, requestId, new AuthenticationException(
-                            adalError, errCode + " " + errMessage));
+                    		(ADALError)data.getSerializableExtra(AuthenticationConstants.ADAL_ERROR_CODE), errCode + " " + errMessage));
                 } else if (resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE) {
                     final AuthenticationRequest authenticationRequest = (AuthenticationRequest)extras
                             .getSerializable(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO);

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -758,8 +758,9 @@ public class AuthenticationContext {
                             + requestId + correlationInfo);
                     
                     ADALError adalError = ADALError.SERVER_INVALID_REQUEST;
-                    if (errCode.equalsIgnoreCase("Code:" + String.valueOf(WebViewClient.ERROR_FAILED_SSL_HANDSHAKE))) {
-                    	adalError = ADALError.ERROR_FAILED_SSL_HANDSHAKE;
+                    Serializable resultADALErrorCode = data.getSerializableExtra(AuthenticationConstants.ADAL_ERROR_CODE);
+                    if (null != resultADALErrorCode) {                            
+                    	adalError = (ADALError)resultADALErrorCode;
                     }
                     
                     waitingRequestOnError(waitingRequest, requestId, new AuthenticationException(

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -109,6 +109,7 @@ abstract class BasicWebViewClient extends WebViewClient {
                 + errorCode);
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE, description);
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO, mRequest);
+        resultIntent.putExtra(AuthenticationConstants.ADAL_ERROR_CODE, ADALError.ERROR_WEBVIEW);
         sendResponse(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);
     }
 

--- a/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/src/src/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -120,6 +120,7 @@ abstract class BasicWebViewClient extends WebViewClient {
         handler.cancel();
         Logger.e(TAG, "Received ssl error", "", ADALError.ERROR_FAILED_SSL_HANDSHAKE);
         Intent resultIntent = new Intent();
+        resultIntent.putExtra(AuthenticationConstants.ADAL_ERROR_CODE, ADALError.ERROR_FAILED_SSL_HANDSHAKE);
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE, "Code:"
                 + ERROR_FAILED_SSL_HANDSHAKE);
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE,


### PR DESCRIPTION
Fixing the SSL Hand Shake Failure Exception fields.

When there is a SSL_HANDSHAKE_FAILURE in the AuthenticationActivity the library is throwing an ADALException with error code set to SERVER_INVALID_REQUEST and the actual error code of (WebViewClient.ERROR_FAILED_SSL_HANDSHAKE) being put in a formatted string in the exception message. Since the ERROR_FAILED_SSL_HANDSHAKE is a defined error in the list of ADALError, making the change to set the ADALException error code to ADALError.ERROR_FAILED_SSL_HANDSHAKE so that it can be better handled at the Application code consuming it.
