### PR TITLE
fix failing tests for default token cache store

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/DefaultTokenCacheStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/DefaultTokenCacheStoreTests.java
@@ -108,7 +108,6 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
         SharedPreferences prefs = mock(SharedPreferences.class);
         when(prefs.contains("testkey")).thenReturn(true);
         when(prefs.getString("testkey", "")).thenReturn("test_encrypted");
-        when(mockSecure.loadSecretKeyForEncryption()).thenReturn(null);
         when(mockSecure.decrypt("test_encrypted"))
                 .thenReturn("{\"mClientId\":\"clientId23\",\"mExpiresOn\":\"" + dateTimeString + "\"}");
         when(


### PR DESCRIPTION
Mockito is having problem for mocking package visible methods. For the failed three tests, all we want to mock is the decrypted item, we don't even need to mock the behavior of loadSecretKeyForEncryption. Also, the current existing test is having the mock behavior to return null, there is no need to do it.  