### PR TITLE
B2c fix cache item

### DIFF
--- a/src/src/com/microsoft/aad/adal/ProfileInfo.java
+++ b/src/src/com/microsoft/aad/adal/ProfileInfo.java
@@ -54,10 +54,10 @@ class ProfileInfo {
                 if (responseItems != null && !responseItems.isEmpty()) {
                     final ProfileInfo profileInfo = new ProfileInfo();
                     profileInfo.mVersion = responseItems.get(ProfileInfoClaim.VERSION);
-                    profileInfo.mSubject = responseItems.get(ProfileInfoClaim.SUBJECT);
+                    profileInfo.mSubject = getValue(responseItems.get(ProfileInfoClaim.SUBJECT));
                     profileInfo.mTenantId = responseItems.get(ProfileInfoClaim.TENANT_ID);
-                    profileInfo.mName = responseItems.get(ProfileInfoClaim.NAME);
-                    profileInfo.mPreferredName = responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME);
+                    profileInfo.mName = getValue(responseItems.get(ProfileInfoClaim.NAME)); //responseItems.get(ProfileInfoClaim.NAME);
+                    profileInfo.mPreferredName = getValue(responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME));//responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME);
                     Logger.v(TAG, "Profile info is extracted from token response");
                     return profileInfo;
                 }
@@ -66,6 +66,14 @@ class ProfileInfo {
             Logger.e(TAG, "Error in parsing user id token", null, ADALError.IDTOKEN_PARSING_FAILURE, ex);
         }
         return null;
+    }
+    
+    private static String getValue(final String value) {
+        if ("null".equalsIgnoreCase(value)) {
+            return null;
+        }
+        
+        return value;
     }
 
     private static final class ProfileInfoClaim {

--- a/src/src/com/microsoft/aad/adal/ProfileInfo.java
+++ b/src/src/com/microsoft/aad/adal/ProfileInfo.java
@@ -56,8 +56,8 @@ class ProfileInfo {
                     profileInfo.mVersion = responseItems.get(ProfileInfoClaim.VERSION);
                     profileInfo.mSubject = getValue(responseItems.get(ProfileInfoClaim.SUBJECT));
                     profileInfo.mTenantId = responseItems.get(ProfileInfoClaim.TENANT_ID);
-                    profileInfo.mName = getValue(responseItems.get(ProfileInfoClaim.NAME)); //responseItems.get(ProfileInfoClaim.NAME);
-                    profileInfo.mPreferredName = getValue(responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME));//responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME);
+                    profileInfo.mName = getValue(responseItems.get(ProfileInfoClaim.NAME));
+                    profileInfo.mPreferredName = getValue(responseItems.get(ProfileInfoClaim.PREFERRED_USERNAME));
                     Logger.v(TAG, "Profile info is extracted from token response");
                     return profileInfo;
                 }

--- a/src/src/com/microsoft/aad/adal/TokenCacheKey.java
+++ b/src/src/com/microsoft/aad/adal/TokenCacheKey.java
@@ -220,6 +220,10 @@ final class TokenCacheKey implements Serializable {
     public String getUniqueId() {
         return mUniqueId;
     }
+    
+    void setUniqueId(final String uniqueUserId) {
+        mUniqueId = uniqueUserId;
+    }
 
     /**
      * Gets DisplayableId.
@@ -228,6 +232,10 @@ final class TokenCacheKey implements Serializable {
      */
     public String getDisplayableId() {
         return mDisplayableId;
+    }
+    
+    void setDisplayableId(final String displayableId) {
+        mDisplayableId = displayableId;
     }
 
     /**


### PR DESCRIPTION
For convergence, we store single entry. If we have RT in the cache, we'll try to use the RT. The token cache key used to find the RT either contains the displayableId or unique userId. However, when we initially get the token, the key we stored into cache contains both(If server returns to us, or null). 