### PR TITLE
Permission checking for Account Manager when broker is used

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TestAuthCallback.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TestAuthCallback.java
@@ -1,0 +1,39 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+/**
+ * Implementation for {@link AuthenticationCallback} for testing purpose.
+ */
+final class TestAuthCallback implements AuthenticationCallback<AuthenticationResult> {
+    public AuthenticationResult callbackResult;
+
+    public Exception callbackException;
+
+    @Override
+    public void onSuccess(AuthenticationResult result) { callbackResult = result; }
+
+    @Override
+    public void onError(Exception exc) { callbackException = exc; }
+}


### PR DESCRIPTION
Check the permissions of Account Manager at the beginning of acquireToken() if when broker is used, so that the lib could detect early if the app has the necessary permissions. If the app does not have the permission, it will throw the UsageAuthenticationException to the callback.

Ref PR #613

Under broker:
o If target version is lower than 23, calling app has to have the following permissions declared in manifest (http://developer.android.com/reference/android/accounts/AccountManager.html): 
 GET_ACCOUNTS
 USE_CREDENTIALS
 MANAGE_ACOUNTS


Beginning in Android 6.0 (API level 23), users grant permissions to apps while the app is running, not when they install the app. 

o If target version is 23, USE_CREDENTIALS and MANAGE_ACCOUNTS are already deprecated. But GET_ACCOUNTS is under protection level "dangerous", calling app is responsible for requesting the run-time permisson. You can reference Runtime permission request for API 23.