### PR TITLE
Fix the IdToken related errors in unit tests

### DIFF
--- a/tests/Functional/src/com/microsoft/aad/adal/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/OauthTests.java
@@ -63,22 +63,18 @@ public class OauthTests extends AndroidTestCase {
     private static final String TEST_AUTHORITY = "https://login.windows.net/common";
 
     @SmallTest
-    public void testParseIdTokenPositive() throws IllegalArgumentException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException, NoSuchFieldException, UnsupportedEncodingException {
-        Object actual = parseIdToken(Util.getIdToken());
-        assertEquals("0DxnAlLi12IvGL", ReflectionUtils.getFieldValue(actual, "mSubject"));
-        assertEquals("6fd1f5cd-a94c-4335-889b-6c598e6d8048",
-                ReflectionUtils.getFieldValue(actual, "mTenantId"));
-        assertEquals("test@test.onmicrosoft.com", ReflectionUtils.getFieldValue(actual, "mUpn"));
-        assertEquals("givenName", ReflectionUtils.getFieldValue(actual, "mGivenName"));
-        assertEquals("familyName", ReflectionUtils.getFieldValue(actual, "mFamilyName"));
-        assertEquals("emailField", ReflectionUtils.getFieldValue(actual, "mEmail"));
-        assertEquals("idpProvider", ReflectionUtils.getFieldValue(actual, "mIdentityProvider"));
-        assertEquals("53c6acf2-2742-4538-918d-e78257ec8516",
-                ReflectionUtils.getFieldValue(actual, "mObjectId"));
-        assertTrue(1387227772 == (Long) ReflectionUtils.getFieldValue(actual, "mPasswordExpiration"));
-        assertEquals("pwdUrl", ReflectionUtils.getFieldValue(actual, "mPasswordChangeUrl"));
+    public void testParseIdTokenPositive() throws UnsupportedEncodingException, AuthenticationException {
+        IdToken actual = new IdToken(Util.getIdToken());
+        assertEquals("0DxnAlLi12IvGL", actual.getSubject());
+        assertEquals("6fd1f5cd-a94c-4335-889b-6c598e6d8048", actual.getTenantId());
+        assertEquals("test@test.onmicrosoft.com", actual.getUpn());
+        assertEquals("givenName", actual.getGivenName());
+        assertEquals("familyName", actual.getFamilyName());
+        assertEquals("emailField", actual.getEmail());
+        assertEquals("idpProvider", actual.getIdentityProvider());
+        assertEquals("53c6acf2-2742-4538-918d-e78257ec8516", actual.getObjectId());
+        assertTrue(1387227772 == actual.getPasswordExpiration());
+        assertEquals("pwdUrl", actual.getPasswordChangeUrl());
     }
 
     @SmallTest
@@ -114,48 +110,51 @@ public class OauthTests extends AndroidTestCase {
     }
 
     @SmallTest
-    public void testParseIdTokenNegativeIncorrectMessage() throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
+    public void testParseIdTokenNegativeIncorrectMessage() {
         String idToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiJlNzBiMTE1ZS1hYzBhLTQ4MjMtODVkYS04ZjRiN2I0ZjAwZTYiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwibmJmIjoxMzc2NDI4MzEwLCJleHAiOjEzNzY0NTcxMTAsInZlciI6IjEuMCIsInRpZCI6IjMwYmFhNjY2LThkZjgtNDhlNy05N2U2LTc3Y2ZkMDk5NTk2MyIsIm9pZCI6IjRmODU5OTg5LWEyZmYtNDExZS05MDQ4LWMzMjIyNDdhYzYyYyIsInVwbiI6ImFkbWluQGFhbHRlc3RzLm9ubWljcm9zb2Z0LmNvbSIsInVuaXF1ZV9uYW1lIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwic3ViIjoiVDU0V2hGR1RnbEJMN1VWYWtlODc5UkdhZEVOaUh5LXNjenNYTmFxRF9jNCIsImZhbWlseV9uYW1lIjoiU2.";
-        Object actual = parseIdToken(idToken);
-        assertNull("IdToken is null", actual);
+        try {
+            final IdToken actual = new IdToken(idToken);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof AuthenticationException);
+        }
     }
 
     @SmallTest
-    public void testParseIdTokenNegativeInvalidEncodedTokens() throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
+    public void testParseIdTokenNegativeInvalidEncodedTokens() {
         String idToken = "..";
-        Object actual = parseIdToken(idToken);
-        assertNull("IdToken is null", actual);
+        try {
+            final IdToken actual = new IdToken(idToken);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof AuthenticationException);
+        }
 
         idToken = "sdf.sdf.";
-        actual = parseIdToken(idToken);
-        assertNull("IdToken is null", actual);
+        try {
+            final IdToken actual = new IdToken(idToken);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof AuthenticationException);
+        }
 
         idToken = "sdf.sdf.34";
