### PR TITLE
ADAL builds with marshmallow SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jdk:
 
 android:
   components:
+    - platform-tools
+    - tools
     - build-tools-23.0.3
     - android-23
     - extra

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ jdk:
 
 android:
   components:
-    - build-tools-21.1.2
+    - build-tools-23.0.3
     - extra
 
 env:
     matrix:
-      - ANDROID_SDKS=android-21 ANDROID_TARGET=android-21
+      - ANDROID_SDKS=android-23 ANDROID_TARGET=android-23
       
 before_install:
   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jdk:
 android:
   components:
     - build-tools-23.0.3
+    - android-23
     - extra
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ android:
     - build-tools-23.0.3
     - android-23
     - extra
+    - extra-android-m2repository
+    - extra-google-m2repository
 
 env:
     matrix:

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -17,12 +17,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.2.0"
         project.archivesBaseName = "adal"
@@ -60,7 +60,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     //Compile Dependencies
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.google.code.gson:gson:2.2.4'
     //Test Dependencies
     androidTestCompile 'org.mockito:mockito-core:1.10.19'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.microsoft.aad.adal.sample"
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -27,7 +27,7 @@ android {
 dependencies {
     //Compile Dependencies
     compile project(':adal')
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     //Test Dependencies
     testCompile 'junit:junit:4.12'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.3"
+    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "com.microsoft.aad.adal.sample"

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.microsoft.aad.adal.testapp"
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -28,7 +28,7 @@ dependencies {
     //Compile Dependencies
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':adal')
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.google.code.gson:gson:2.4'
     //Test Dependencies
     testCompile 'junit:junit:4.12'

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.3"
+    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "com.microsoft.aad.adal.testapp"

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.microsoft.aad.adal.userappwithbroker"
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 23
     }
 
     buildTypes {

--- a/userappwithbroker/project.properties
+++ b/userappwithbroker/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-21
+target=android-23
 android.library.reference.1=../../src


### PR DESCRIPTION
Changing the build.gradle files to use android sdk version 23
Apache library is not available by default, the testapp needs it. Adding a flag in testapp's build.gradle to use apache library. Issue #570 