### PR TITLE
b2c fixes for reading profile info and tokencache store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <scm.branch>master</scm.branch>
     <maven.version>3.1.1</maven.version>
-    <adal.version>2.0-alpha</adal.version>
+    <adal.version>2.0.1-alpha</adal.version>
     <android.platform.maven.plugin>18</android.platform.maven.plugin>
     <android.version>[4.1.1.4,)</android.version>
     <android.support.version>[18,)</android.support.version>

--- a/samples/hello/src/com/microsoft/aad/adal/hello/Constants.java
+++ b/samples/hello/src/com/microsoft/aad/adal/hello/Constants.java
@@ -32,16 +32,17 @@ public class Constants {
     
     // AAD PARAMETERS
     // https://login.windows.net/tenantInfo
-    static final String AUTHORITY_URL = "https://login.windows-ppe.net/common";
+    static final String AUTHORITY_URL = "https://login.microsoftonline.com/common";// "https://login.windows-ppe.net/common";
 
     // Clientid is given from AAD page when you register your Android app
-    static final String CLIENT_ID = "b67b2169-6966-4597-b3e4-f698dc5df864";
+    static final String CLIENT_ID = "a7d8cef0-4145-49b2-a91d-95c54051fa3f";// "b67b2169-6966-4597-b3e4-f698dc5df864";
 
     // RedirectUri
     static final String REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob";// "msauth://com.example.userapp2/WiEb9EPiRwdK5vgH%2FQPajYeR%2F%2Bs%3D";
 
     // URI for the resource. You need to setup this resource at AAD
-    static final String[] SCOPE = new String[]{"https://outlook.office.com/Mail.Read"};
+    static final String[] SCOPE = new String[] { "User.Read" };// new
+                                                               // String[]{"https://outlook.office.com/Mail.Read"};
 
     // Endpoint we are targeting for the deployed WebAPI service
     static final String SERVICE_URL = "https://android.azurewebsites.net/api/values";

--- a/samples/hello/src/com/microsoft/aad/adal/hello/Constants.java
+++ b/samples/hello/src/com/microsoft/aad/adal/hello/Constants.java
@@ -32,17 +32,16 @@ public class Constants {
     
     // AAD PARAMETERS
     // https://login.windows.net/tenantInfo
-    static final String AUTHORITY_URL = "https://login.microsoftonline.com/common";// "https://login.windows-ppe.net/common";
+    static final String AUTHORITY_URL = "app-authority";
 
     // Clientid is given from AAD page when you register your Android app
-    static final String CLIENT_ID = "a7d8cef0-4145-49b2-a91d-95c54051fa3f";// "b67b2169-6966-4597-b3e4-f698dc5df864";
+    static final String CLIENT_ID = "app-client-id";
 
     // RedirectUri
-    static final String REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob";// "msauth://com.example.userapp2/WiEb9EPiRwdK5vgH%2FQPajYeR%2F%2Bs%3D";
+    static final String REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob";
 
     // URI for the resource. You need to setup this resource at AAD
-    static final String[] SCOPE = new String[] { "User.Read" };// new
-                                                               // String[]{"https://outlook.office.com/Mail.Read"};
+    static final String[] SCOPE = new String[]{"https://outlook.office.com/Mail.Read"};
 
     // Endpoint we are targeting for the deployed WebAPI service
     static final String SERVICE_URL = "https://android.azurewebsites.net/api/values";

--- a/samples/hello/src/com/microsoft/aad/adal/hello/MainActivity.java
+++ b/samples/hello/src/com/microsoft/aad/adal/hello/MainActivity.java
@@ -29,6 +29,14 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 
+import com.microsoft.aad.adal.AuthenticationCallback;
+import com.microsoft.aad.adal.AuthenticationContext;
+import com.microsoft.aad.adal.AuthenticationResult;
+import com.microsoft.aad.adal.AuthenticationSettings;
+import com.microsoft.aad.adal.Logger;
+import com.microsoft.aad.adal.PromptBehavior;
+import com.microsoft.aad.adal.UserIdentifier;
+
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Intent;
@@ -45,14 +53,6 @@ import android.webkit.CookieSyncManager;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import com.microsoft.aad.adal.AuthenticationCallback;
-import com.microsoft.aad.adal.AuthenticationContext;
-import com.microsoft.aad.adal.AuthenticationResult;
-import com.microsoft.aad.adal.Logger;
-import com.microsoft.aad.adal.PromptBehavior;
-import com.microsoft.aad.adal.UserIdentifier;
-import com.microsoft.aad.adal.UserIdentifier.UserIdentifierType;
 
 public class MainActivity extends Activity {
 
@@ -190,7 +190,9 @@ public class MainActivity extends Activity {
     public void onClickAcquireTokenSilent(View v) {
         Log.v(TAG, "onClickAcquireTokenSilent is clicked");
         mLoginProgressDialog.show();
-        mAuthContext.acquireTokenSilent(Constants.SCOPE, policySignin, Constants.CLIENT_ID, new UserIdentifier(getUniqueId(), UserIdentifier.UserIdentifierType.UniqueId),
+        AuthenticationSettings.INSTANCE.setExpirationBuffer(3600);
+        mAuthContext.acquireTokenSilent(new String[] { Constants.CLIENT_ID }, policySignin, Constants.CLIENT_ID,
+                new UserIdentifier(getUniqueId(), UserIdentifier.UserIdentifierType.UniqueId),
                 getCallback());
     }
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -97,6 +97,8 @@ public class AuthenticationConstants {
         public static final String ERROR_CODES = "error_codes";
 
         public static final String EXPIRES_IN = "expires_in";
+        
+        public static final String ID_TOKEN_EXPIRES_IN = "id_token_expires_in";
 
         public static final String GRANT_TYPE = "grant_type";
 
@@ -135,6 +137,16 @@ public class AuthenticationConstants {
         static final String ID_TOKEN_PASSWORD_CHANGE_URL = "pwd_url";
 
         public static final Object PROFILE_INFO = "profile_info";
+        
+        static final String OPEN_ID = "openid";
+
+        static final class PROFILE_INFO_CLAIM {
+            static final String VERSION = "ver";
+            static final String SUBJECT = "sub";
+            static final String TENANT_ID = "tid";
+            static final String PREFERRED_USERNAME = "preferred_username";
+            static final String NAME = "name";
+        }
     }
 
     public static final class AAD {

--- a/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -136,17 +136,9 @@ public class AuthenticationConstants {
 
         static final String ID_TOKEN_PASSWORD_CHANGE_URL = "pwd_url";
 
-        public static final Object PROFILE_INFO = "profile_info";
+        public static final String PROFILE_INFO = "profile_info";
         
         static final String OPEN_ID = "openid";
-
-        static final class PROFILE_INFO_CLAIM {
-            static final String VERSION = "ver";
-            static final String SUBJECT = "sub";
-            static final String TENANT_ID = "tid";
-            static final String PREFERRED_USERNAME = "preferred_username";
-            static final String NAME = "name";
-        }
     }
 
     public static final class AAD {

--- a/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -138,7 +138,11 @@ public class AuthenticationConstants {
 
         public static final String PROFILE_INFO = "profile_info";
         
-        static final String OPEN_ID = "openid";
+        static final String SCOPE_OPEN_ID = "openid";
+        
+        static final String SCOPE_OFFLINE_ACCESS = "offline_access";
+        
+        static final String SCOPE_PROFILE = "profile";
     }
 
     public static final class AAD {

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1354,14 +1354,18 @@ public class AuthenticationContext {
             mTokenCacheStore.deleteIntersectingScope(key);
             
             TokenCacheItem cacheItem = new TokenCacheItem(request, result, result.getIsMultiResourceRefreshToken());
-            mTokenCacheStore.setItem(key, cacheItem);
-            
-            // Record idtoken with clientid as scope
-            if(request.isIdTokenRequest()){
-                cacheItem.setScope(new String[]{request.getClientId()});
-                key.setScope(new String[]{request.getClientId()});
-                mTokenCacheStore.setItem(key, cacheItem);
+
+            // If request contains open_id, convert it to client id.
+            final String[] scopesInRequest = request.getScope();
+            if (scopesInRequest != null && scopesInRequest.length == 1
+                    && (scopesInRequest[0] == AuthenticationConstants.OAuth2.OPEN_ID
+                            || scopesInRequest[0] == request.getClientId())) {
+                final String[] convertedScope = new String[] { request.getClientId() };
+                key.setScope(convertedScope);
+                cacheItem.setScope(convertedScope);
             }
+
+            mTokenCacheStore.setItem(key, cacheItem);
         }
     }
 

--- a/src/src/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1358,11 +1358,10 @@ public class AuthenticationContext {
             // If request contains open_id, convert it to client id.
             final String[] scopesInRequest = request.getScope();
             if (scopesInRequest != null && scopesInRequest.length == 1
-                    && (scopesInRequest[0] == AuthenticationConstants.OAuth2.OPEN_ID
+                    && (scopesInRequest[0] == AuthenticationConstants.OAuth2.SCOPE_OPEN_ID
                             || scopesInRequest[0] == request.getClientId())) {
                 final String[] convertedScope = new String[] { request.getClientId() };
                 key.setScope(convertedScope);
-                cacheItem.setScope(convertedScope);
             }
 
             mTokenCacheStore.setItem(key, cacheItem);

--- a/src/src/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/src/src/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -229,8 +229,9 @@ class AuthenticationRequest implements Serializable {
             set.remove(mClientId); // remove client id if it exists
         }
        
-        set.add("openid");
-        set.add("offline_access");
+        set.add(AuthenticationConstants.OAuth2.SCOPE_OPEN_ID);
+        set.add(AuthenticationConstants.OAuth2.SCOPE_OFFLINE_ACCESS);
+        set.add(AuthenticationConstants.OAuth2.SCOPE_PROFILE);
         return set.toArray(new String[set.size()]);
     }
     

--- a/src/src/com/microsoft/aad/adal/ITokenCacheStore.java
+++ b/src/src/com/microsoft/aad/adal/ITokenCacheStore.java
@@ -70,5 +70,5 @@ public interface ITokenCacheStore extends Serializable {
     
     String serialize();
     
-    void deSerialize(String blob);
+    void deserialize(String blob);
 }

--- a/src/src/com/microsoft/aad/adal/JsonHelper.java
+++ b/src/src/com/microsoft/aad/adal/JsonHelper.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.aad.adal;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+class JsonHelper {
+    static void extractJsonObjects(Map<String, String> extractedItems, final String jsonBody) throws JSONException {
+        final JSONObject jsonObject = new JSONObject(jsonBody);
+
+        @SuppressWarnings("unchecked")
+        final Iterator<String> i = jsonObject.keys();
+
+        while (i.hasNext()) {
+            final String key = i.next();
+            extractedItems.put(key, jsonObject.getString(key));
+        }
+    }
+}

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -163,6 +163,13 @@ class Oauth2 {
                 AuthenticationConstants.OAuth2.REDIRECT_URI,
                 StringExtensions.URLFormEncode(mRequest.getRedirectUri()));
         
+        String scope = StringExtensions.createStringFromArray(mRequest.getDecoratedScopeRequest(),
+                " ");
+        if (!StringExtensions.IsNullOrBlank(scope)) {
+            message = String.format("%s&%s=%s", message, AuthenticationConstants.AAD.SCOPE,
+                    StringExtensions.URLFormEncode(scope));
+        }
+        
         if (!StringExtensions.IsNullOrBlank(mRequest.getPolicy())) {
             message = String.format("%s&%s=%s", message, AuthenticationConstants.AAD.QUERY_POLICY,
                     URLEncoder.encode(mRequest.getPolicy(), AuthenticationConstants.ENCODING_UTF8));
@@ -248,7 +255,7 @@ class Oauth2 {
         } else {
             token = response.get(AuthenticationConstants.OAuth2.ID_TOKEN);
             expiresIn = response.get(AuthenticationConstants.OAuth2.ID_TOKEN_EXPIRES_IN);
-            scope = AuthenticationConstants.OAuth2.OPEN_ID;
+            scope = mRequest.getClientId();
         }
         
         final Calendar expires = new GregorianCalendar();

--- a/src/src/com/microsoft/aad/adal/ProfileInfo.java
+++ b/src/src/com/microsoft/aad/adal/ProfileInfo.java
@@ -18,7 +18,13 @@
 
 package com.microsoft.aad.adal;
 
+import java.util.HashMap;
+
+import android.util.Base64;
+
 class ProfileInfo {
+    static final String TAG = ProfileInfo.class.getSimpleName();
+
     String mVersion;
 
     String mSubject;
@@ -29,6 +35,44 @@ class ProfileInfo {
 
     String mPreferredName;
     
-    public ProfileInfo(){
+    private ProfileInfo() {}
+
+    static ProfileInfo parseProfileInfo(String rawProfileInfo) {
+        try {
+            // Message Base64 encoded text
+
+            if (!StringExtensions.IsNullOrBlank(rawProfileInfo)) {
+                // URL_SAFE: Encoder/decoder flag bit to use
+                // "URL and filename safe" variant of Base64
+                // (see RFC 3548 section 4) where - and _ are used in place of +
+                // and /.
+                byte[] data = Base64.decode(rawProfileInfo, Base64.URL_SAFE);
+                final String decodedBody = new String(data, "UTF-8");
+
+                HashMap<String, String> responseItems = new HashMap<String, String>();
+                JsonHelper.extractJsonObjects(responseItems, decodedBody);
+                if (responseItems != null && !responseItems.isEmpty()) {
+                    final ProfileInfo profileInfo = new ProfileInfo();
+                    profileInfo.mVersion = responseItems.get(ProfileInfoClaim.VERSION);
+                    profileInfo.mSubject = responseItems.get(ProfileInfoClaim.SUBJECT);
+                    profileInfo.mTenantId = responseItems.get(ProfileInfoClaim.TENANT_ID);
+                    profileInfo.mName = responseItems.get(ProfileInfoClaim.NAME);
+                    profileInfo.mPreferredName = responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME);
+                    Logger.v(TAG, "Profile info is extracted from token response");
+                    return profileInfo;
+                }
+            }
+        } catch (Exception ex) {
+            Logger.e(TAG, "Error in parsing user id token", null, ADALError.IDTOKEN_PARSING_FAILURE, ex);
+        }
+        return null;
+    }
+
+    private static final class ProfileInfoClaim {
+        static final String VERSION = "ver";
+        static final String SUBJECT = "sub";
+        static final String TENANT_ID = "tid";
+        static final String PREFERRED_USERNAME = "preferred_username";
+        static final String NAME = "name";
     }
 }

--- a/src/src/com/microsoft/aad/adal/ProfileInfo.java
+++ b/src/src/com/microsoft/aad/adal/ProfileInfo.java
@@ -19,25 +19,16 @@
 package com.microsoft.aad.adal;
 
 class ProfileInfo {
+    String mVersion;
+
     String mSubject;
 
     String mTenantId;
 
-    String mUpn;
-
     String mName;
 
-    String mEmail;
-
-    String mIdentityProvider;
+    String mPreferredName;
     
-    String mObjectId;
-    
-    long mPasswordExpiration;
-    
-    String mPasswordChangeUrl;
-        
     public ProfileInfo(){
-        
     }
 }

--- a/src/src/com/microsoft/aad/adal/TokenCache.java
+++ b/src/src/com/microsoft/aad/adal/TokenCache.java
@@ -131,7 +131,7 @@ public class TokenCache implements ITokenCacheStore {
         return "";
     }
 
-    public final void deSerialize(String input) {
+    public final void deserialize(String input) {
         try {
             mCacheItems = new HashMap<TokenCacheKey, TokenCacheItem>();
 
@@ -327,7 +327,7 @@ public class TokenCache implements ITokenCacheStore {
     void initCache(){
         if (mPrefs.contains(CACHE_BLOB)) {
             String json = mPrefs.getString(CACHE_BLOB, "");
-            deSerialize(json);
+            deserialize(json);
         }
     }
 

--- a/src/src/com/microsoft/aad/adal/TokenCacheKey.java
+++ b/src/src/com/microsoft/aad/adal/TokenCacheKey.java
@@ -249,7 +249,7 @@ final class TokenCacheKey implements Serializable {
         // if key is specified for mrrt, it does not need to check scope
         // intersection
         return mAuthority.equalsIgnoreCase(item.getAuthority()) && mClientId.equalsIgnoreCase(item.getClientId())
-                && (mIsMultipleResourceRefreshToken || isScopeIntersect(item.getScope()))
+                && isScopeIntersect(item.getScope())
                 && (TextUtils.isEmpty(mUniqueId) || item.getUserInfo() == null
                         || mUniqueId.equalsIgnoreCase(item.getUserInfo().getUniqueId()))
                 && (TextUtils.isEmpty(mDisplayableId) || item.getUserInfo() == null

--- a/src/src/com/microsoft/aad/adal/TokenCacheKey.java
+++ b/src/src/com/microsoft/aad/adal/TokenCacheKey.java
@@ -1,8 +1,10 @@
 package com.microsoft.aad.adal;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,317 +16,310 @@ import android.text.TextUtils;
  */
 final class TokenCacheKey implements Serializable {
 
-	/**
-	 * Serial version id.
-	 */
-	private static final long serialVersionUID = 8067972995583126404L;
+    /**
+     * Serial version id.
+     */
+    private static final long serialVersionUID = 8067972995583126404L;
 
-	private static final String TAG = "TokenCacheKey";
+    private static final String TAG = "TokenCacheKey";
 
-	private String mAuthority = "";
+    private String mAuthority = "";
 
-	private String[] mScope;
+    private String[] mScope;
 
-	private String mClientId = "";
+    private String mClientId = "";
 
-	private String mUniqueId = "";
+    private String mUniqueId = "";
 
-	private String mDisplayableId = "";
+    private String mDisplayableId = "";
 
-	private boolean mIsMultipleResourceRefreshToken;
-	
-	private String mPolicy = "";
+    private boolean mIsMultipleResourceRefreshToken;
 
-	private TokenCacheKey() {
-	}
+    private String mPolicy = "";
 
-	public String toJsonString() throws JSONException {
-		JSONObject obj = new JSONObject();
-		obj.put("a", mAuthority);
-		obj.put("s", StringExtensions.createStringFromArray(mScope, " "));
-		obj.put("c", mClientId);
-		obj.put("u", mUniqueId);
-		obj.put("d", mDisplayableId);
-		obj.put("mr", mIsMultipleResourceRefreshToken);
-		obj.put("p", mPolicy);
-		return obj.toString();
-	}
+    private TokenCacheKey() {
+    }
 
-	public String getLog() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("Authority:" + mAuthority);
-		sb.append(" scope:" + StringExtensions.createStringFromArray(mScope, " "));
-		sb.append(" clientid:" + mClientId);
-		sb.append(" uniqueid:" + mUniqueId);
-		sb.append(" mrrt:" + mIsMultipleResourceRefreshToken);
-		sb.append(" p:" + mPolicy);
-		return sb.toString();
-	}
+    public String toJsonString() throws JSONException {
+        JSONObject obj = new JSONObject();
+        obj.put("a", mAuthority);
+        obj.put("s", StringExtensions.createStringFromArray(mScope, " "));
+        obj.put("c", mClientId);
+        obj.put("u", mUniqueId);
+        obj.put("d", mDisplayableId);
+        obj.put("mr", mIsMultipleResourceRefreshToken);
+        obj.put("p", mPolicy);
+        return obj.toString();
+    }
 
-	/**
-	 * @param authority
-	 *            URL of the authenticating authority
-	 * @param scope
-	 *            scope identifier
-	 * @param clientId
-	 *            client identifier
-	 * @param isMultiResourceRefreshToken
-	 *            true/false for refresh token type
-	 * @param userId
-	 *            userid provided from {@link UserInfo}
-	 * @return CacheKey to use in saving token
-	 */
-	public static TokenCacheKey createCacheKey(String authority,
-			String[] scope, String policy, String clientId,
-			boolean isMultiResourceRefreshToken, String uniqueId,
-			String displayableId) {
+    public String getLog() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Authority:" + mAuthority);
+        sb.append(" scope:" + StringExtensions.createStringFromArray(mScope, " "));
+        sb.append(" clientid:" + mClientId);
+        sb.append(" uniqueid:" + mUniqueId);
+        sb.append(" mrrt:" + mIsMultipleResourceRefreshToken);
+        sb.append(" p:" + mPolicy);
+        return sb.toString();
+    }
 
-		if (authority == null) {
-			throw new IllegalArgumentException("authority");
-		}
+    /**
+     * @param authority
+     *            URL of the authenticating authority
+     * @param scope
+     *            scope identifier
+     * @param clientId
+     *            client identifier
+     * @param isMultiResourceRefreshToken
+     *            true/false for refresh token type
+     * @param userId
+     *            userid provided from {@link UserInfo}
+     * @return CacheKey to use in saving token
+     */
+    public static TokenCacheKey createCacheKey(String authority, String[] scope, String policy, String clientId,
+            boolean isMultiResourceRefreshToken, String uniqueId, String displayableId) {
 
-		if (clientId == null) {
-			throw new IllegalArgumentException("clientId");
-		}
+        if (authority == null) {
+            throw new IllegalArgumentException("authority");
+        }
 
-		TokenCacheKey key = new TokenCacheKey();
+        if (clientId == null) {
+            throw new IllegalArgumentException("clientId");
+        }
 
-		// MultiResource token items will be stored without resource
-		key.mScope = scope;
+        TokenCacheKey key = new TokenCacheKey();
 
-		key.mAuthority = authority.toLowerCase(Locale.US);
-		if (key.mAuthority.endsWith("/")) {
-			key.mAuthority = (String) key.mAuthority.subSequence(0,
-					key.mAuthority.length() - 1);
-		}
+        key.mScope = scope;
 
-		key.mClientId = clientId.toLowerCase(Locale.US);
-		key.mIsMultipleResourceRefreshToken = isMultiResourceRefreshToken;
+        key.mAuthority = authority.toLowerCase(Locale.US);
+        if (key.mAuthority.endsWith("/")) {
+            key.mAuthority = (String) key.mAuthority.subSequence(0, key.mAuthority.length() - 1);
+        }
 
-		// optional
-		if (!StringExtensions.IsNullOrBlank(uniqueId)) {
-			key.mUniqueId = uniqueId.toLowerCase(Locale.US);
-		}
+        key.mClientId = clientId.toLowerCase(Locale.US);
+        key.mIsMultipleResourceRefreshToken = isMultiResourceRefreshToken;
 
-		if (!StringExtensions.IsNullOrBlank(displayableId)) {
-			key.mDisplayableId = displayableId.toLowerCase(Locale.US);
-		}
-		
-		if (!StringExtensions.IsNullOrBlank(policy)) {
-		    key.mPolicy = policy;
-		}
+        // optional
+        if (!StringExtensions.IsNullOrBlank(uniqueId)) {
+            key.mUniqueId = uniqueId.toLowerCase(Locale.US);
+        }
 
-		return key;
-	}
+        if (!StringExtensions.IsNullOrBlank(displayableId)) {
+            key.mDisplayableId = displayableId.toLowerCase(Locale.US);
+        }
 
-	/**
-	 * @param item
-	 *            Token item in the cache
-	 * @return CacheKey to save token
-	 */
-	public static TokenCacheKey createCacheKey(TokenCacheItem item) {
-		if (item == null) {
-			throw new IllegalArgumentException("TokenCacheItem");
-		}
+        if (!StringExtensions.IsNullOrBlank(policy)) {
+            key.mPolicy = policy;
+        }
 
-		String uniqueId = "";
-		String displayableId = "";
+        return key;
+    }
 
-		if (item.getUserInfo() != null) {
-			uniqueId = item.getUserInfo().getUniqueId();
-			displayableId = item.getUserInfo().getDisplayableId();
-		}
+    /**
+     * @param item
+     *            Token item in the cache
+     * @return CacheKey to save token
+     */
+    public static TokenCacheKey createCacheKey(TokenCacheItem item) {
+        if (item == null) {
+            throw new IllegalArgumentException("TokenCacheItem");
+        }
 
-		return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(),
-				item.getClientId(), item.getIsMultiResourceRefreshToken(),
-				uniqueId, displayableId);
-	}
+        String uniqueId = "";
+        String displayableId = "";
 
-	/**
-	 * @param item
-	 *            AuthenticationRequest item
-	 * @return CacheKey to save token
-	 */
-	public static TokenCacheKey createCacheKey(AuthenticationRequest item) {
-		if (item == null) {
-			throw new IllegalArgumentException("AuthenticationRequest");
-		}
+        if (item.getUserInfo() != null) {
+            uniqueId = item.getUserInfo().getUniqueId();
+            displayableId = item.getUserInfo().getDisplayableId();
+        }
 
-		return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(),
-				item.getClientId(), false, item.getUserIdentifier()
-						.getUniqueId(), item.getUserIdentifier()
-						.getDisplayableId());
-	}
+        return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(), item.getClientId(),
+                item.getIsMultiResourceRefreshToken(), uniqueId, displayableId);
+    }
 
-	/**
-	 * Store multi resource refresh tokens with different key. Key will not
-	 * include resource and set flag to y.
-	 * 
-	 * @param item
-	 *            AuthenticationRequest item
-	 * @param cacheUserId
-	 *            UserId in the cache
-	 * @return CacheKey to save token
-	 */
-	public static TokenCacheKey createMultiResourceRefreshTokenKey(
-			AuthenticationRequest item, String cacheUniqueID, String cacheDispId) {
-		if (item == null) {
-			throw new IllegalArgumentException("AuthenticationRequest");
-		}
+    /**
+     * @param item
+     *            AuthenticationRequest item
+     * @return CacheKey to save token
+     */
+    public static TokenCacheKey createCacheKey(AuthenticationRequest item) {
+        if (item == null) {
+            throw new IllegalArgumentException("AuthenticationRequest");
+        }
 
-		return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(),
-				item.getClientId(), true, cacheUniqueID, cacheDispId);
-	}
+        return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(), item.getClientId(), false,
+                item.getUserIdentifier().getUniqueId(), item.getUserIdentifier().getDisplayableId());
+    }
 
-	public static TokenCacheKey createCacheKey(AuthenticationRequest request,
-			AuthenticationResult result) {
-		String uniqueId = "";
-		String displayableId = "";
+    /**
+     * Store multi resource refresh tokens with different key. Key will not
+     * include resource and set flag to y.
+     * 
+     * @param item
+     *            AuthenticationRequest item
+     * @param cacheUserId
+     *            UserId in the cache
+     * @return CacheKey to save token
+     */
+    public static TokenCacheKey createMultiResourceRefreshTokenKey(AuthenticationRequest item, String cacheUniqueID,
+            String cacheDispId) {
+        if (item == null) {
+            throw new IllegalArgumentException("AuthenticationRequest");
+        }
 
-		if (result.getUserInfo() != null) {
-			uniqueId = result.getUserInfo().getUniqueId();
-			Logger.v(TAG, "Create key with uniqueid:" + uniqueId);
-			displayableId = result.getUserInfo().getDisplayableId();
-		}
+        return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(), item.getClientId(), true,
+                cacheUniqueID, cacheDispId);
+    }
 
-		return createCacheKey(request.getAuthority(), request.getScope(), request.getPolicy(),
-				request.getClientId(), result.getIsMultiResourceRefreshToken(),
-				uniqueId, displayableId);
-	}
+    public static TokenCacheKey createCacheKey(AuthenticationRequest request, AuthenticationResult result) {
+        String uniqueId = "";
+        String displayableId = "";
 
-	/**
-	 * Gets Authority.
-	 * 
-	 * @return Authority
-	 */
-	public String getAuthority() {
-		return mAuthority;
-	}
+        if (result.getUserInfo() != null) {
+            uniqueId = result.getUserInfo().getUniqueId();
+            Logger.v(TAG, "Create key with uniqueid:" + uniqueId);
+            displayableId = result.getUserInfo().getDisplayableId();
+        }
 
-	/**
-	 * Gets Scope.
-	 * 
-	 * @return Scope
-	 */
-	public String[] getScope() {
-		return mScope;
-	}
+        // TODO: test for the scope
+        return createCacheKey(request.getAuthority(), request.getScope(), request.getPolicy(), request.getClientId(),
+                result.getIsMultiResourceRefreshToken(), uniqueId, displayableId);
+    }
 
-	/**
-	 * Gets ClientId.
-	 * 
-	 * @return ClientId
-	 */
-	public String getClientId() {
-		return mClientId;
-	}
+    /**
+     * Gets Authority.
+     * 
+     * @return Authority
+     */
+    public String getAuthority() {
+        return mAuthority;
+    }
 
-	/**
-	 * Gets UniqueId.
-	 * 
-	 * @return UniqueId
-	 */
-	public String getUniqueId() {
-		return mUniqueId;
-	}
+    /**
+     * Gets Scope.
+     * 
+     * @return Scope
+     */
+    public String[] getScope() {
+        return mScope;
+    }
 
-	/**
-	 * Gets DisplayableId.
-	 * 
-	 * @return DisplayableId
-	 */
-	public String getDisplayableId() {
-		return mDisplayableId;
-	}
+    /**
+     * Gets ClientId.
+     * 
+     * @return ClientId
+     */
+    public String getClientId() {
+        return mClientId;
+    }
 
-	/**
-	 * Gets status for multi resource refresh token.
-	 * 
-	 * @return status for multi resource refresh token
-	 */
-	public boolean getIsMultipleResourceRefreshToken() {
-		return mIsMultipleResourceRefreshToken;
-	}
+    /**
+     * Gets UniqueId.
+     * 
+     * @return UniqueId
+     */
+    public String getUniqueId() {
+        return mUniqueId;
+    }
 
-	public void setIsMultipleResourceRefreshToken(boolean mrrt) {
-		this.mIsMultipleResourceRefreshToken = mrrt;
-	}
+    /**
+     * Gets DisplayableId.
+     * 
+     * @return DisplayableId
+     */
+    public String getDisplayableId() {
+        return mDisplayableId;
+    }
+
+    /**
+     * Gets status for multi resource refresh token.
+     * 
+     * @return status for multi resource refresh token
+     */
+    public boolean getIsMultipleResourceRefreshToken() {
+        return mIsMultipleResourceRefreshToken;
+    }
+
+    public void setIsMultipleResourceRefreshToken(boolean mrrt) {
+        this.mIsMultipleResourceRefreshToken = mrrt;
+    }
 
     public boolean matches(TokenCacheItem item) {
         // MMRT items can be used without checking resource
         // Match user if specified
         // if key is specified for mrrt, it does not need to check scope
         // intersection
-        return mAuthority.equalsIgnoreCase(item.getAuthority())
-                && mClientId.equalsIgnoreCase(item.getClientId())
+        return mAuthority.equalsIgnoreCase(item.getAuthority()) && mClientId.equalsIgnoreCase(item.getClientId())
                 && (mIsMultipleResourceRefreshToken || isScopeIntersect(item.getScope()))
-                && (TextUtils.isEmpty(mUniqueId) || item.getUserInfo() == null || mUniqueId
-                        .equalsIgnoreCase(item.getUserInfo().getUniqueId()))
-                && (TextUtils.isEmpty(mDisplayableId) || item.getUserInfo() == null || mDisplayableId
-                        .equalsIgnoreCase(item.getUserInfo().getDisplayableId()))
+                && (TextUtils.isEmpty(mUniqueId) || item.getUserInfo() == null
+                        || mUniqueId.equalsIgnoreCase(item.getUserInfo().getUniqueId()))
+                && (TextUtils.isEmpty(mDisplayableId) || item.getUserInfo() == null
+                        || mDisplayableId.equalsIgnoreCase(item.getUserInfo().getDisplayableId()))
                 && (TextUtils.isEmpty(mPolicy) || mPolicy.equalsIgnoreCase(item.getPolicy()));
     }
 
     public boolean isUserEmpty() {
-		return TextUtils.isEmpty(mDisplayableId)
-				&& TextUtils.isEmpty(mUniqueId);
-	}
+        return TextUtils.isEmpty(mDisplayableId) && TextUtils.isEmpty(mUniqueId);
+    }
 
-	@Override
-	public boolean equals(Object o) {
-		if (o == null || !(o instanceof TokenCacheKey)) {
-			return false;
-		}
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof TokenCacheKey)) {
+            return false;
+        }
 
-		TokenCacheKey other = (TokenCacheKey) o;
-		return mAuthority.equalsIgnoreCase(other.getAuthority())
-				&& mClientId.equalsIgnoreCase(other.getClientId())
-				&& isScopeEquals(other.getScope())
-				&& mIsMultipleResourceRefreshToken == other.mIsMultipleResourceRefreshToken
-				&& (mUniqueId.equalsIgnoreCase(other.getUniqueId()))
-				&& (mDisplayableId.equalsIgnoreCase(other.getDisplayableId())
-				&& mPolicy.equalsIgnoreCase(other.mPolicy));
-	}
-	
+        TokenCacheKey other = (TokenCacheKey) o;
+        return mAuthority.equalsIgnoreCase(other.getAuthority()) && mClientId.equalsIgnoreCase(other.getClientId())
+                && isScopeEquals(other.getScope())
+                && mIsMultipleResourceRefreshToken == other.mIsMultipleResourceRefreshToken
+                && (mUniqueId.equalsIgnoreCase(other.getUniqueId()))
+                && (mDisplayableId.equalsIgnoreCase(other.getDisplayableId())
+                        && mPolicy.equalsIgnoreCase(other.mPolicy));
+    }
+
     @Override
     public int hashCode() {
         int hash = 7;
         hash = 17 * hash + mAuthority.hashCode();
         hash = 17 * hash + mClientId.hashCode();
-        hash = 17 * hash + ((mScope == null || mScope.length == 0) ? 7 : mScope.hashCode());
+        hash = 17 * hash + ((mScope == null || mScope.length == 0) ? 7 : getHashCodeForScope(mScope));
         hash = 17 * hash + (mIsMultipleResourceRefreshToken ? 7 : 0);
         hash = 17 * hash + mUniqueId.hashCode();
         hash = 17 * hash + mDisplayableId.hashCode();
         hash = 17 * hash + mPolicy.hashCode();
         return hash;
     }
-	
-	private boolean isScopeIntersect(String[] scopes) {
-	    Set<String> self = StringExtensions.createSet(mScope);
-	    if(scopes != null && scopes.length != 0){
-	        for(String onescope: scopes){
-	            if(self.contains(onescope.toLowerCase(Locale.US))){
-	                return true;
-	            }
-	        }
-	    }
-	    
+
+    private boolean isScopeIntersect(String[] scopes) {
+        Set<String> self = StringExtensions.createSet(mScope);
+        if (scopes != null && scopes.length != 0) {
+            for (String onescope : scopes) {
+                if (self.contains(onescope.toLowerCase(Locale.US))) {
+                    return true;
+                }
+            }
+        }
+
         return false;
     }
-	
-	private boolean isScopeEquals(String[] otherScope){
-	    Set<String> self = StringExtensions.createSet(mScope);
+
+    private boolean isScopeEquals(String[] otherScope) {
+        Set<String> self = StringExtensions.createSet(mScope);
         Set<String> other = StringExtensions.createSet(otherScope);
 
-        if (self.size() == other.size())
-        {
+        if (self.size() == other.size()) {
             return self.containsAll(other);
         }
 
         return false;
-	}
+    }
 
     void setScope(String[] scope) {
-       this.mScope = scope;        
+        this.mScope = scope;
+    }
+
+    private int getHashCodeForScope(final String[] scopes) {
+        final Set<String> scopesSet = new TreeSet<String>(Arrays.asList(scopes));
+        return scopesSet.hashCode();
     }
 }

--- a/src/src/com/microsoft/aad/adal/TokenCacheKey.java
+++ b/src/src/com/microsoft/aad/adal/TokenCacheKey.java
@@ -147,7 +147,7 @@ final class TokenCacheKey implements Serializable {
             throw new IllegalArgumentException("AuthenticationRequest");
         }
 
-        return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(), item.getClientId(), false,
+        return createCacheKey(item.getAuthority(), item.getScope(), item.getPolicy(), item.getClientId(), true,
                 item.getUserIdentifier().getUniqueId(), item.getUserIdentifier().getDisplayableId());
     }
 
@@ -181,7 +181,6 @@ final class TokenCacheKey implements Serializable {
             displayableId = result.getUserInfo().getDisplayableId();
         }
 
-        // TODO: test for the scope
         return createCacheKey(request.getAuthority(), request.getScope(), request.getPolicy(), request.getClientId(),
                 result.getIsMultiResourceRefreshToken(), uniqueId, displayableId);
     }

--- a/src/src/com/microsoft/aad/adal/UserInfo.java
+++ b/src/src/com/microsoft/aad/adal/UserInfo.java
@@ -19,9 +19,7 @@
 package com.microsoft.aad.adal;
 
 import java.io.Serializable;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 
 import android.net.Uri;
 import android.os.Bundle;
@@ -35,6 +33,8 @@ public class UserInfo implements Serializable {
      * 
      */
     private static final long serialVersionUID = 8790127561636702672L;
+
+    private String mVersion;
 
     private String mUniqueId;
 
@@ -64,36 +64,21 @@ public class UserInfo implements Serializable {
         mDisplayableId = displayableId;
     }
 
-    public UserInfo(ProfileInfo token) {
-
-        mUniqueId = null;
-        mDisplayableId = null;
-
-        if (!StringExtensions.IsNullOrBlank(token.mObjectId)) {
-            mUniqueId = token.mObjectId;
-        } else if (!StringExtensions.IsNullOrBlank(token.mSubject)) {
-            mUniqueId = token.mSubject;
+    public UserInfo(ProfileInfo profileinfo) {
+        if (!StringExtensions.IsNullOrBlank(profileinfo.mVersion)) {
+            mVersion = profileinfo.mVersion;
         }
 
-        if (!StringExtensions.IsNullOrBlank(token.mUpn)) {
-            mDisplayableId = token.mUpn;
-        } else if (!StringExtensions.IsNullOrBlank(token.mEmail)) {
-            mDisplayableId = token.mEmail;
+        if (!StringExtensions.IsNullOrBlank(profileinfo.mSubject)) {
+            mUniqueId = profileinfo.mSubject;
         }
 
-        mName = token.mName;
-        mIdentityProvider = token.mIdentityProvider;
-        if (token.mPasswordExpiration > 0) {
-            // pwd_exp returns seconds to expiration time
-            // it returns in seconds. Date accepts milliseconds.
-            Calendar expires = new GregorianCalendar();
-            expires.add(Calendar.SECOND, (int)token.mPasswordExpiration);
-            mPasswordExpiresOn = expires.getTime();
+        if (!StringExtensions.IsNullOrBlank(profileinfo.mPreferredName)) {
+            mDisplayableId = profileinfo.mPreferredName;
         }
 
-        mPasswordChangeUrl = null;
-        if (!StringExtensions.IsNullOrBlank(token.mPasswordChangeUrl)) {
-            mPasswordChangeUrl = Uri.parse(token.mPasswordChangeUrl);
+        if (!StringExtensions.IsNullOrBlank(profileinfo.mName)) {
+            mName = profileinfo.mName;
         }
     }
 


### PR DESCRIPTION
1. ProfileInfo should only contain version, sub, name, preferredname and tenant id
2. when storing token cache item into cache, only store one token item. Also update the hashcode calculation for scopes. 
3. typo on the id_token_expires_in