-        actual = parseIdToken(idToken);
-        assertNull("IdToken is null", actual);
+        try {
+            final IdToken actual = new IdToken(idToken);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof AuthenticationException);
+        }
 
         idToken = "dfdf";
-        actual = parseIdToken(idToken);
-        assertNull("IdToken is null", actual);
+        try {
+            final IdToken actual = new IdToken(idToken);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof AuthenticationException);
+        }
 
         idToken = ".....";
-        actual = parseIdToken(idToken);
-        assertNull("IdToken is null", actual);
-    }
-
-    @SmallTest
-    private Object parseIdToken(String idToken) throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
-        Object request = createAuthenticationRequest("http://www.something.com", "resource",
-                "client", "redirect", "loginhint@ggg.com", null, null, null);
-        Object oauth = createOAuthInstance(request);
-        Method m = ReflectionUtils.getTestMethod(oauth, "parseIdToken", String.class);
-        return (Object)m.invoke(oauth, idToken);
+        try {
+            final IdToken actual = new IdToken(idToken);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof AuthenticationException);
+        }
     }
 
     @SmallTest

--- a/tests/Functional/src/com/microsoft/aad/adal/UserInfoTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/UserInfoTests.java
@@ -23,12 +23,13 @@
 
 package com.microsoft.aad.adal;
 
-import java.lang.reflect.InvocationTargetException;
+import java.io.UnsupportedEncodingException;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 
+import android.net.Uri;
 import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Base64;
 import junit.framework.TestCase;
 
 public class UserInfoTests extends TestCase {
@@ -44,49 +45,41 @@ public class UserInfoTests extends TestCase {
     }
 
     @SmallTest
-    public void testIdTokenParam_upn() throws IllegalArgumentException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException,
-            InvocationTargetException, NoSuchFieldException {
-        Object obj = setIdTokenFields("objectid", "upnid", "email", "subj");
-        UserInfo info = (UserInfo)ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
-                + ".UserInfo", obj);
+    public void testIdTokenParam_upn() throws UnsupportedEncodingException, AuthenticationException {
+        IdToken idToken = new IdToken(getIdToken("objectid", "upnid", "email", "subj"));
+        UserInfo info = new UserInfo(idToken);
         assertEquals("same userid", "objectid", info.getUserId());
         assertEquals("same name", "givenName", info.getGivenName());
         assertEquals("same family name", "familyName", info.getFamilyName());
         assertEquals("same idenity name", "provider", info.getIdentityProvider());
         assertEquals("check displayable", "upnid", info.getDisplayableId());
 
-        obj = setIdTokenFields("", "upnid", "email", "subj");
-        info = (UserInfo)ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
-                + ".UserInfo", obj);
+        idToken = new IdToken(getIdToken("", "upnid", "email", "subj"));
+        info = new UserInfo(idToken);
         assertEquals("same userid", "subj", info.getUserId());
         assertEquals("same name", "givenName", info.getGivenName());
         assertEquals("same family name", "familyName", info.getFamilyName());
         assertEquals("same idenity name", "provider", info.getIdentityProvider());
         assertEquals("check displayable", "upnid", info.getDisplayableId());
 
-        obj = setIdTokenFields("", "upnid", "email", "");
-        info = (UserInfo)ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
-                + ".UserInfo", obj);
+        idToken = new IdToken(getIdToken("", "upnid", "email", ""));
+        info = new UserInfo(idToken);
         assertNull("null userid", info.getUserId());
         assertEquals("same name", "givenName", info.getGivenName());
         assertEquals("same family name", "familyName", info.getFamilyName());
         assertEquals("same idenity name", "provider", info.getIdentityProvider());
         assertEquals("check displayable", "upnid", info.getDisplayableId());
 
-        obj = setIdTokenFields("", "", "email", "");
-        info = (UserInfo)ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
-                + ".UserInfo", obj);
+        idToken = new IdToken(getIdToken("", "", "email", ""));
+        info = new UserInfo(idToken);
         assertNull("null userid", info.getUserId());
         assertEquals("same name", "givenName", info.getGivenName());
         assertEquals("same family name", "familyName", info.getFamilyName());
         assertEquals("same idenity name", "provider", info.getIdentityProvider());
         assertEquals("check displayable", "email", info.getDisplayableId());
 
-        obj = setIdTokenFields("", "", "", "");
-        info = (UserInfo)ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
-                + ".UserInfo", obj);
-
+        idToken = new IdToken(getIdToken("", "", "", ""));
+        info = new UserInfo(idToken);
         assertNull("null userid", info.getUserId());
         assertNull("check displayable", info.getDisplayableId());
         assertEquals("same name", "givenName", info.getGivenName());
@@ -95,42 +88,49 @@ public class UserInfoTests extends TestCase {
     }
 
     @SmallTest
