### PR TITLE
check the permissions of Account Manager at the beginning of the broker flow

### DIFF
--- a/samples/hello/src/com/microsoft/aad/adal/hello/LoginFragment.java
+++ b/samples/hello/src/com/microsoft/aad/adal/hello/LoginFragment.java
@@ -20,6 +20,7 @@ import com.microsoft.aad.adal.AuthenticationContext;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.IWindowComponent;
 import com.microsoft.aad.adal.PromptBehavior;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 
 public class LoginFragment extends Fragment {
 
@@ -79,7 +80,12 @@ public class LoginFragment extends Fragment {
             CookieManager cookieManager = CookieManager.getInstance();
             cookieManager.removeAllCookie();
             CookieSyncManager.getInstance().sync();
-            mAuthContext.getCache().removeAll();
+            try {
+				mAuthContext.getCache().removeAll();
+			} catch (final UsageAuthenticationException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
         } else {
             // login
             mAuthContext.acquireToken(wrapFragment(LoginFragment.this), Constants.RESOURCE_ID,

--- a/samples/hello/src/com/microsoft/aad/adal/hello/MainActivity.java
+++ b/samples/hello/src/com/microsoft/aad/adal/hello/MainActivity.java
@@ -51,6 +51,7 @@ import com.microsoft.aad.adal.AuthenticationContext;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.PromptBehavior;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 
 public class MainActivity extends Activity {
 
@@ -281,12 +282,17 @@ public class MainActivity extends Activity {
     }
 
     public void onClickClearTokens(View view) {
-        if (mAuthContext != null && mAuthContext.getCache() != null) {
-            displayMessage("Clearing tokens");
-            mAuthContext.getCache().removeAll();
-        } else {
-            textView1.setText("Cache is null");
-        }
+        try {
+			if (mAuthContext != null && mAuthContext.getCache() != null) {
+			    displayMessage("Clearing tokens");
+			    mAuthContext.getCache().removeAll();
+			} else {
+			    textView1.setText("Cache is null");
+			}
+		} catch (final UsageAuthenticationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
     }
 
     public void onClickClearCookies(View view) {

--- a/src/src/com/microsoft/aad/adal/ApplicationReceiver.java
+++ b/src/src/com/microsoft/aad/adal/ApplicationReceiver.java
@@ -96,13 +96,17 @@ public class ApplicationReceiver extends BroadcastReceiver {
                     // 1) there is saved request in sharedPreference
                     // 2) app has the correct configuration to get token from broker
                     // 3) the saved request is not timeout
-                    if (!StringExtensions.IsNullOrBlank(request) && brokerProxy.canSwitchToBroker() 
-                            && isRequestTimestampValidForResume(dateTimeForSavedRequest)) {
-                        Logger.v(TAG + methodName, receivedInstalledPackageName + " is installed, start sending request to broker.");
-                        resumeRequestInBroker(context, request);
-                    } else {
-                        Logger.v(TAG + methodName, "No request saved in sharedpreferences or request already timeout"
-                                + ", cannot resume broker request.");
+                    try {
+                        if (!StringExtensions.IsNullOrBlank(request) && brokerProxy.canSwitchToBroker() 
+                                && isRequestTimestampValidForResume(dateTimeForSavedRequest)) {
+                            Logger.v(TAG + methodName, receivedInstalledPackageName + " is installed, start sending request to broker.");
+                            resumeRequestInBroker(context, request);
+                        } else {
+                            Logger.v(TAG + methodName, "No request saved in sharedpreferences or request already timeout"
+                                    + ", cannot resume broker request.");
+                        }
+                    } catch (final UsageAuthenticationException e) {
+                        Logger.v(TAG + methodName, e.getMessage());
                     }
                 }
             }

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -207,8 +207,9 @@ public class AuthenticationContext {
      * SharedPreferences and handles synchronization by itself.
      * 
      * @return ITokenCacheStore Current cache used
+     * @throws UsageAuthenticationException 
      */
-    public ITokenCacheStore getCache() {
+    public ITokenCacheStore getCache() throws UsageAuthenticationException {
         if (mBrokerProxy.canSwitchToBroker()) {
             // return cache implementation related to broker so that app can
             // clear tokens for related accounts
@@ -1304,110 +1305,116 @@ public class AuthenticationContext {
         
         // BROKER flow intercepts here
         // cache and refresh call happens through the authenticator service
-        if (mBrokerProxy.canSwitchToBroker()
-                && mBrokerProxy.verifyUser(request.getLoginHint(),
-                        request.getUserId())) {
-            Logger.v(TAG, "It switched to broker for context: " + mContext.getPackageName());
-            AuthenticationResult result = null;
-            request.setVersion(getVersionName());
-            request.setBrokerAccountName(request.getLoginHint());
-            
-            //check if the redirectUri is valid
-            try {
-                //the broker redirectUri will be checked only if 
-                //the request from client App is not silent
-                //otherwise the acquiretokensilent might be interrupted 
-                //by DeveloperAuthenticationException
-                if(!request.isSilent()) {
-                    verifyBrokerRedirectUri(request);
-                }
-            } catch(UsageAuthenticationException exception) {
-                Logger.v(TAG + methodName, "Did not pass the verification of the broker redirect URI");
-                callbackHandle.onError(exception);
-                return result;
-            }
-            
-            // Don't send background request, if prompt flag is always or
-            // refresh_session
-            if (!promptUser(request.getPrompt())
-                    && (!StringExtensions.IsNullOrBlank(request.getBrokerAccountName()) || !StringExtensions
-                            .IsNullOrBlank(request.getUserId()))) {
+        try {
+            if (mBrokerProxy.canSwitchToBroker()
+                    && mBrokerProxy.verifyUser(request.getLoginHint(),
+                            request.getUserId())) {
+                Logger.v(TAG, "It switched to broker for context: " + mContext.getPackageName());
+                AuthenticationResult result = null;
+                request.setVersion(getVersionName());
+                request.setBrokerAccountName(request.getLoginHint());
+                
+                //check if the redirectUri is valid
                 try {
-                    Logger.v(TAG, "User is specified for background token request");
-                    result = mBrokerProxy.getAuthTokenInBackground(request);
-                } catch (AuthenticationException ex) {
-                    // pass back to caller for known exceptions such as failure
-                    // to encrypt
-                    callbackHandle.onError(ex);
-                    return null;
+                    //the broker redirectUri will be checked only if 
+                    //the request from client App is not silent
+                    //otherwise the acquiretokensilent might be interrupted 
+                    //by DeveloperAuthenticationException
+                    if(!request.isSilent()) {
+                        verifyBrokerRedirectUri(request);
+                    }
+                } catch(UsageAuthenticationException exception) {
+                    Logger.v(TAG + methodName, "Did not pass the verification of the broker redirect URI");
+                    callbackHandle.onError(exception);
+                    return result;
                 }
-            } else {
-                Logger.v(TAG, "User is not specified for background token request");
-            }
-
-            if (result != null && result.getAccessToken() != null
-                    && !result.getAccessToken().isEmpty()) {
-                Logger.v(TAG, "Token is returned from background call ");
-                callbackHandle.onSuccess(result);
-                return result;
-            }
-
-            // Launch broker activity
-            // if cache and refresh request is not handled.
-            // Initial request to authenticator needs to launch activity to
-            // record calling uid for the account. This happens for Prompt auto
-            // or always behavior.
-            Logger.v(TAG, "Token is not returned from backgroud call");
-            if (!request.isSilent() && activity != null) {
-
-                // Only happens with callback since silent call does not show UI
-                Logger.v(TAG, "Launch activity for Authenticator");
-                mAuthorizationCallback = callbackHandle.callback;
-                request.setRequestId(callbackHandle.callback.hashCode());
-                Logger.v(TAG, "Starting Authentication Activity with callback:"
-                        + callbackHandle.callback.hashCode());
-                putWaitingRequest(callbackHandle.callback.hashCode(),
-                        new AuthenticationRequestState(callbackHandle.callback.hashCode(), request,
-                                callbackHandle.callback));
-                if (result != null && result.isInitialRequest()) {
-                    Logger.v(TAG, "Initial request to authenticator");
-                    // Log the initial request but not force a prompt
-                }
-
-                // onActivityResult will receive the response
-                // Activity needs to launch to record calling app for this
-                // account
-                Intent brokerIntent = mBrokerProxy.getIntentForBrokerActivity(request);
-                if (brokerIntent != null) {
+                
+                // Don't send background request, if prompt flag is always or
+                // refresh_session
+                if (!promptUser(request.getPrompt())
+                        && (!StringExtensions.IsNullOrBlank(request.getBrokerAccountName()) || !StringExtensions
+                                .IsNullOrBlank(request.getUserId()))) {
                     try {
-                        Logger.v(TAG, "Calling activity pid:" + android.os.Process.myPid()
-                                + " tid:" + android.os.Process.myTid() + "uid:"
-                                + android.os.Process.myUid());
-                        activity.startActivityForResult(brokerIntent,
-                                AuthenticationConstants.UIRequest.BROWSER_FLOW);
-                    } catch (ActivityNotFoundException e) {
-                        Logger.e(TAG, "Activity login is not found after resolving intent", "",
-                                ADALError.DEVELOPER_ACTIVITY_IS_NOT_RESOLVED, e);
-                        callbackHandle.onError(new AuthenticationException(
-                                ADALError.BROKER_ACTIVITY_IS_NOT_RESOLVED));
+                        Logger.v(TAG, "User is specified for background token request");
+                        result = mBrokerProxy.getAuthTokenInBackground(request);
+                    } catch (AuthenticationException ex) {
+                        // pass back to caller for known exceptions such as failure
+                        // to encrypt
+                        callbackHandle.onError(ex);
+                        return null;
                     }
                 } else {
-                    callbackHandle.onError(new AuthenticationException(
-                            ADALError.DEVELOPER_ACTIVITY_IS_NOT_RESOLVED));
+                    Logger.v(TAG, "User is not specified for background token request");
                 }
+
+                if (result != null && result.getAccessToken() != null
+                        && !result.getAccessToken().isEmpty()) {
+                    Logger.v(TAG, "Token is returned from background call ");
+                    callbackHandle.onSuccess(result);
+                    return result;
+                }
+
+                // Launch broker activity
+                // if cache and refresh request is not handled.
+                // Initial request to authenticator needs to launch activity to
+                // record calling uid for the account. This happens for Prompt auto
+                // or always behavior.
+                Logger.v(TAG, "Token is not returned from backgroud call");
+                if (!request.isSilent() && activity != null) {
+
+                    // Only happens with callback since silent call does not show UI
+                    Logger.v(TAG, "Launch activity for Authenticator");
+                    mAuthorizationCallback = callbackHandle.callback;
+                    request.setRequestId(callbackHandle.callback.hashCode());
+                    Logger.v(TAG, "Starting Authentication Activity with callback:"
+                            + callbackHandle.callback.hashCode());
+                    putWaitingRequest(callbackHandle.callback.hashCode(),
+                            new AuthenticationRequestState(callbackHandle.callback.hashCode(), request,
+                                    callbackHandle.callback));
+                    if (result != null && result.isInitialRequest()) {
+                        Logger.v(TAG, "Initial request to authenticator");
+                        // Log the initial request but not force a prompt
+                    }
+
+                    // onActivityResult will receive the response
+                    // Activity needs to launch to record calling app for this
+                    // account
+                    Intent brokerIntent = mBrokerProxy.getIntentForBrokerActivity(request);
+                    if (brokerIntent != null) {
+                        try {
+                            Logger.v(TAG, "Calling activity pid:" + android.os.Process.myPid()
+                                    + " tid:" + android.os.Process.myTid() + "uid:"
+                                    + android.os.Process.myUid());
+                            activity.startActivityForResult(brokerIntent,
+                                    AuthenticationConstants.UIRequest.BROWSER_FLOW);
+                        } catch (ActivityNotFoundException e) {
+                            Logger.e(TAG, "Activity login is not found after resolving intent", "",
+                                    ADALError.DEVELOPER_ACTIVITY_IS_NOT_RESOLVED, e);
+                            callbackHandle.onError(new AuthenticationException(
+                                    ADALError.BROKER_ACTIVITY_IS_NOT_RESOLVED));
+                        }
+                    } else {
+                        callbackHandle.onError(new AuthenticationException(
+                                ADALError.DEVELOPER_ACTIVITY_IS_NOT_RESOLVED));
+                    }
+                } else {
+
+                    // User does not want to launch activity
+                    final String msg = "Prompt is not allowed and failed to get token:";
+                    Logger.e(TAG, msg, "", ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
+                    callbackHandle.onError(new AuthenticationException(
+                            ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, msg));
+                }
+
+                // It will start activity if callback is provided. Return null here.
+                return null;
             } else {
-
-                // User does not want to launch activity
-                String msg = "Prompt is not allowed and failed to get token:";
-                Logger.e(TAG, msg, "", ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
-                callbackHandle.onError(new AuthenticationException(
-                        ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, msg));
+                return localFlow(callbackHandle, activity, useDialog, request);
             }
-
-            // It will start activity if callback is provided. Return null here.
-            return null;
-        } else {
-            return localFlow(callbackHandle, activity, useDialog, request);
+        } catch (final UsageAuthenticationException e) {
+            Logger.v(TAG + methodName, e.getMessage());  
+            callbackHandle.onError(e);  
+            return null;  
         }
     }
 

--- a/src/src/com/microsoft/aad/adal/IBrokerProxy.java
+++ b/src/src/com/microsoft/aad/adal/IBrokerProxy.java
@@ -35,8 +35,9 @@ interface IBrokerProxy {
      * 
      * @return True package is available and authenticator is installed at
      *         Account manager
+     * @throws UsageAuthenticationException 
      */
-    boolean canSwitchToBroker();
+    boolean canSwitchToBroker() throws UsageAuthenticationException;
     
     boolean verifyUser(String username, String uniqueid);
 

--- a/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/AuthenticationContextTest.java
@@ -184,7 +184,12 @@ public class AuthenticationContextTest extends AndroidTestCase {
         String authority = "https://github.com/MSOpenTech";
         AuthenticationContext context = new AuthenticationContext(getContext(), authority, false,
                 null);
-        assertNull(context.getCache());
+        try {
+			assertNull(context.getCache());
+		} catch (UsageAuthenticationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
     }
 
     public void testConstructorWithCache() throws NoSuchAlgorithmException, NoSuchPaddingException {
@@ -192,25 +197,33 @@ public class AuthenticationContextTest extends AndroidTestCase {
         DefaultTokenCacheStore expected = new DefaultTokenCacheStore(getContext());
         AuthenticationContext context = new AuthenticationContext(getContext(), authority, false,
                 expected);
-        assertEquals("Cache object is expected to be same", expected, context.getCache());
+        try {
+			assertEquals("Cache object is expected to be same", expected, context.getCache());
+		} catch (UsageAuthenticationException e1) {
+			// TODO Auto-generated catch block
+			e1.printStackTrace();
+		}
 
         AuthenticationContext contextDefaultCache = new AuthenticationContext(getContext(),
                 authority, false);
-        assertNotNull(contextDefaultCache.getCache());
+        try {
+			assertNotNull(contextDefaultCache.getCache());
+		} catch (UsageAuthenticationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
     }
 
     public void testConstructor_InternetPermission() throws NoSuchAlgorithmException,
             NoSuchPaddingException {
         String authority = "https://github.com/MSOpenTech";
         FileMockContext mockContext = new FileMockContext(getContext());
-        mockContext.requestedPermissionName = "android.permission.INTERNET";
-        mockContext.responsePermissionFlag = PackageManager.PERMISSION_GRANTED;
 
         // no exception
         new AuthenticationContext(mockContext, authority, false);
 
         try {
-            mockContext.responsePermissionFlag = PackageManager.PERMISSION_DENIED;
+        	mockContext.setPermission("android.permission.INTERNET",PackageManager.PERMISSION_DENIED);
             new AuthenticationContext(mockContext, authority, false);
             Assert.fail("Supposed to fail");
         } catch (Exception e) {
@@ -2081,7 +2094,7 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Class<?> c = Class.forName("com.microsoft.aad.adal.AuthenticationRequest");
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
-        //test@case valid redirect uri
+        //test case valid redirect uri
         String testRedirectUri = authContext.getRedirectUriForBroker();
         Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
             "resource", "clientid", testRedirectUri, "loginHint");
@@ -2099,14 +2112,14 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Class<?> c = Class.forName("com.microsoft.aad.adal.AuthenticationRequest");
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
-        //test@case broker redirect uri with invalid prefix
+        //test case broker redirect uri with invalid prefix
         try {
             String testRedirectUri = "http://helloApp";
             Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                     "resource", "clientid", testRedirectUri, "loginHint");
             m.invoke(authContext, authRequest);
             Assert.fail("It is expected to return an exception here.");
-        } catch(InvocationTargetException e) {
+        } catch(final InvocationTargetException e) {
             assertTrue(e.getCause() instanceof UsageAuthenticationException);
             assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((UsageAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("prefix"));
@@ -2123,14 +2136,14 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Class<?> c = Class.forName("com.microsoft.aad.adal.AuthenticationRequest");
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
-        //test@case broker redirect uri with invalid packageName
+        //test case broker redirect uri with invalid packageName
         try {
              String testRedirectUri = "msauth://testapp/gwdiktUBDmQq%2BfbWiJoa%2B%2FYH070%3D";
              Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                      "resource", "clientid", testRedirectUri, "loginHint");
              m.invoke(authContext, authRequest);
              Assert.fail("It is expected to return an exception here.");
-        } catch(InvocationTargetException e) {
+        } catch(final InvocationTargetException e) {
             assertTrue(e.getCause() instanceof UsageAuthenticationException);
             assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((UsageAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("package name"));
@@ -2147,14 +2160,14 @@ public class AuthenticationContextTest extends AndroidTestCase {
         Class<?> c = Class.forName("com.microsoft.aad.adal.AuthenticationRequest");
         Method m = ReflectionUtils.getTestMethod(authContext, "verifyBrokerRedirectUri", c);
 
-        //test@case broker redirect uri with invalid signature
+        //test case broker redirect uri with invalid signature
         try {
         String testRedirectUri = "msauth://" + getContext().getPackageName() + "/falsesignH070%3D";
         Object authRequest = AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, 
                 "resource", "clientid", testRedirectUri, "loginHint");
         m.invoke(authContext, authRequest);
         Assert.fail("It is expected to return an exception here.");
-        } catch(InvocationTargetException e) {
+        } catch(final InvocationTargetException e) {
             assertTrue(e.getCause() instanceof UsageAuthenticationException);
             assertEquals(ADALError.DEVELOPER_REDIRECTURI_INVALID,((UsageAuthenticationException)e.getCause()).getCode());
             assertTrue((e.getCause()).getMessage().toString().contains("signature"));
@@ -2402,9 +2415,14 @@ public class AuthenticationContextTest extends AndroidTestCase {
     }
 
     private void clearCache(AuthenticationContext context) {
-        if (context.getCache() != null) {
-            context.getCache().removeAll();
-        }
+        try {
+			if (context.getCache() != null) {
+			    context.getCache().removeAll();
+			}
+		} catch (UsageAuthenticationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
     }
 
     class MockCache implements ITokenCacheStore {

--- a/tests/Functional/src/com/microsoft/aad/adal/test/FileMockContext.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/FileMockContext.java
@@ -26,6 +26,8 @@ package com.microsoft.aad.adal.test;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import android.accounts.AccountManager;
 import android.content.Context;
@@ -51,15 +53,14 @@ class FileMockContext extends MockContext {
 
     int fileWriteMode;
 
-    String requestedPermissionName;
-
-    int responsePermissionFlag;
+    Map<String, Integer> permissionMap = new HashMap<String, Integer>();
 
     public FileMockContext(Context context) {
         mContext = context;
         // default
-        requestedPermissionName = "android.permission.INTERNET";
-        responsePermissionFlag = PackageManager.PERMISSION_GRANTED;
+        final String requestedPermissionName = "android.permission.INTERNET";
+        final int responsePermissionFlag = PackageManager.PERMISSION_GRANTED;
+        permissionMap.put(requestedPermissionName,responsePermissionFlag);
     }
 
     @Override
@@ -103,20 +104,33 @@ class FileMockContext extends MockContext {
     public PackageManager getPackageManager() {
         return new TestPackageManager();
     }
+    
+    public void setPermission(String permissionName, int permissionFlag) {
+        permissionMap.put(permissionName, permissionFlag);
+    }
+    
+    public boolean removePermission(String permissionName) {
+        if(permissionMap.containsKey(permissionName)) {
+            permissionMap.remove(permissionName);
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     class TestPackageManager extends MockPackageManager {
         @Override
         public ResolveInfo resolveActivity(Intent intent, int flags) {
-            if (resolveIntent)
+            if (resolveIntent) {
                 return new ResolveInfo();
-
+            }
             return null;
         }
 
         @Override
         public int checkPermission(String permName, String pkgName) {
-            if (permName.equals(requestedPermissionName)) {
-                return responsePermissionFlag;
+            if (permissionMap.containsKey(permName)) {
+                return permissionMap.get(permName);
             }
             return PackageManager.PERMISSION_DENIED;
         }

--- a/tests/Functional/src/com/microsoft/aad/adal/test/FileTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/FileTokenCacheStoreTests.java
@@ -39,6 +39,7 @@ import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.Logger.ILogger;
 import com.microsoft.aad.adal.Logger.LogLevel;
 import com.microsoft.aad.adal.TokenCacheItem;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 import com.microsoft.aad.adal.UserInfo;
 
 import android.content.Context;
@@ -260,8 +261,9 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
 
     /**
      * memory cache is shared between context
+     * @throws UsageAuthenticationException 
      */
-    public void testMemoryCacheMultipleContext() {
+    public void testMemoryCacheMultipleContext() throws UsageAuthenticationException {
         String file = FILE_DEFAULT_NAME + "testGetItem";
         setupCache(file);
         ITokenCacheStore tokenCacheA = new FileTokenCacheStore(targetContex, file);

--- a/tests/Functional/src/com/microsoft/aad/adal/test/MemoryTokenCacheStoreTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/test/MemoryTokenCacheStoreTests.java
@@ -38,6 +38,7 @@ import com.microsoft.aad.adal.CacheKey;
 import com.microsoft.aad.adal.ITokenCacheStore;
 import com.microsoft.aad.adal.MemoryTokenCacheStore;
 import com.microsoft.aad.adal.TokenCacheItem;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 
 public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
 
@@ -135,9 +136,10 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
      * 
      * @throws NoSuchPaddingException
      * @throws NoSuchAlgorithmException
+     * @throws UsageAuthenticationException 
      */
     public void testMemoryCacheMultipleContext() throws NoSuchAlgorithmException,
-            NoSuchPaddingException {
+            NoSuchPaddingException, UsageAuthenticationException {
         ITokenCacheStore tokenCacheA = setupItems();
         AuthenticationContext contextA = new AuthenticationContext(getInstrumentation()
                 .getContext(), VALID_AUTHORITY, false, tokenCacheA);

--- a/tests/testapp/src/com/microsoft/aad/adal/testapp/MainActivity.java
+++ b/tests/testapp/src/com/microsoft/aad/adal/testapp/MainActivity.java
@@ -59,6 +59,7 @@ import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.Logger.ILogger;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.TokenCacheItem;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -266,7 +267,12 @@ public class MainActivity extends Activity {
         btnSetExpired.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                setTokenExpired();
+                try {
+					setTokenExpired();
+				} catch (UsageAuthenticationException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
             }
         });
 
@@ -442,7 +448,12 @@ public class MainActivity extends Activity {
             initContext();
         }
 
-        mContext.getCache().removeAll();
+        try {
+			mContext.getCache().removeAll();
+		} catch (UsageAuthenticationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
         textViewStatus.setText("");
     }
 
@@ -457,8 +468,9 @@ public class MainActivity extends Activity {
 
     /**
      * set all expired
+     * @throws UsageAuthenticationException 
      */
-    private void setTokenExpired() {
+    private void setTokenExpired() throws UsageAuthenticationException {
         Log.d(TAG, "Setting item to expire...");
 
         Calendar calendar = new GregorianCalendar();
@@ -495,16 +507,21 @@ public class MainActivity extends Activity {
     public ArrayList<TokenCacheItem> getTokens() {
         Log.d(TAG, "Setting item to expire...");
         ArrayList<TokenCacheItem> items = new ArrayList<TokenCacheItem>();
-        DefaultTokenCacheStore cache = (DefaultTokenCacheStore)mContext.getCache();
-        final Iterator<TokenCacheItem> allItems = cache.getAll();
-        while (allItems.hasNext()) {
-            TokenCacheItem tokenCacheItem = allItems.next();
-            if (tokenCacheItem != null) {
-                items.add(tokenCacheItem);
-            }
-        }
-
-        return items;
+        DefaultTokenCacheStore cache;
+		try {
+			cache = (DefaultTokenCacheStore)mContext.getCache();
+			final Iterator<TokenCacheItem> allItems = cache.getAll();
+	        while (allItems.hasNext()) {
+	            TokenCacheItem tokenCacheItem = allItems.next();
+	            if (tokenCacheItem != null) {
+	                items.add(tokenCacheItem);
+	            }
+	        }
+		} catch (UsageAuthenticationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return items;
     }
 
     /**

--- a/tests/testapp/src/com/microsoft/aad/adal/testapp/TestScriptRunner.java
+++ b/tests/testapp/src/com/microsoft/aad/adal/testapp/TestScriptRunner.java
@@ -32,6 +32,7 @@ import com.microsoft.aad.adal.AuthenticationContext;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.HttpWebResponse;
 import com.microsoft.aad.adal.PromptBehavior;
+import com.microsoft.aad.adal.UsageAuthenticationException;
 import com.microsoft.aad.adal.WebRequestHandler;
 
 import android.app.Activity;
@@ -381,7 +382,12 @@ public class TestScriptRunner {
                 data.mErrorMessage = "Context is not initialized";
                 data.mErrorInRun = true;
             } else {
-                data.mContext.getCache().removeAll();
+                try {
+					data.mContext.getCache().removeAll();
+				} catch (UsageAuthenticationException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
             }
         }
     }


### PR DESCRIPTION
Check the permissions of Account Manager at the beginning of the broker flow, so that the lib could detect early if the app has the necessary permissions. If the app does not have the permission, it will fail instead falling back to the local flow.

Ref PR #484