-    public void testIdTokenParam_password() throws IllegalArgumentException,
-            ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, NoSuchFieldException {
-        Object obj = setIdTokenFields("objectid", "upnid", "email", "subj");
-        Calendar calendar = new GregorianCalendar();
-        int seconds = 1000;
-        ReflectionUtils.setFieldValue(obj, "mPasswordExpiration", seconds);
-        ReflectionUtils.setFieldValue(obj, "mPasswordChangeUrl",
-                "https://github.com/MSOpenTech/azure-activedirectory-library");
-        UserInfo info = (UserInfo)ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
-                + ".UserInfo", obj);
-        calendar.add(Calendar.SECOND, seconds);
-        Date passwordExpiresOn = calendar.getTime();
+    public void testIdTokenParam_password() throws AuthenticationException, UnsupportedEncodingException {
+        final String rawIdToken = getIdToken("objectid", "upnid", "email", "subj");
+        final IdToken idToken = new IdToken(rawIdToken);
+        final UserInfo info = new UserInfo(idToken);
+
+        Calendar expires = new GregorianCalendar();
+        expires.add(Calendar.SECOND, (int) idToken.getPasswordExpiration());
+
         assertEquals("same userid", "objectid", info.getUserId());
         assertEquals("same name", "givenName", info.getGivenName());
         assertEquals("same family name", "familyName", info.getFamilyName());
         assertEquals("same idenity name", "provider", info.getIdentityProvider());
         assertEquals("check displayable", "upnid", info.getDisplayableId());
-        assertEquals("check expireson", passwordExpiresOn.getTime() / 1000, info
-                .getPasswordExpiresOn().getTime() / 1000);
-        assertEquals("check uri", "https://github.com/MSOpenTech/azure-activedirectory-library",
+        assertEquals("check expireson", expires.getTime().getTime() / 1000,
+                info.getPasswordExpiresOn().getTime() / 1000);
+        assertEquals("check uri", Uri.parse(idToken.getPasswordChangeUrl()).toString(),
                 info.getPasswordChangeUrl().toString());
     }
 
-    private Object setIdTokenFields(String objId, String upn, String email, String subject)
-            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, NoSuchFieldException {
-        Object obj = ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME + ".IdToken");
-        ReflectionUtils.setFieldValue(obj, "mObjectId", objId);
-        ReflectionUtils.setFieldValue(obj, "mSubject", subject);
-        ReflectionUtils.setFieldValue(obj, "mTenantId", "tenantid");
-        ReflectionUtils.setFieldValue(obj, "mUpn", upn);
-        ReflectionUtils.setFieldValue(obj, "mGivenName", "givenName");
-        ReflectionUtils.setFieldValue(obj, "mFamilyName", "familyName");
-        ReflectionUtils.setFieldValue(obj, "mEmail", email);
-        ReflectionUtils.setFieldValue(obj, "mIdentityProvider", "provider");
-        return obj;
+    private String getIdToken(String objId, String upnStr, String emailStr, String subjectStr)
+            throws UnsupportedEncodingException {
+        final String sIdTokenClaims = "{\"aud\":\"c3c7f5e5-7153-44d4-90e6-329686d48d76\",\"iss\":\"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048/\",\"iat\":1387224169,\"nbf\":1387224170,\"exp\":1387227769,\"pwd_exp\":1387227772,\"pwd_url\":\"pwdUrl\",\"ver\":\"1.0\",\"tid\":\"%s\",\"oid\":\"%s\",\"upn\":\"%s\",\"unique_name\":\"%s\",\"sub\":\"%s\",\"family_name\":\"%s\",\"given_name\":\"%s\",\"altsecid\":\"%s\",\"idp\":\"%s\",\"email\":\"%s\"}";
+        final String sIdTokenHeader = "{\"typ\":\"JWT\",\"alg\":\"none\"}";
+        final String tid = "tenantid";
+        final String oid = objId;
+        final String upn = upnStr;
+        final String unique_name = "testUnique@test.onmicrosoft.com";
+        final String sub = subjectStr;
+        final String family_name = "familyName";
+        final String given_name = "givenName";
+        final String altsecid = "altsecid";
+        final String idp = "provider";
+        final String email = emailStr;
+        final String claims = String.format(sIdTokenClaims, tid, oid, upn, unique_name, sub, family_name, given_name,
+                altsecid, idp, email);
+        return String.format("%s.%s.",
+                new String(
+                        Base64.encode(sIdTokenHeader.getBytes(AuthenticationConstants.ENCODING_UTF8),
+                                Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE),
+                        AuthenticationConstants.ENCODING_UTF8),
+                new String(
+                        Base64.encode(claims.getBytes(AuthenticationConstants.ENCODING_UTF8),
+                                Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE),
+                        AuthenticationConstants.ENCODING_UTF8));
     }
 }


### PR DESCRIPTION
The change of the IdToken constructor cause the failures in several tests which correlated to the IdToken and OAuth class. This PR is aiming at fix this bug.