### PR TITLE
static analysis clean up for issue 682

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -125,7 +125,7 @@ task pmd(type: Pmd) {
     description 'Run pmd'
     group 'verification'
 
-    ruleSets = ["java-basic", "java-braces", "java-strings", "java-design", "java-unusedcode"]
+    ruleSets = ["java-basic", "java-braces", "java-strings", "java-unusedcode"]
     source = fileTree('src/main/java')
 
     reports {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ADALErrorTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ADALErrorTest.java
@@ -52,7 +52,7 @@ public class ADALErrorTest extends InstrumentationTestCase {
 
         AuthenticationSettings.INSTANCE
                 .setBrokerPackageName(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
-        Log.d(TAG, "testSignature is set");
+        Log.d(TAG, "mTestSignature is set");
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -100,7 +100,8 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null));
+                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_INTERNAL_ERROR, null, null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -213,7 +214,8 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         final byte[] postMessage = Util.getPoseMessage(mrrt, clientId, resource);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
                 AdditionalMatchers.aryEq(postMessage), Mockito.anyString()))
-                .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"), null));
+                .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
+                        Util.getErrorResponseBody("invalid_grant"), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -269,7 +271,8 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         final byte[] postMessage = Util.getPoseMessage(mrrt, clientId, resource);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
                 AdditionalMatchers.aryEq(postMessage), Mockito.anyString()))
-                .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_OK, Util.getSuccessTokenResponse(true, false), null));
+                .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(true, false), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -318,7 +321,9 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_OK, Util.getSuccessTokenResponse(true, true), null));
+                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(true, true), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -372,7 +377,8 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
                 Mockito.anyString().getBytes(), Mockito.anyString()))
-                .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"), null));
+                .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
+                        Util.getErrorResponseBody("invalid_grant"), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -495,12 +501,18 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         //FRT request fails with invalid_grant
-        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(), AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
-                Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"), null));
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
+                Mockito.anyString())).thenReturn(new HttpWebResponse(
+                HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"),
+                null));
 
         // MRT request also fails
-        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(), AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
-                Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_request"), null));
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
+                        Util.getErrorResponseBody("invalid_request"), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -512,10 +524,14 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         }
 
         // Verify post request with MRRT token is executed first, followed by post request with FRT. 
-        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)), Mockito.anyString());
-        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)), Mockito.anyString());
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(
+                        frtToken, clientId, resource)), Mockito.anyString());
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
+                Mockito.anyString());
 
         // Verify cache entry
         // the First FRT request should delete the FRT entries
@@ -564,12 +580,18 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         // MRRT request fails with invalid_grant
-        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(), AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
-                Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"), null));
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
+                        Util.getErrorResponseBody("invalid_grant"), null));
 
         // FRT request succeed
-        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(), AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
-                Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_OK, Util.getSuccessTokenResponse(true, true), null));
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(true, true), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -583,10 +605,14 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         }
 
         // Verify post request with MRRT token is executed first, followed by post request with FRT. 
-        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)), Mockito.anyString());
-        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)), Mockito.anyString());
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(
+                        Util.getPoseMessage(mrrtToken, clientId, resource)), Mockito.anyString());
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
+                Mockito.anyString());
 
         // Verify cache entry, FRT return token back, should store entries with user in cache.
         // FRT token entry
@@ -621,7 +647,9 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody(null), null));
+                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
+                        Util.getErrorResponseBody(null), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {
@@ -661,8 +689,9 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
-                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
-                Util.getErrorResponseBody("interaction_required"), null));
+                Mockito.anyString().getBytes(), Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
+                        Util.getErrorResponseBody("interaction_required"), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
         try {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -39,16 +39,13 @@ import java.util.concurrent.TimeUnit;
 
 public class AndroidTestHelper extends InstrumentationTestCase {
 
-    protected final static int REQUEST_TIME_OUT = 40000; // miliseconds
-
-    /** The Constant ENCODING_UTF8. */
-    public static final String ENCODING_UTF8 = "UTF_8";
+    protected static final int REQUEST_TIME_OUT = 40000; // miliseconds
 
     private static final String TAG = "AndroidTestHelper";
 
-    protected byte[] testSignature = null;
+    protected byte[] mTestSignature;
 
-    protected String testTag = null;
+    protected String mTestTag;
 
     @Override
     protected void setUp() throws Exception {
@@ -60,16 +57,16 @@ public class AndroidTestHelper extends InstrumentationTestCase {
         PackageInfo info = getInstrumentation().getContext().getPackageManager()
                 .getPackageInfo("com.microsoft.aad.adal.testapp", PackageManager.GET_SIGNATURES);
         for (Signature signature : info.signatures) {
-            testSignature = signature.toByteArray();
+            mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
-            md.update(testSignature);
-            testTag = Base64.encodeToString(md.digest(), Base64.DEFAULT);
+            md.update(mTestSignature);
+            mTestTag = Base64.encodeToString(md.digest(), Base64.DEFAULT);
             break;
         }
-        AuthenticationSettings.INSTANCE.setBrokerSignature(testTag);
+        AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
         AuthenticationSettings.INSTANCE
                 .setBrokerPackageName(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
-        Log.d(TAG, "testSignature is set");
+        Log.d(TAG, "mTestSignature is set");
     }
 
     @Override

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AndroidTestHelper extends InstrumentationTestCase {
 
-    protected static final int REQUEST_TIME_OUT = 40000; // miliseconds
+    protected static final int REQUEST_TIME_OUT = 40000; // milliseconds
 
     private static final String TAG = "AndroidTestHelper";
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AssertUtils.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AssertUtils.java
@@ -32,7 +32,7 @@ import junit.framework.Assert;
 public class AssertUtils extends Assert {
 
     private static final String TAG = "AssertUtils";
-    protected static final int REQUEST_TIME_OUT = 20000; // miliseconds
+    protected static final int REQUEST_TIME_OUT = 20000; // milliseconds
     
     public static void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
             final Runnable testCode) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AssertUtils.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AssertUtils.java
@@ -32,7 +32,7 @@ import junit.framework.Assert;
 public class AssertUtils extends Assert {
 
     private static final String TAG = "AssertUtils";
-    protected final static int REQUEST_TIME_OUT = 20000; // miliseconds
+    protected static final int REQUEST_TIME_OUT = 20000; // miliseconds
     
     public static void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
             final Runnable testCode) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationActivityUnitTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationActivityUnitTest.java
@@ -215,8 +215,8 @@ public class AuthenticationActivityUnitTest extends ActivityUnitTestCase<Authent
         mActivity = getActivity();
         AuthenticationSettings.INSTANCE.setDeviceCertificateProxyClass(MockDeviceCertProxy.class);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
-        MockDeviceCertProxy.sPrivateKey = null;
+        MockDeviceCertProxy.setIsValidIssuer(true);
+        MockDeviceCertProxy.setPrivateKey(null);
         String url = AuthenticationConstants.Broker.PKEYAUTH_REDIRECT
                 + "?Nonce=nonce1234&CertAuthorities=ABC&Version=1.0&SubmitUrl=submiturl&Context=serverContext";
         WebViewClient client = getCustomWebViewClient();

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -606,9 +606,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         context.acquireTokenByRefreshToken("refresh", "clientId", "resource", mockCallback);
 
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
-        assertTrue("Exception type", mockCallback.mException instanceof AuthenticationException);
+        assertTrue("Exception type", mockCallback.getException() instanceof AuthenticationException);
         assertEquals("Connection related error code", ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE,
-                ((AuthenticationException) mockCallback.mException).getCode());
+                ((AuthenticationException) mockCallback.getException()).getCode());
     }
 
 
@@ -643,8 +643,10 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Verify that new refresh token is matching to mock response
-        assertEquals("Same token", "I am a new access token", callback.mResult.getAccessToken());
-        assertEquals("Same refresh token", "I am a new refresh token", callback.mResult.getRefreshToken());
+        assertEquals("Same token", "I am a new access token",
+                callback.getAuthenticationResult().getAccessToken());
+        assertEquals("Same refresh token", "I am a new refresh token",
+                callback.getAuthenticationResult().getRefreshToken());
 
         final CountDownLatch signal2 = new CountDownLatch(1);
         callback = new MockAuthenticationCallback(signal2);
@@ -653,12 +655,15 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal2.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Verify that new refresh token is matching to mock response
-        assertEquals("Same token", "I am a new access token", callback.mResult.getAccessToken());
-        assertEquals("Same refresh token", "I am a new refresh token", callback.mResult.getRefreshToken());
+        assertEquals("Same token", "I am a new access token",
+                callback.getAuthenticationResult().getAccessToken());
+        assertEquals("Same refresh token", "I am a new refresh token",
+                callback.getAuthenticationResult().getRefreshToken());
 
-        assertNotNull("Result has user info from idtoken", callback.mResult.getUserInfo());
+        assertNotNull("Result has user info from idtoken",
+                callback.getAuthenticationResult().getUserInfo());
         assertEquals("Result has user info from idtoken", TEST_IDTOKEN_UPN,
-                callback.mResult.getUserInfo().getDisplayableId());
+                callback.getAuthenticationResult().getUserInfo().getDisplayableId());
     }
 
     public void testAcquireTokenByRefreshTokenNotReturningRefreshToken() throws IOException, InterruptedException {
@@ -683,8 +688,10 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Verify that new refresh token is matching to mock response
-        assertEquals("Same token", "I am a new access token", callback.mResult.getAccessToken());
-        assertEquals("Same refresh token", refreshToken, callback.mResult.getRefreshToken());
+        assertEquals("Same token", "I am a new access token",
+                callback.getAuthenticationResult().getAccessToken());
+        assertEquals("Same refresh token", refreshToken,
+                callback.getAuthenticationResult().getRefreshToken());
     }
 
     /**
@@ -706,9 +713,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback result
-        assertNotNull("Error is not null", callback.mException);
+        assertNotNull("Error is not null", callback.getException());
         assertEquals("NOT_VALID_URL", ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL,
-                ((AuthenticationException) callback.mException).getCode());
+                ((AuthenticationException) callback.getException()).getCode());
     }
 
     /**
@@ -734,7 +741,7 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback result
-        assertNull("Error is null", callback.mException);
+        assertNull("Error is null", callback.getException());
         assertEquals("Activity was attempted to start with request code",
                 AuthenticationConstants.UIRequest.BROWSER_FLOW,
                 testActivity.mStartActivityRequestCode);
@@ -757,7 +764,7 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check correlationID that was set in the Discovery obj
-        assertNull("Error is null", callback.mException);
+        assertNull("Error is null", callback.getException());
         assertEquals("Activity was attempted to start with request code",
                 AuthenticationConstants.UIRequest.BROWSER_FLOW,
                 testActivity.mStartActivityRequestCode);
@@ -784,9 +791,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback result
-        assertNotNull("Error is not null", callback.mException);
+        assertNotNull("Error is not null", callback.getException());
         assertEquals("NOT_VALID_URL", ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE,
-                ((AuthenticationException) callback.mException).getCode());
+                ((AuthenticationException) callback.getException()).getCode());
         assertTrue(
                 "Activity was not attempted to start with request code",
                 AuthenticationConstants.UIRequest.BROWSER_FLOW != testActivity.mStartActivityRequestCode);
@@ -825,7 +832,7 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback result
-        assertNull("Error is null", callback.mException);
+        assertNull("Error is null", callback.getException());
         assertEquals("Activity was attempted to start with request code",
                 AuthenticationConstants.UIRequest.BROWSER_FLOW,
                 testActivity.mStartActivityRequestCode);
@@ -869,7 +876,8 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        verifyRefreshTokenResponse(mockCache, callback.mException, callback.mResult);
+        verifyRefreshTokenResponse(mockCache, callback.getException(),
+                callback.getAuthenticationResult());
 
         // Do silent token request and return idtoken in the result
 
@@ -922,15 +930,15 @@ public final class AuthenticationContextTest extends AndroidTestCase {
                 "resource", "clientid", "redirectUri", acquireTokenHint, callback);
 
         // Token will return to callback with idToken
-        verifyTokenResult(idtoken, callback.mResult);
+        verifyTokenResult(idtoken, callback.getAuthenticationResult());
 
         // Same call should get token from cache
         final CountDownLatch signalCallback2 = new CountDownLatch(1);
-        callback.mSignal = signalCallback2;
+        callback.setSignal(signalCallback2);
         context.acquireToken(testActivity, "resource", "clientid", "redirectUri", acquireTokenHint,
                 callback);
         signalCallback2.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
-        verifyTokenResult(idtoken, callback.mResult);
+        verifyTokenResult(idtoken, callback.getAuthenticationResult());
 
         // Call with userId should return from cache as well
         AuthenticationResult result = context.acquireTokenSilentSync("resource", "clientid",
@@ -983,14 +991,14 @@ public final class AuthenticationContextTest extends AndroidTestCase {
                 "resource", "clientid", "redirectUri", loginHint, callback);
 
         // Token will return to callback with idToken
-        verifyTokenResult(idtoken, callback.mResult);
+        verifyTokenResult(idtoken, callback.getAuthenticationResult());
 
         // Same call with correct upn will return from cache
         final CountDownLatch signalCallback2 = new CountDownLatch(1);
-        callback.mSignal = signalCallback2;
+        callback.setSignal(signalCallback2);
         context.acquireToken(testActivity, "resource", "clientid", "redirectUri", loginHint, callback);
         signalCallback2.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
-        verifyTokenResult(idtoken, callback.mResult);
+        verifyTokenResult(idtoken, callback.getAuthenticationResult());
 
         // Call with userId should return from cache as well
         AuthenticationResult result = context.acquireTokenSilentSync("resource", "clientid",
@@ -1029,7 +1037,7 @@ public final class AuthenticationContextTest extends AndroidTestCase {
                 "resource", "clientid", "redirectUri", null, callback);
 
         // Token will return to callback with idToken
-        verifyTokenResult(null, callback.mResult);
+        verifyTokenResult(null, callback.getAuthenticationResult());
 
         // Call with userId should return from cache as well
         AuthenticationResult result = context.acquireTokenSilentSync("resource", "clientid", null);
@@ -1076,7 +1084,8 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        verifyRefreshTokenResponse(mockCache, callback.mException, callback.mResult);
+        verifyRefreshTokenResponse(mockCache, callback.getException(),
+                callback.getAuthenticationResult());
         verifyFamilyIdStoredInTokenCacheItem(mockCache,
                 CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId", TEST_IDTOKEN_UPN), "1");
 
@@ -1298,18 +1307,24 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        assertNull("Error is null", callback.mException);
-        assertEquals("Same access token in cache", tokenToTest, callback.mResult.getAccessToken());
+        assertNull("Error is null", callback.getException());
+        assertEquals("Same access token in cache", tokenToTest,
+                callback.getAuthenticationResult().getAccessToken());
         assertEquals("Same refresh token in cache", "refreshToken",
-                callback.mResult.getRefreshToken());
-        assertEquals("Same userid in cache", "userId124", callback.mResult.getUserInfo()
+                callback.getAuthenticationResult().getRefreshToken());
+        assertEquals("Same userid in cache", "userId124",
+                callback.getAuthenticationResult().getUserInfo()
                 .getUserId());
-        assertEquals("Same name in cache", "name", callback.mResult.getUserInfo().getGivenName());
-        assertEquals("Same familyName in cache", "familyName", callback.mResult.getUserInfo()
+        assertEquals("Same name in cache", "name",
+                callback.getAuthenticationResult().getUserInfo().getGivenName());
+        assertEquals("Same familyName in cache", "familyName",
+                callback.getAuthenticationResult().getUserInfo()
                 .getFamilyName());
-        assertEquals("Same displayid in cache", "userA", callback.mResult.getUserInfo()
+        assertEquals("Same displayid in cache", "userA",
+                callback.getAuthenticationResult().getUserInfo()
                 .getDisplayableId());
-        assertEquals("Same tenantid in cache", "tenantId", callback.mResult.getTenantId());
+        assertEquals("Same tenantid in cache", "tenantId",
+                callback.getAuthenticationResult().getTenantId());
         clearCache(context);
     }
 
@@ -1351,10 +1366,10 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         context.acquireTokenSilentAsync(resource, clientId, "user1", callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
-        assertNotNull("Error is not null", callback.mException);
+        assertNotNull("Error is not null", callback.getException());
         assertTrue(
                 "Error is related to user mismatch",
-                callback.mException.getMessage().contains(
+                callback.getException().getMessage().contains(
                         "User returned by service does not match the one in the request"));
         clearCache(context);
     }
@@ -1391,9 +1406,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         context.acquireTokenSilentAsync(resource, clientId, null, callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
-        assertNull(callback.mException);
-        assertNotNull(callback.mResult);
-        assertNotNull(callback.mResult.getAccessToken());
+        assertNull(callback.getException());
+        assertNotNull(callback.getAuthenticationResult());
+        assertNotNull(callback.getAuthenticationResult().getAccessToken());
     }
 
     @SmallTest
@@ -1445,10 +1460,13 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        assertNull("Error is null", callback.mException);
-        assertEquals("token for user1", "token1", callback.mResult.getAccessToken());
-        assertEquals("idtoken for user1", "userName1", callback.mResult.getUserInfo().getDisplayableId());
-        assertEquals("idtoken for user1", "userAname", callback.mResult.getUserInfo().getGivenName());
+        assertNull("Error is null", callback.getException());
+        assertEquals("token for user1", "token1",
+                callback.getAuthenticationResult().getAccessToken());
+        assertEquals("idtoken for user1", "userName1",
+                callback.getAuthenticationResult().getUserInfo().getDisplayableId());
+        assertEquals("idtoken for user1", "userAname",
+                callback.getAuthenticationResult().getUserInfo().getGivenName());
 
         // User2 with userid call
         final CountDownLatch signal2 = new CountDownLatch(1);
@@ -1459,9 +1477,11 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal2.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        assertNull("Error is null", callback2.mException);
-        assertEquals("token for user1", "token2", callback2.mResult.getAccessToken());
-        assertEquals("idtoken for user1", "userName2", callback2.mResult.getUserInfo().getDisplayableId());
+        assertNull("Error is null", callback2.getException());
+        assertEquals("token for user1", "token2",
+                callback2.getAuthenticationResult().getAccessToken());
+        assertEquals("idtoken for user1", "userName2",
+                callback2.getAuthenticationResult().getUserInfo().getDisplayableId());
 
         // User2 with loginHint call
         final CountDownLatch signal3 = new CountDownLatch(1);
@@ -1473,13 +1493,14 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal3.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        assertNull("Error is null", callback3.mException);
-        assertEquals("token for user1", "token1", callback3.mResult.getAccessToken());
-        assertEquals("idtoken for user1", "userName1", callback3.mResult.getUserInfo().getDisplayableId());
+        assertNull("Error is null", callback3.getException());
+        assertEquals("token for user1", "token1",
+                callback3.getAuthenticationResult().getAccessToken());
+        assertEquals("idtoken for user1", "userName1",
+                callback3.getAuthenticationResult().getUserInfo().getDisplayableId());
 
         clearCache(context);
     }
-
 
     @SmallTest
     public void testOnActivityResultMissingIntentData() throws NoSuchAlgorithmException,
@@ -1727,9 +1748,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         // 1st token request, read from cache.
         context.acquireToken(testActivity, resource, "ClienTid", "redirectUri", TEST_IDTOKEN_UPN, callback);
         signal.await(requestWaitMs, TimeUnit.MILLISECONDS);
-        assertNull("Error is null", callback.mException);
+        assertNull("Error is null", callback.getException());
         assertEquals("Same token in response as in cache", tokenToTest,
-                callback.mResult.getAccessToken());
+                callback.getAuthenticationResult().getAccessToken());
 
         // 2nd token request, use MRRT to refresh
         signal = new CountDownLatch(1);
@@ -1738,9 +1759,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
                 callback);
         signal.await(requestWaitMs, TimeUnit.MILLISECONDS);
 
-        assertNull("Error is null", callback.mException);
+        assertNull("Error is null", callback.getException());
         assertEquals("Same token as refresh token result", expectedAT,
-                callback.mResult.getAccessToken());
+                callback.getAuthenticationResult().getAccessToken());
 
         // 3rd request, different resource with same userid
         signal = new CountDownLatch(1);
@@ -1751,21 +1772,21 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(requestWaitMs, TimeUnit.MILLISECONDS);
 
         assertEquals("Token is returned from refresh token request", expectedAT,
-                callback.mResult.getAccessToken());
+                callback.getAuthenticationResult().getAccessToken());
         assertFalse("Multiresource is not set in the mocked response",
-                callback.mResult.getIsMultiResourceRefreshToken());
+                callback.getAuthenticationResult().getIsMultiResourceRefreshToken());
 
         // Same call again to use it from cache
         signal = new CountDownLatch(1);
         callback = new MockAuthenticationCallback(signal);
-        callback.mResult = null;
+        callback.setAuthenticationResult(null);
         HttpUrlConnectionFactory.mockedConnection = null;
         context.acquireToken(testActivity, "anotherResource123", "ClienTid", "redirectUri", TEST_IDTOKEN_UPN,
                 callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         assertEquals("Same token in response as in cache for same call", expectedAT,
-                callback.mResult.getAccessToken());
+                callback.getAuthenticationResult().getAccessToken());
 
         // Empty userid will prompt.
         // Items are linked to userid. If it is not there, it can't use for
@@ -1776,7 +1797,8 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         context.acquireToken(testActivity, resource, "ClienTid", "redirectUri", "", callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
-        assertNull("Result is null since it tries to start activity", callback.mResult);
+        assertNull("Result is null since it tries to start activity",
+                callback.getAuthenticationResult());
         assertEquals("Activity was attempted to start.",
                 AuthenticationConstants.UIRequest.BROWSER_FLOW,
                 testActivity.mStartActivityRequestCode);
@@ -1822,9 +1844,9 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         // Check response in callback
-        assertNull("Error is null", callback.mException);
+        assertNull("Error is null", callback.getException());
         assertEquals("Same token in response as in cache", tokenToTest,
-                callback.mResult.getAccessToken());
+                callback.getAuthenticationResult().getAccessToken());
 
         // Request with different resource will result in prompt since Cache
         // does not have multi resource token

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
@@ -38,12 +38,8 @@ import java.util.concurrent.CountDownLatch;
 import com.microsoft.aad.adal.AuthenticationParameters.AuthenticationParamCallback;
 import com.microsoft.aad.adal.Logger.ILogger;
 import com.microsoft.aad.adal.Logger.LogLevel;
-
-import android.test.suitebuilder.annotation.Suppress;
 import android.util.Log;
-
 import junit.framework.Assert;
-
 import org.mockito.Mockito;
 
 public class AuthenticationParamsTests extends AndroidTestHelper {
@@ -106,8 +102,10 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
         Util.prepareMockedUrlConnection(mockedConnection);
 
         final String response = "Bearer authorization_uri=\"https://login.windows.net/test.onmicrosoft.com\", resource=\"testresource\"";
-        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(401);
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(
+                Util.createInputStream(response));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(
+                HttpURLConnection.HTTP_UNAUTHORIZED);
 
         Mockito.when(mockedConnection.getHeaderFields()).thenReturn(Collections.singletonMap(
                 AuthenticationParameters.AUTHENTICATE_HEADER, Collections.singletonList(response)));

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationRequestTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationRequestTests.java
@@ -31,6 +31,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 
 public class AuthenticationRequestTests extends AndroidTestCase {
+    static final int REQUEST_ID = 1234;
 
     @Override
     protected void setUp() throws Exception {
@@ -128,9 +129,8 @@ public class AuthenticationRequestTests extends AndroidTestCase {
             InvocationTargetException {
         Object o = ReflectionUtils.getInstance(ReflectionUtils.TEST_PACKAGE_NAME
                 + ".AuthenticationRequest", "authority1", "resource2", "client3");
-        ReflectionUtils.setterValue(o, "setRequestId", Integer.valueOf(1234));
+        ReflectionUtils.setterValue(o, "setRequestId", Integer.valueOf(REQUEST_ID));
         int actual = ReflectionUtils.getterValue(Integer.class, o, "getRequestId");
-        assertEquals("Same RequestId", 1234, actual);
+        assertEquals("Same RequestId", REQUEST_ID, actual);
     }
-
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BaseTokenStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BaseTokenStoreTests.java
@@ -24,22 +24,41 @@
 package com.microsoft.aad.adal;
 
 import java.util.Locale;
-
 import android.content.Context;
 
 public abstract class BaseTokenStoreTests extends AndroidTestHelper {
 
     protected static final String TEST_AUTHORITY2 = "https://Developer.AndroiD.com/reference/android";
 
-    protected Context mCtx;
+    private Context mCtx;
 
-    protected TokenCacheItem mTestItem;
+    private TokenCacheItem mTestItem;
 
-    protected TokenCacheItem mTestItem2;
+    private TokenCacheItem mTestItem2;
 
-    protected TokenCacheItem mTestItemUser2;
+    private TokenCacheItem mTestItemUser2;
 
-    protected TokenCacheItem mTestItemMultiResourceUser2;
+    private TokenCacheItem mTestItemMultiResourceUser2;
+
+    Context getContext() {
+        return mCtx;
+    }
+
+    TokenCacheItem getTestItem() {
+        return mTestItem;
+    }
+
+    TokenCacheItem getTestItem2() {
+        return mTestItem2;
+    }
+
+    TokenCacheItem getTestItemUser2() {
+        return mTestItemUser2;
+    }
+
+    TokenCacheItem getTestItemMultiResourceUser2() {
+        return mTestItemMultiResourceUser2;
+    }
 
     @Override
     protected void setUp() throws Exception {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/CacheKeyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/CacheKeyTests.java
@@ -66,7 +66,7 @@ public class CacheKeyTests extends AndroidTestCase {
     /**
      * empty values does not fail
      */
-    public void testcreateCacheKey_EmptyValues() {
+    public void testcreateCacheKeyEmptyValues() {
         String testKey = CacheKey.createCacheKey("", "", "", false, "", "");
         assertEquals("expected key", "$$$n$null$foci-", testKey);
 
@@ -77,17 +77,17 @@ public class CacheKeyTests extends AndroidTestCase {
         assertEquals("expected key", "$$$n$userid$foci-", testKeyWithUser);
     }
 
-    public void testcreateCacheKey_NullItem() {
+    public void testcreateCacheKeyNullItem() {
 
         try {
-            CacheKey.createCacheKey((TokenCacheItem)null);
+            CacheKey.createCacheKey((TokenCacheItem) null);
             Assert.fail("not expected");
         } catch (Exception exc) {
             assertTrue("argument exception", exc instanceof IllegalArgumentException);
         }
     }
 
-    public void testcreateCacheKey_NullArgument() {
+    public void testcreateCacheKeyNullArgument() {
 
         try {
             CacheKey.createCacheKey(null, null, null, false, null, null);
@@ -97,7 +97,7 @@ public class CacheKeyTests extends AndroidTestCase {
         }
     }
 
-    public void testcreateCacheKey_NullResource() {
+    public void testcreateCacheKeyNullResource() {
 
         // Test resource is null and the cache key is not for MRRT
         try {
@@ -105,7 +105,8 @@ public class CacheKeyTests extends AndroidTestCase {
             Assert.fail("not expected");
         } catch (Exception exc) {
             assertTrue("argument exception", exc instanceof IllegalArgumentException);
-            assertEquals("contains resource", "resource", ((IllegalArgumentException)exc).getMessage());
+            assertEquals("contains resource", "resource",
+                    ((IllegalArgumentException) exc).getMessage());
         }
         
         // Test resource is null but the cache key is for MRRT. 
@@ -117,7 +118,7 @@ public class CacheKeyTests extends AndroidTestCase {
         }
     }
     
-    public void testcreateCacheKey_NullClientid() {
+    public void testcreateCacheKeyNullClientid() {
 
         // Test both client id and family client id is null
         try {
@@ -125,7 +126,8 @@ public class CacheKeyTests extends AndroidTestCase {
             fail("Expect exceptions");
         } catch (Exception exc) {
             assertTrue("argument exception", exc instanceof IllegalArgumentException);
-            assertEquals("contains clientId", "both clientId and familyClientId are null", ((IllegalArgumentException)exc).getMessage());
+            assertEquals("contains clientId", "both clientId and familyClientId are null",
+                    ((IllegalArgumentException) exc).getMessage());
         }
         
         // Test client id is null but family client id is not null

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
@@ -60,11 +60,11 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
         String thumbPrint = "thumbprint23432432";
         X509Certificate mockCert = mock(X509Certificate.class);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
-        MockDeviceCertProxy.sThumbPrint = thumbPrint;
-        MockDeviceCertProxy.sPrivateKey = privateKey;
-        MockDeviceCertProxy.sPublicKey = publicKey;
-        MockDeviceCertProxy.sCertificate = mockCert;
+        MockDeviceCertProxy.setIsValidIssuer(true);
+        MockDeviceCertProxy.setThumbPrint(thumbPrint);
+        MockDeviceCertProxy.setPrivateKey(privateKey);
+        MockDeviceCertProxy.setPublicKey(publicKey);
+        MockDeviceCertProxy.setCertificate(mockCert);
         IJWSBuilder mockJwsBuilder = mock(IJWSBuilder.class);
         when(mockJwsBuilder.generateSignedJWT(nonce, submitUrl, privateKey, publicKey, mockCert))
                 .thenReturn("signedJwtHere");
@@ -99,10 +99,10 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
         String context = "ABcdeded";
         X509Certificate mockCert = mock(X509Certificate.class);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
-        MockDeviceCertProxy.sPrivateKey = privateKey;
-        MockDeviceCertProxy.sPublicKey = publicKey;
-        MockDeviceCertProxy.sCertificate = mockCert;
+        MockDeviceCertProxy.setIsValidIssuer(true);
+        MockDeviceCertProxy.setPrivateKey(privateKey);
+        MockDeviceCertProxy.setPublicKey(publicKey);
+        MockDeviceCertProxy.setCertificate(mockCert);
         IJWSBuilder mockJwsBuilder = mock(IJWSBuilder.class);
         when(mockJwsBuilder.generateSignedJWT(nonce, submitUrl, privateKey, publicKey, mockCert))
                 .thenReturn("signedJwtHere");
@@ -175,10 +175,10 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
 
         X509Certificate mockCert = mock(X509Certificate.class);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
-        MockDeviceCertProxy.sPrivateKey = privateKey;
-        MockDeviceCertProxy.sPublicKey = publicKey;
-        MockDeviceCertProxy.sCertificate = mockCert;
+        MockDeviceCertProxy.setIsValidIssuer(true);
+        MockDeviceCertProxy.setPrivateKey(privateKey);
+        MockDeviceCertProxy.setPublicKey(publicKey);
+        MockDeviceCertProxy.setCertificate(mockCert);
 
         final String nonce = "123123-123213-123";
         final String context = "ABcdeded";
@@ -226,7 +226,7 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
         Object mockJwsBuilder = mock(IJWSBuilder.class);
         Object handler = getInstance(mockJwsBuilder);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = false;
+        MockDeviceCertProxy.setIsValidIssuer(false);
         Method m = ReflectionUtils.getTestMethod(handler, "getChallengeResponseFromUri",
                 String.class);
         String submitUrl = "http://fs.contoso.com/adfs/services/trust";
@@ -269,7 +269,7 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
         Object mockJwsBuilder = mock(IJWSBuilder.class);
         Object handler = getInstance(mockJwsBuilder);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = false;
+        MockDeviceCertProxy.setIsValidIssuer(false);
         Method m = ReflectionUtils.getTestMethod(handler, "getChallengeResponseFromUri",
                 String.class);
 
@@ -327,7 +327,7 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
         Object mockJwsBuilder = mock(IJWSBuilder.class);
         Object handler = getInstance(mockJwsBuilder);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
+        MockDeviceCertProxy.setIsValidIssuer(true);
         Method m = ReflectionUtils.getTestMethod(handler, "getChallengeResponseFromUri",
                 String.class);
         String submitUrl = "http://fs.contoso.com/adfs/services/trust";
@@ -356,10 +356,10 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
         String context = "ABcdeded";
         X509Certificate mockCert = mock(X509Certificate.class);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
-        MockDeviceCertProxy.sPrivateKey = privateKey;
-        MockDeviceCertProxy.sPublicKey = publicKey;
-        MockDeviceCertProxy.sCertificate = mockCert;
+        MockDeviceCertProxy.setIsValidIssuer(true);
+        MockDeviceCertProxy.setPrivateKey(privateKey);
+        MockDeviceCertProxy.setPublicKey(publicKey);
+        MockDeviceCertProxy.setCertificate(mockCert);
         IJWSBuilder mockJwsBuilder = mock(IJWSBuilder.class);
         when(mockJwsBuilder.generateSignedJWT(nonce, submitUrl, privateKey, publicKey, mockCert))
                 .thenReturn("signedJwtHere");

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/DefaultTokenCacheStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/DefaultTokenCacheStoreTests.java
@@ -52,13 +52,12 @@ public class DefaultTokenCacheStoreTests extends BaseTokenStoreTests {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        mCtx = this.getInstrumentation().getContext();
     }
 
     @Override
     protected void tearDown() throws Exception {
         AuthenticationSettings.INSTANCE.setSharedPrefPackageName(null);
-        DefaultTokenCacheStore store = new DefaultTokenCacheStore(mCtx);
+        DefaultTokenCacheStore store = new DefaultTokenCacheStore(getContext());
         store.removeAll();
         super.tearDown();
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
@@ -62,7 +62,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final String response = "{\"tenant_discovery_endpoint\":\"valid endpoint\"}";
         Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final URL testingURL = new URL("https://login.somewhere.com/path");
         try {
@@ -115,7 +115,8 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final String response = "{\"error_codes\":\"errors\"}";
         Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(400);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(
+                HttpURLConnection.HTTP_BAD_REQUEST);
 
         try {
             discovery.validateAuthority(endpointFull);
@@ -135,7 +136,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final String response = "{invalidJson}";
         Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final URL endpointFull = new URL("https://login.invalidlogin.net/common/oauth2/authorize");
         try {
@@ -211,7 +212,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final String response = "{\"tenant_discovery_endpoint\":\"valid endpoint\"}";
         Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         try {
             discovery.validateAuthority(endpointFull);
@@ -236,7 +237,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final String addHostResponse = "{\"tenant_discovery_endpoint\":\"valid endpoint\"}";
         Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(addHostResponse));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final URL endpointTest = new URL("https://login.test-direct-add.net/common");
         try {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/FileTokenCacheStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/FileTokenCacheStoreTests.java
@@ -291,7 +291,7 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
 
         private String mLogMessage;
 
-        ADALError mLogErrorCode;
+        private ADALError mLogErrorCode;
 
         @Override
         public void Log(String tag, String message, String additionalMessage, LogLevel level,
@@ -302,6 +302,10 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
 
         public String getLogMessage() {
             return mLogMessage;
+        }
+
+        public ADALError getErrorCode() {
+            return mLogErrorCode;
         }
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
@@ -66,7 +66,7 @@ public class HttpDialogTests extends AndroidTestCase {
         AuthenticationSettings.INSTANCE.setBrokerSignature(testTag);
         AuthenticationSettings.INSTANCE
                 .setBrokerPackageName(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
-        Log.d(TAG, "testSignature is set");
+        Log.d(TAG, "mTestSignature is set");
     }
 
     public void testCreateDialogTest() throws NoSuchMethodException, ClassNotFoundException, IllegalArgumentException,

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MemoryTokenCacheStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MemoryTokenCacheStoreTests.java
@@ -42,7 +42,6 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        mCtx = this.getInstrumentation().getContext();
     }
 
     @Override
@@ -73,15 +72,15 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
                 // Remove and then verify that
                 // One thread will do the actual remove action.
                 try {
-                    store.removeItem(CacheKey.createCacheKey(mTestItem));
-                    TokenCacheItem item = store.getItem(CacheKey.createCacheKey(mTestItem));
+                    store.removeItem(CacheKey.createCacheKey(getTestItem()));
+                    TokenCacheItem item = store.getItem(CacheKey.createCacheKey(getTestItem()));
                     assertNull("Token cache item is expected to be null", item);
 
                     item = store.getItem(CacheKey.createCacheKey("", "", "", false, "", null));
                     assertNull("Token cache item is expected to be null", item);
 
-                    store.removeItem(CacheKey.createCacheKey(mTestItem2));
-                    item = store.getItem(CacheKey.createCacheKey(mTestItem));
+                    store.removeItem(CacheKey.createCacheKey(getTestItem2()));
+                    item = store.getItem(CacheKey.createCacheKey(getTestItem()));
                     assertNull("Token cache item is expected to be null", item);
                 } catch (AuthenticationException e) {
                     e.printStackTrace();
@@ -93,7 +92,7 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
 
         testMultiThread(activeTestThreads, signal, runnable);
 
-        TokenCacheItem item = store.getItem(CacheKey.createCacheKey(mTestItem));
+        TokenCacheItem item = store.getItem(CacheKey.createCacheKey(getTestItem()));
         assertNull("Token cache item is expected to be null", item);
     }
 
@@ -117,15 +116,15 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
         fileIn.close();
 
         // Verify the cache
-        TokenCacheItem item = deSerialized.getItem(CacheKey.createCacheKey(mTestItem));
+        TokenCacheItem item = deSerialized.getItem(CacheKey.createCacheKey(getTestItem()));
         assertNotNull("Token cache item is expected to be NOT null", item);
 
-        item = deSerialized.getItem(CacheKey.createCacheKey(mTestItem2));
+        item = deSerialized.getItem(CacheKey.createCacheKey(getTestItem2()));
         assertNotNull("Token cache item is expected to be NOT null", item);
 
         // do remove operation
-        deSerialized.removeItem(CacheKey.createCacheKey(mTestItem));
-        item = deSerialized.getItem(CacheKey.createCacheKey(mTestItem));
+        deSerialized.removeItem(CacheKey.createCacheKey(getTestItem()));
+        item = deSerialized.getItem(CacheKey.createCacheKey(getTestItem()));
         assertNull("Token cache item is expected to be null", item);
     }
 
@@ -145,22 +144,21 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
                 .getContext(), VALID_AUTHORITY, false, tokenCacheA);
 
         // Verify the cache
-        TokenCacheItem item = contextA.getCache().getItem(CacheKey.createCacheKey(mTestItem));
+        TokenCacheItem item = contextA.getCache().getItem(CacheKey.createCacheKey(getTestItem()));
         assertNotNull("Token cache item is expected to be NOT null", item);
 
-        item = contextA.getCache().getItem(CacheKey.createCacheKey(mTestItem2));
+        item = contextA.getCache().getItem(CacheKey.createCacheKey(getTestItem2()));
         assertNotNull("Token cache item is expected to be NOT null", item);
-        item = contextB.getCache().getItem(CacheKey.createCacheKey(mTestItem2));
+        item = contextB.getCache().getItem(CacheKey.createCacheKey(getTestItem2()));
         assertNotNull("Token cache item is expected to be NOT null", item);
 
         // do remove operation
-        contextA.getCache().removeItem(CacheKey.createCacheKey(mTestItem));
-        item = contextA.getCache().getItem(CacheKey.createCacheKey(mTestItem));
+        contextA.getCache().removeItem(CacheKey.createCacheKey(getTestItem()));
+        item = contextA.getCache().getItem(CacheKey.createCacheKey(getTestItem()));
         assertNull("Token cache item is expected to be null", item);
 
-        item = contextB.getCache().getItem(CacheKey.createCacheKey(mTestItem));
+        item = contextB.getCache().getItem(CacheKey.createCacheKey(getTestItem()));
         assertNull("Token cache item is expected to be null", item);
-
     }
 
     @Override

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockAuthenticationCallback.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockAuthenticationCallback.java
@@ -30,11 +30,11 @@ import java.util.concurrent.CountDownLatch;
  */
 class MockAuthenticationCallback implements AuthenticationCallback<AuthenticationResult> {
 
-    Exception mException = null;
+    private Exception mException = null;
 
-    AuthenticationResult mResult = null;
+    private AuthenticationResult mResult = null;
 
-    CountDownLatch mSignal;
+    private CountDownLatch mSignal;
 
     public MockAuthenticationCallback() {
         mSignal = null;
@@ -47,14 +47,40 @@ class MockAuthenticationCallback implements AuthenticationCallback<Authenticatio
     @Override
     public void onSuccess(AuthenticationResult result) {
         mResult = result;
-        if (mSignal != null)
+        if (mSignal != null) {
             mSignal.countDown();
+        }
     }
 
     @Override
     public void onError(Exception exc) {
         mException = exc;
-        if (mSignal != null)
+        if (mSignal != null) {
             mSignal.countDown();
+        }
+    }
+
+    final void setException(final Exception exception) {
+        mException = exception;
+    }
+
+    final Exception getException() {
+        return mException;
+    }
+
+    final void setAuthenticationResult(final AuthenticationResult result) {
+        mResult = result;
+    }
+
+    final AuthenticationResult getAuthenticationResult() {
+        return mResult;
+    }
+
+    final void setSignal(final CountDownLatch signal) {
+        mSignal = signal;
+    }
+
+    final CountDownLatch getSignal() {
+        return mSignal;
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockDeviceCertProxy.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockDeviceCertProxy.java
@@ -36,15 +36,15 @@ import java.util.List;
  */
 public class MockDeviceCertProxy implements IDeviceCertificate {
 
-    static X509Certificate sCertificate = null;
+    private static X509Certificate sCertificate = null;
 
-    static RSAPrivateKey sPrivateKey = null;
+    private static RSAPrivateKey sPrivateKey = null;
 
-    static RSAPublicKey sPublicKey = null;
+    private static RSAPublicKey sPublicKey = null;
 
-    static String sThumbPrint = null;
+    private static String sThumbPrint = null;
 
-    static boolean sValidIssuer = false;
+    private static boolean sValidIssuer = false;
 
     public static void reset() {
         sCertificate = null;
@@ -77,5 +77,25 @@ public class MockDeviceCertProxy implements IDeviceCertificate {
     public boolean isValidIssuer(List<String> certAuthorities) {
         // TODO Auto-generated method stub
         return sValidIssuer;
+    }
+
+    static final void setCertificate(final X509Certificate certificate) {
+        sCertificate = certificate;
+    }
+
+    static final void setPrivateKey(final RSAPrivateKey privateKey) {
+        sPrivateKey = privateKey;
+    }
+
+    static final void setPublicKey(final RSAPublicKey publicKey) {
+        sPublicKey = publicKey;
+    }
+
+    static final void setThumbPrint(final String thumbPrint) {
+        sThumbPrint = thumbPrint;
+    }
+
+    static final void setIsValidIssuer(final boolean isValidIssuer) {
+        sValidIssuer = isValidIssuer;
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockWebRequestHandler.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockWebRequestHandler.java
@@ -86,8 +86,8 @@ class MockWebRequestHandler implements IWebRequestHandler {
         return mRequestHeaders;
     }
 
-    public void setReturnResponse(HttpWebResponse mReturnResponse) {
-        this.mReturnResponse = mReturnResponse;
+    public void setReturnResponse(HttpWebResponse returnResponse) {
+        this.mReturnResponse = returnResponse;
     }
 
     public void setReturnException(String exception) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -403,7 +403,7 @@ public class OauthTests extends AndroidTestCase {
                 webrequest, "test");
 
         // Verify that callback can receive this error
-        assertNull("callback doesnot have error", testResult.getException());
+        assertNull("callback does not have error", testResult.getException());
         assertNotNull("Result is not null", testResult.getAuthenticationResult());
         assertEquals("Same access token", "sometokenhere",
                 testResult.getAuthenticationResult().getAccessToken());
@@ -455,7 +455,7 @@ public class OauthTests extends AndroidTestCase {
                 mockWebRequest, mockJwsBuilder, "testRefreshToken");
 
         // Verify that callback can receive this error
-        assertNull("callback doesnot have error", testResult.getException());
+        assertNull("callback does not have error", testResult.getException());
         assertNotNull("Result is not null", testResult.getAuthenticationResult());
         assertEquals("Same access token", "accessTokenHere",
                 testResult.getAuthenticationResult().getAccessToken());

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -335,9 +335,9 @@ public class OauthTests extends AndroidTestCase {
                 refreshToken);
 
         // Verify that we have error for request handler
-        assertTrue("web request argument error", testResult.mException.getMessage()
+        assertTrue("web request argument error", testResult.getException().getMessage()
                 .contains("webRequestHandler"));
-        assertNull("Result is null", testResult.mResult);
+        assertNull("Result is null", testResult.getAuthenticationResult());
     }
 
     @SmallTest
@@ -351,9 +351,9 @@ public class OauthTests extends AndroidTestCase {
         MockAuthenticationCallback testResult = refreshToken(request, webrequest, "test");
 
         // Verify that we have error for request handler
-        assertTrue("web request argument error", testResult.mException.getMessage()
+        assertTrue("web request argument error", testResult.getException().getMessage()
                 .contains("url"));
-        assertNull("Result is null", testResult.mResult);
+        assertNull("Result is null", testResult.getAuthenticationResult());
     }
 
     @SmallTest
@@ -366,9 +366,9 @@ public class OauthTests extends AndroidTestCase {
                 webrequest, "test");
 
         // Verify that callback can receive this error
-        assertTrue("callback receives error", testResult.mException.getMessage()
+        assertTrue("callback receives error", testResult.getException().getMessage()
                 .contains("request should return error"));
-        assertNull("Result is null", testResult.mResult);
+        assertNull("Result is null", testResult.getAuthenticationResult());
     }
 
     @SmallTest
@@ -384,10 +384,10 @@ public class OauthTests extends AndroidTestCase {
                 webrequest, "test");
 
         // Verify that callback can receive this error
-        assertNull("AuthenticationResult is null", testResult.mResult);
-        assertNotNull("Exception is not null", testResult.mException);
+        assertNull("AuthenticationResult is null", testResult.getAuthenticationResult());
+        assertNotNull("Exception is not null", testResult.getException());
         assertEquals("Exception has same error message", TEST_RETURNED_EXCEPTION,
-                testResult.mException.getMessage());
+                testResult.getException().getMessage());
     }
 
     @SmallTest
@@ -403,11 +403,12 @@ public class OauthTests extends AndroidTestCase {
                 webrequest, "test");
 
         // Verify that callback can receive this error
-        assertNull("callback doesnot have error", testResult.mException);
-        assertNotNull("Result is not null", testResult.mResult);
-        assertEquals("Same access token", "sometokenhere", testResult.mResult.getAccessToken());
+        assertNull("callback doesnot have error", testResult.getException());
+        assertNotNull("Result is not null", testResult.getAuthenticationResult());
+        assertEquals("Same access token", "sometokenhere",
+                testResult.getAuthenticationResult().getAccessToken());
         assertEquals("Same refresh token", "refreshfasdfsdf435",
-                testResult.mResult.getRefreshToken());
+                testResult.getAuthenticationResult().getRefreshToken());
     }
 
     @SuppressWarnings("unchecked")
@@ -424,10 +425,10 @@ public class OauthTests extends AndroidTestCase {
         final String thumbPrint = "thumbPrinttest";
         AuthenticationSettings.INSTANCE.setDeviceCertificateProxyClass(MockDeviceCertProxy.class);
         MockDeviceCertProxy.reset();
-        MockDeviceCertProxy.sValidIssuer = true;
-        MockDeviceCertProxy.sThumbPrint = thumbPrint;
-        MockDeviceCertProxy.sPrivateKey = privateKey;
-        MockDeviceCertProxy.sPublicKey = publicKey;
+        MockDeviceCertProxy.setIsValidIssuer(true);
+        MockDeviceCertProxy.setThumbPrint(thumbPrint);
+        MockDeviceCertProxy.setPrivateKey(privateKey);
+        MockDeviceCertProxy.setPublicKey(publicKey);
         final IJWSBuilder mockJwsBuilder = mock(IJWSBuilder.class);
         when(
                 mockJwsBuilder.generateSignedJWT(eq(nonce), any(String.class), eq(privateKey),
@@ -454,11 +455,12 @@ public class OauthTests extends AndroidTestCase {
                 mockWebRequest, mockJwsBuilder, "testRefreshToken");
 
         // Verify that callback can receive this error
-        assertNull("callback doesnot have error", testResult.mException);
-        assertNotNull("Result is not null", testResult.mResult);
-        assertEquals("Same access token", "accessTokenHere", testResult.mResult.getAccessToken());
+        assertNull("callback doesnot have error", testResult.getException());
+        assertNotNull("Result is not null", testResult.getAuthenticationResult());
+        assertEquals("Same access token", "accessTokenHere",
+                testResult.getAuthenticationResult().getAccessToken());
         assertEquals("Same refresh token", "refreshWithDeviceChallenge",
-                testResult.mResult.getRefreshToken());
+                testResult.getAuthenticationResult().getRefreshToken());
     }
 
     @SuppressWarnings("unchecked")
@@ -479,11 +481,11 @@ public class OauthTests extends AndroidTestCase {
                 mockWebRequest, "testRefreshToken");
 
         // Verify that callback can receive this error
-        assertNotNull("Callback has error", testResult.mException);
-        assertNotNull(testResult.mException);
-        assertTrue(testResult.mException instanceof AuthenticationException);
+        assertNotNull("Callback has error", testResult.getException());
+        assertNotNull(testResult.getException());
+        assertTrue(testResult.getException() instanceof AuthenticationException);
         assertEquals("Check error message", "Challenge header is empty",
-                testResult.mException.getMessage());
+                testResult.getException().getMessage());
     }
 
     @SmallTest
@@ -648,9 +650,9 @@ public class OauthTests extends AndroidTestCase {
         final Oauth2 oauth2 = createOAuthInstance(request, webRequest);
 
         try {
-            callback.mResult = oauth2.refreshToken(refreshToken);
+            callback.setAuthenticationResult(oauth2.refreshToken(refreshToken));
         } catch (Exception e) {
-            callback.mException = e;
+            callback.setException(e);
         }
 
         // callback has set the result from the call
@@ -665,9 +667,9 @@ public class OauthTests extends AndroidTestCase {
         final MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
         final Oauth2 oauth2 = createOAuthInstance(request, webRequest, jwsBuilder);
         try {
-            callback.mResult = oauth2.refreshToken(refreshToken);
+            callback.setAuthenticationResult(oauth2.refreshToken(refreshToken));
         } catch (Exception e) {
-            callback.mException = e;
+            callback.setException(e);
         }
 
         // callback has set the result from the call

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TestAuthCallback.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TestAuthCallback.java
@@ -40,8 +40,12 @@ final class TestAuthCallback implements AuthenticationCallback<AuthenticationRes
     }
 
     @Override
-    public void onSuccess(AuthenticationResult result) { mCallbackResult = result; }
+    public void onSuccess(AuthenticationResult result) {
+        mCallbackResult = result;
+    }
 
     @Override
-    public void onError(Exception exc) { mCallbackException = exc; }
+    public void onError(Exception exc) {
+        mCallbackException = exc;
+    }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/UserInfoTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/UserInfoTests.java
@@ -33,6 +33,7 @@ import android.util.Base64;
 import junit.framework.TestCase;
 
 public class UserInfoTests extends TestCase {
+    static final int MILLISECONDS_TO_SECONDS = 1000;
 
     @SmallTest
     public void testUserInfo() {
@@ -45,7 +46,7 @@ public class UserInfoTests extends TestCase {
     }
 
     @SmallTest
-    public void testIdTokenParam_upn() throws UnsupportedEncodingException, AuthenticationException {
+    public void testIdTokenParamUpn() throws UnsupportedEncodingException, AuthenticationException {
         IdToken idToken = new IdToken(getIdToken("objectid", "upnid", "email", "subj"));
         UserInfo info = new UserInfo(idToken);
         assertEquals("same userid", "objectid", info.getUserId());
@@ -88,7 +89,7 @@ public class UserInfoTests extends TestCase {
     }
 
     @SmallTest
-    public void testIdTokenParam_password() throws AuthenticationException, UnsupportedEncodingException {
+    public void testIdTokenParamPassword() throws AuthenticationException, UnsupportedEncodingException {
         final String rawIdToken = getIdToken("objectid", "upnid", "email", "subj");
         final IdToken idToken = new IdToken(rawIdToken);
         final UserInfo info = new UserInfo(idToken);
@@ -101,27 +102,27 @@ public class UserInfoTests extends TestCase {
         assertEquals("same family name", "familyName", info.getFamilyName());
         assertEquals("same idenity name", "provider", info.getIdentityProvider());
         assertEquals("check displayable", "upnid", info.getDisplayableId());
-        assertEquals("check expireson", expires.getTime().getTime() / 1000,
-                info.getPasswordExpiresOn().getTime() / 1000);
+        assertEquals("check expireson", expires.getTime().getTime() / MILLISECONDS_TO_SECONDS,
+                info.getPasswordExpiresOn().getTime() / MILLISECONDS_TO_SECONDS);
         assertEquals("check uri", Uri.parse(idToken.getPasswordChangeUrl()).toString(),
                 info.getPasswordChangeUrl().toString());
     }
 
     private String getIdToken(String objId, String upnStr, String emailStr, String subjectStr)
             throws UnsupportedEncodingException {
-        final String sIdTokenClaims = "{\"aud\":\"c3c7f5e5-7153-44d4-90e6-329686d48d76\",\"iss\":\"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048/\",\"iat\":1387224169,\"nbf\":1387224170,\"exp\":1387227769,\"pwd_exp\":1387227772,\"pwd_url\":\"pwdUrl\",\"ver\":\"1.0\",\"tid\":\"%s\",\"oid\":\"%s\",\"upn\":\"%s\",\"unique_name\":\"%s\",\"sub\":\"%s\",\"family_name\":\"%s\",\"given_name\":\"%s\",\"altsecid\":\"%s\",\"idp\":\"%s\",\"email\":\"%s\"}";
+        final String sIdTokenClaims = "{\"aud\":\"c3c7f5e5-7153-44d4-90e6-329686d48d76\",\"iss\":\"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048/\",\"iat\":1387224169,\"nbf\":1387224170,\"exp\":1387227769,\"pwd_exp\":1387227772,\"pwd_url\":\"pwdUrl\",\"ver\":\"1.0\",\"tid\":\"%s\",\"oid\":\"%s\",\"upn\":\"%s\",\"uniqueName\":\"%s\",\"sub\":\"%s\",\"family_name\":\"%s\",\"given_name\":\"%s\",\"altsecid\":\"%s\",\"idp\":\"%s\",\"email\":\"%s\"}";
         final String sIdTokenHeader = "{\"typ\":\"JWT\",\"alg\":\"none\"}";
         final String tid = "tenantid";
         final String oid = objId;
         final String upn = upnStr;
-        final String unique_name = "testUnique@test.onmicrosoft.com";
+        final String uniqueName = "testUnique@test.onmicrosoft.com";
         final String sub = subjectStr;
-        final String family_name = "familyName";
-        final String given_name = "givenName";
+        final String familyName = "familyName";
+        final String givenName = "givenName";
         final String altsecid = "altsecid";
         final String idp = "provider";
         final String email = emailStr;
-        final String claims = String.format(sIdTokenClaims, tid, oid, upn, unique_name, sub, family_name, given_name,
+        final String claims = String.format(sIdTokenClaims, tid, oid, upn, uniqueName, sub, familyName, givenName,
                 altsecid, idp, email);
         return String.format("%s.%s.",
                 new String(

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -47,7 +47,7 @@ final class Util {
 
     static final String ENCODED_SIGNATURE = "MIIGDjCCA/agAwIBAgIEUiDePDANBgkqhkiG9w0BAQsFADCByDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjErMCkGA1UECxMiV2luZG93cyBJbnR1bmUgU2lnbmluZyBmb3IgQW5kcm9pZDFFMEMGA1UEAxM8TWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIChEbyBOb3QgVHJ1c3QpMB4XDTEzMDgzMDE4MDIzNloXDTM2MTAyMTE4MDIzNlowgcgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xKzApBgNVBAsTIldpbmRvd3MgSW50dW5lIFNpZ25pbmcgZm9yIEFuZHJvaWQxRTBDBgNVBAMTPE1pY3Jvc29mdCBDb3Jwb3JhdGlvbiBUaGlyZCBQYXJ0eSBNYXJrZXRwbGFjZSAoRG8gTm90IFRydXN0KTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKl5psvH2mb9nmMz1QdQRX3UFJrl4ARRp9Amq4HC1zXFL6oCzhq6ZkuOGFoPPwTSVseBJsw4FSaX21sDWISpx/cjpg7RmJvNwf0IC6BUxDaQMpeo4hBKErKzqgyXa2T9GmVpkSb2TLpL8IpLtkxih8+GB6/09DkXR10Ir+cE+Pdkd/4iV44oKLxTbLprX1Rspcu07p/4JS6jO5vgDVV9OqRLLcAwrlewqua9oTDbAp/mDldztp//Z+8XiY6j/AJCKFvn+cA4s6s5kYj/jsK4/wt9nfo5aD9vRzE2j2IIH1T0Qj6NLTNxB7+Ij6dykE8QHJ7Vd/Y5af9QZwXyyPdSvwqhvKafS0baSqy1gLaNLA/gc/1Sh/ASXaDEhKHHAsLChkVFCE7cPwKPnBHudNBmS6HQ6Zo3UMwYVQVe7u+6jjvfo4gqmZglMhhzhauekNrHV91E+GkY3NGH2cHDEbpbl0JAAdWsI4jtJSN8c9Y8lSX00D7KdQ2NJhYl7mJsS10/3Ex1HYr8nDRq/IlAhGdSVC/qc9RktfYiYcmfZ/Iel5n+KkQt1svrF1TDCHYg/bcC7BhCwlaoa4Nu0hvLHvSbrsnB+gKtovCCilswPwCnDdAYmSMnwsAtBwJXqxD6HXbBCNX4A+qUrR+sYhmFa8jIVzAXa4I3iTvVQkTvrf9YriP7AgMBAAEwDQYJKoZIhvcNAQELBQADggIBAEdMG13+y2OvUHP1lHP22CNXk5e2lVgKZaEEWdxqGFZPuNsXsrHjAMOM4ocmyPUYAlscZsSRcMffMlBqbTyXIDfjkICwuJ+QdD7ySEKuLA1iWFMpwa30PSeZP4H0AlF9RkFhl/J9a9Le+5LdQihicHaTD2DEqCAQvR2RhonBr4vOV2bDnVParhaAEIMzwg2btj4nz8R/S0Nnx1O0YEHoXzbDRYHfL9ZfERp+9I8rtvWhRQRdhh9JNUbSPS6ygFZO67VECfxCOZ1MzPY9YEEdCcpPt5rgMEKVh7VPH14zsBuky2Opf6rGGS1m1Q26edG9dPtnAYax5AIkUG6cI3tW957qmUVSnIvlMzt6+OMYSKf5R5fdPdRlH1l8hak9vMxO2l344HyD0vAmbk01dw44PhIfuoq2qNAIt3lweEhZna8m5s9r1NEaRTf1BrVHXloAM+sipd5vQNs6oezSCicU7vwvUH1hIz0FOiCsLPTyxlfHk3ESS5QsivJS82TLSIb9HLX07OyENRRm8cVZdDbz6rRR+UWn1ZNEM9q56IZ+nCIOCbTjYlw1oZFowJDCL1IH8i7nhKVGBWf7TfukucDzh8ThOgMyyv6rIPutnssxQqQ7ed6iivc1y4Graihrr9n2HODRo3iUCXi+G4kfdmMwp2iwJz+Kjhyuqf7lhdOld6cs";
 
-    static final int TOKENS_EXPIRES_MINUITE = 60;
+    static final int TOKENS_EXPIRES_MINUTE = 60;
 
     static String getIdToken() throws UnsupportedEncodingException {
         final String sIdTokenClaims = "{\"aud\":\"c3c7f5e5-7153-44d4-90e6-329686d48d76\",\"iss\":\"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048/\",\"iat\":1387224169,\"nbf\":1387224170,\"exp\":1387227769,\"pwd_exp\":1387227772,\"pwd_url\":\"pwdUrl\",\"ver\":\"1.0\",\"tid\":\"%s\",\"oid\":\"%s\",\"upn\":\"%s\",\"unique_name\":\"%s\",\"sub\":\"%s\",\"family_name\":\"%s\",\"given_name\":\"%s\",\"altsecid\":\"%s\",\"idp\":\"%s\",\"email\":\"%s\"}";
@@ -78,7 +78,7 @@ final class Util {
                                             final String displayableId) {
         Calendar expiredTime = new GregorianCalendar();
         Log.d("Test", "Time now:" + expiredTime.toString());
-        expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUITE);
+        expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUTE);
         TokenCacheItem tokenCacheItem = new TokenCacheItem();
         tokenCacheItem.setAuthority(authority);
         tokenCacheItem.setResource(resource);
@@ -145,7 +145,7 @@ final class Util {
             final String userId, final String familyClientId) {
         Calendar expiredTime = new GregorianCalendar();
         Logger.d("Test", "Time now:" + expiredTime.toString());
-        expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUITE);
+        expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUTE);
         final UserInfo userInfo = new UserInfo(userId, "GivenName", "FamilyName", "idp", displayableId);
         final AuthenticationResult authResult = new AuthenticationResult("accessToken", "refresh_token", expiredTime.getTime(), 
                 isMRRT, userInfo, "TenantId", "IdToken");

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -36,27 +36,34 @@ import org.mockito.Mockito;
 import android.util.Base64;
 import android.util.Log;
 
-class Util {
+final class Util {
+    /**
+     * Private constructor to prevent the class from being initiated.
+     */
+    private Util() { }
+
     public static final int TEST_PASSWORD_EXPIRATION = 1387227772;
     static final String TEST_IDTOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiJlNzBiMTE1ZS1hYzBhLTQ4MjMtODVkYS04ZjRiN2I0ZjAwZTYiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwibmJmIjoxMzc2NDI4MzEwLCJleHAiOjEzNzY0NTcxMTAsInZlciI6IjEuMCIsInRpZCI6IjMwYmFhNjY2LThkZjgtNDhlNy05N2U2LTc3Y2ZkMDk5NTk2MyIsIm9pZCI6IjRmODU5OTg5LWEyZmYtNDExZS05MDQ4LWMzMjIyNDdhYzYyYyIsInVwbiI6ImFkbWluQGFhbHRlc3RzLm9ubWljcm9zb2Z0LmNvbSIsInVuaXF1ZV9uYW1lIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwic3ViIjoiVDU0V2hGR1RnbEJMN1VWYWtlODc5UkdhZEVOaUh5LXNjenNYTmFxRF9jNCIsImZhbWlseV9uYW1lIjoiU2VwZWhyaSIsImdpdmVuX25hbWUiOiJBZnNoaW4ifQ.";
 
     static final String ENCODED_SIGNATURE = "MIIGDjCCA/agAwIBAgIEUiDePDANBgkqhkiG9w0BAQsFADCByDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjErMCkGA1UECxMiV2luZG93cyBJbnR1bmUgU2lnbmluZyBmb3IgQW5kcm9pZDFFMEMGA1UEAxM8TWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIChEbyBOb3QgVHJ1c3QpMB4XDTEzMDgzMDE4MDIzNloXDTM2MTAyMTE4MDIzNlowgcgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xKzApBgNVBAsTIldpbmRvd3MgSW50dW5lIFNpZ25pbmcgZm9yIEFuZHJvaWQxRTBDBgNVBAMTPE1pY3Jvc29mdCBDb3Jwb3JhdGlvbiBUaGlyZCBQYXJ0eSBNYXJrZXRwbGFjZSAoRG8gTm90IFRydXN0KTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKl5psvH2mb9nmMz1QdQRX3UFJrl4ARRp9Amq4HC1zXFL6oCzhq6ZkuOGFoPPwTSVseBJsw4FSaX21sDWISpx/cjpg7RmJvNwf0IC6BUxDaQMpeo4hBKErKzqgyXa2T9GmVpkSb2TLpL8IpLtkxih8+GB6/09DkXR10Ir+cE+Pdkd/4iV44oKLxTbLprX1Rspcu07p/4JS6jO5vgDVV9OqRLLcAwrlewqua9oTDbAp/mDldztp//Z+8XiY6j/AJCKFvn+cA4s6s5kYj/jsK4/wt9nfo5aD9vRzE2j2IIH1T0Qj6NLTNxB7+Ij6dykE8QHJ7Vd/Y5af9QZwXyyPdSvwqhvKafS0baSqy1gLaNLA/gc/1Sh/ASXaDEhKHHAsLChkVFCE7cPwKPnBHudNBmS6HQ6Zo3UMwYVQVe7u+6jjvfo4gqmZglMhhzhauekNrHV91E+GkY3NGH2cHDEbpbl0JAAdWsI4jtJSN8c9Y8lSX00D7KdQ2NJhYl7mJsS10/3Ex1HYr8nDRq/IlAhGdSVC/qc9RktfYiYcmfZ/Iel5n+KkQt1svrF1TDCHYg/bcC7BhCwlaoa4Nu0hvLHvSbrsnB+gKtovCCilswPwCnDdAYmSMnwsAtBwJXqxD6HXbBCNX4A+qUrR+sYhmFa8jIVzAXa4I3iTvVQkTvrf9YriP7AgMBAAEwDQYJKoZIhvcNAQELBQADggIBAEdMG13+y2OvUHP1lHP22CNXk5e2lVgKZaEEWdxqGFZPuNsXsrHjAMOM4ocmyPUYAlscZsSRcMffMlBqbTyXIDfjkICwuJ+QdD7ySEKuLA1iWFMpwa30PSeZP4H0AlF9RkFhl/J9a9Le+5LdQihicHaTD2DEqCAQvR2RhonBr4vOV2bDnVParhaAEIMzwg2btj4nz8R/S0Nnx1O0YEHoXzbDRYHfL9ZfERp+9I8rtvWhRQRdhh9JNUbSPS6ygFZO67VECfxCOZ1MzPY9YEEdCcpPt5rgMEKVh7VPH14zsBuky2Opf6rGGS1m1Q26edG9dPtnAYax5AIkUG6cI3tW957qmUVSnIvlMzt6+OMYSKf5R5fdPdRlH1l8hak9vMxO2l344HyD0vAmbk01dw44PhIfuoq2qNAIt3lweEhZna8m5s9r1NEaRTf1BrVHXloAM+sipd5vQNs6oezSCicU7vwvUH1hIz0FOiCsLPTyxlfHk3ESS5QsivJS82TLSIb9HLX07OyENRRm8cVZdDbz6rRR+UWn1ZNEM9q56IZ+nCIOCbTjYlw1oZFowJDCL1IH8i7nhKVGBWf7TfukucDzh8ThOgMyyv6rIPutnssxQqQ7ed6iivc1y4Graihrr9n2HODRo3iUCXi+G4kfdmMwp2iwJz+Kjhyuqf7lhdOld6cs";
-    
+
+    static final int TOKENS_EXPIRES_MINUITE = 60;
+
     static String getIdToken() throws UnsupportedEncodingException {
         final String sIdTokenClaims = "{\"aud\":\"c3c7f5e5-7153-44d4-90e6-329686d48d76\",\"iss\":\"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048/\",\"iat\":1387224169,\"nbf\":1387224170,\"exp\":1387227769,\"pwd_exp\":1387227772,\"pwd_url\":\"pwdUrl\",\"ver\":\"1.0\",\"tid\":\"%s\",\"oid\":\"%s\",\"upn\":\"%s\",\"unique_name\":\"%s\",\"sub\":\"%s\",\"family_name\":\"%s\",\"given_name\":\"%s\",\"altsecid\":\"%s\",\"idp\":\"%s\",\"email\":\"%s\"}";
         final String sIdTokenHeader = "{\"typ\":\"JWT\",\"alg\":\"none\"}";
         final String tid = "6fd1f5cd-a94c-4335-889b-6c598e6d8048";
         final String oid = "53c6acf2-2742-4538-918d-e78257ec8516";
         final String upn = "test@test.onmicrosoft.com";
-        final String unique_name = "testUnique@test.onmicrosoft.com";
+        final String uniqueName = "testUnique@test.onmicrosoft.com";
         final String sub = "0DxnAlLi12IvGL";
-        final String family_name = "familyName";
-        final String given_name = "givenName";
+        final String familyName = "familyName";
+        final String givenName = "givenName";
         final String altsecid = "altsecid";
         final String idp = "idpProvider";
         final String email = "emailField";
-        final String claims = String.format(sIdTokenClaims, tid, oid, upn, unique_name, sub, family_name,
-                given_name, altsecid, idp, email);
+        final String claims = String.format(sIdTokenClaims, tid, oid, upn, uniqueName, sub, familyName,
+                givenName, altsecid, idp, email);
         return String.format("%s.%s.", 
                 new String(Base64.encode(sIdTokenHeader.getBytes(AuthenticationConstants.ENCODING_UTF8), 
                         Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE), 
@@ -66,11 +73,12 @@ class Util {
                         AuthenticationConstants.ENCODING_UTF8));
         }
     
-    static TokenCacheItem getTokenCacheItem(final String authority,final String resource, final String clientId, 
-            final String userId, final String displayableId) {
+    static TokenCacheItem getTokenCacheItem(final String authority, final String resource,
+                                            final String clientId, final String userId,
+                                            final String displayableId) {
         Calendar expiredTime = new GregorianCalendar();
         Log.d("Test", "Time now:" + expiredTime.toString());
-        expiredTime.add(Calendar.MINUTE, -60);
+        expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUITE);
         TokenCacheItem tokenCacheItem = new TokenCacheItem();
         tokenCacheItem.setAuthority(authority);
         tokenCacheItem.setResource(resource);
@@ -130,14 +138,14 @@ class Util {
     }
     
     static String urlFormEncode(String source) throws UnsupportedEncodingException {
-        return URLEncoder.encode(source, "UTF_8");
+        return URLEncoder.encode(source, AuthenticationConstants.ENCODING_UTF8);
     }
     
     static AuthenticationResult getAuthenticationResult(final boolean isMRRT, final String displayableId, 
             final String userId, final String familyClientId) {
         Calendar expiredTime = new GregorianCalendar();
         Logger.d("Test", "Time now:" + expiredTime.toString());
-        expiredTime.add(Calendar.MINUTE, -60);
+        expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUITE);
         final UserInfo userInfo = new UserInfo(userId, "GivenName", "FamilyName", "idp", displayableId);
         final AuthenticationResult authResult = new AuthenticationResult("accessToken", "refresh_token", expiredTime.getTime(), 
                 isMRRT, userInfo, "TenantId", "IdToken");

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/WebRequestHandlerTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/WebRequestHandlerTests.java
@@ -75,7 +75,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
 
         Mockito.when(mockedConnection.getInputStream())
                 .thenReturn(Util.createInputStream(testCorrelationId.toString()));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(400);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
 
         final HttpWebResponse testResponse = sendCorrelationIdRequest(testUrl, testCorrelationId, false);
 
@@ -135,7 +135,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         Util.prepareMockedUrlConnection(mockedConnection);
         Mockito.when(mockedConnection.getInputStream())
                 .thenReturn(Util.createInputStream("testabc-value123"));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final WebRequestHandler request = new WebRequestHandler();
         HttpWebResponse httpResponse = request.sendGet(getUrl(TEST_WEBAPI_URL),
@@ -160,7 +160,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
                 .thenReturn(Util.createInputStream(AAD.ADAL_ID_PLATFORM + "-Android" + "dummy string"
                         + AAD.ADAL_ID_VERSION + "-"
                         + AuthenticationContext.getVersionName()));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final WebRequestHandler request = new WebRequestHandler();
         HttpWebResponse httpResponse = request.sendGet(getUrl(TEST_WEBAPI_URL),
@@ -195,7 +195,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         Util.prepareMockedUrlConnection(mockedConnection);
         Mockito.when(mockedConnection.getInputStream())
                 .thenReturn(Util.createInputStream("test get with id"));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final WebRequestHandler request = new WebRequestHandler();
         HttpWebResponse httpResponse = request.sendGet(getUrl(TEST_WEBAPI_URL + "/1"), null);
@@ -216,11 +216,11 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         Mockito.when(mockedConnection.getInputStream())
                 .thenReturn(Util.createInputStream(message.getAccessToken() + message.getUserName()));
 
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(200);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final WebRequestHandler request = new WebRequestHandler();
         final HttpWebResponse httpResponse = request.sendPost(getUrl(TEST_WEBAPI_URL), null,
-                json.getBytes(ENCODING_UTF8), "application/json");
+                json.getBytes(AuthenticationConstants.ENCODING_UTF8), "application/json");
 
         assertTrue("status is 200", httpResponse.getStatusCode() == HttpURLConnection.HTTP_OK);
         final String responseMsg = new String(httpResponse.getBody());

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/WebRequestHandlerTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/WebRequestHandlerTests.java
@@ -38,6 +38,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -99,9 +100,8 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
 
         WebRequestHandler request = new WebRequestHandler();
         request.setRequestCorrelationId(testID);
-        HashMap<String, String> headers = null;
+        final Map<String, String> headers = new HashMap<>();
         if (!withoutHeader) {
-            headers = new HashMap<String, String>();
             headers.put("Accept", "application/json");
         }
         return request.sendPost(getUrl(message), headers, null,
@@ -112,7 +112,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         assertThrowsException(IllegalArgumentException.class, "url", new ThrowableRunnable() {
             public void run() throws IOException {
                 WebRequestHandler request = new WebRequestHandler();
-                request.sendGet(null, null);
+                request.sendGet(null, new HashMap<String, String>());
             }
         });
     }
@@ -122,7 +122,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         assertThrowsException(IllegalArgumentException.class, "url", new ThrowableRunnable() {
             public void run() throws IOException {
                 WebRequestHandler request = new WebRequestHandler();
-                request.sendGet(getUrl("ftp://test.com"), null);
+                request.sendGet(getUrl("ftp://test.com"), new HashMap<String, String>());
             }
         });
     }
@@ -180,7 +180,8 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         WebRequestHandler request = new WebRequestHandler();
         try {
             request.sendGet(
-                    getUrl("http://www.somethingabcddnotexists.com"), null);
+                    getUrl("http://www.somethingabcddnotexists.com"),
+                    new HashMap<String, String>());
             fail("Unreachable host, should throw IOException");
         } catch (final IOException e) {
             assertTrue(e instanceof UnknownHostException);
@@ -198,7 +199,8 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final WebRequestHandler request = new WebRequestHandler();
-        HttpWebResponse httpResponse = request.sendGet(getUrl(TEST_WEBAPI_URL + "/1"), null);
+        HttpWebResponse httpResponse = request.sendGet(getUrl(TEST_WEBAPI_URL + "/1"),
+                new HashMap<String, String>());
 
         assertTrue("status is 200", httpResponse.getStatusCode() == HttpURLConnection.HTTP_OK);
         final String responseMsg = new String(httpResponse.getBody());
@@ -219,7 +221,8 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final WebRequestHandler request = new WebRequestHandler();
-        final HttpWebResponse httpResponse = request.sendPost(getUrl(TEST_WEBAPI_URL), null,
+        final HttpWebResponse httpResponse = request.sendPost(getUrl(TEST_WEBAPI_URL),
+                new HashMap<String, String>(),
                 json.getBytes(AuthenticationConstants.ENCODING_UTF8), "application/json");
 
         assertTrue("status is 200", httpResponse.getStatusCode() == HttpURLConnection.HTTP_OK);

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenInteractiveRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenInteractiveRequest.java
@@ -52,7 +52,7 @@ final class AcquireTokenInteractiveRequest {
         mAuthRequest = authRequest;
     }
 
-     void acquireToken(final IWindowComponent activity, final AuthenticationDialog dialog)
+    void acquireToken(final IWindowComponent activity, final AuthenticationDialog dialog)
             throws AuthenticationException {
         //Check if there is network connection
         HttpWebRequest.throwIfNetworkNotAvaliable(mContext);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -705,7 +705,8 @@ public class AuthenticationActivity extends Activity {
                     try {
                         final X509Certificate[] certChain = KeyChain.getCertificateChain(
                                 getApplicationContext(), alias);
-                        final PrivateKey privateKey = KeyChain.getPrivateKey(mCallingContext, alias);
+                        final PrivateKey privateKey = KeyChain.getPrivateKey(
+                                getCallingContext(), alias);
 
                         Logger.v(TAG + methodName, "Certificate is chosen by user, proceed with TLS request.");
                         request.proceed(privateKey, certChain);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -23,55 +23,69 @@
 
 package com.microsoft.aad.adal;
 
-public class AuthenticationConstants {
+/**
+ * {@link AuthenticationConstants} contains all the constant value the SDK is using.
+ */
+public final class AuthenticationConstants {
+    /**
+     * Private constructor to prevent an utility class from being initiated.
+     */
+    private AuthenticationConstants() { }
 
+    /**
+     * Holding all the constant value involved in the webview.
+     */
     public static final class Browser {
+
+        /** Represents the request object used to construst request sent to authorize endpoint. */
         public static final String REQUEST_MESSAGE = "com.microsoft.aad.adal:BrowserRequestMessage";
 
+        /** Represents the request object returned from webview. */
         public static final String RESPONSE_REQUEST_INFO = "com.microsoft.aad.adal:BrowserRequestInfo";
 
+        /** Represents the error code returned from webview. */
         public static final String RESPONSE_ERROR_CODE = "com.microsoft.aad.adal:BrowserErrorCode";
 
+        /** Represents the error message returned from webview. */
         public static final String RESPONSE_ERROR_MESSAGE = "com.microsoft.aad.adal:BrowserErrorMessage";
 
+        /** Represents the exception returned from webview. */
         public static final String RESPONSE_AUTHENTICATION_EXCEPTION = "com.microsoft.aad.adal:AuthenticationException";
 
+        /** Represents the final url that webview receives. */
         public static final String RESPONSE_FINAL_URL = "com.microsoft.aad.adal:BrowserFinalUrl";
 
+        /** Represents the response returned from broker. */
         public static final String RESPONSE = "com.microsoft.aad.adal:BrokerResponse";
 
+        /** Represent the error code of invalid request returned from webview. */
         public static final String WEBVIEW_INVALID_REQUEST = "Invalid request";
 
+        /** Used by LocalBroadcastReceivers to filter the intent string of request cancellation. */
         public static final String ACTION_CANCEL = "com.microsoft.aad.adal:BrowserCancel";
 
+        /** Used as the key to send back request id. */
         public static final String REQUEST_ID = "com.microsoft.aad.adal:RequestId";
     }
 
+    /**
+     * Represents the response code.
+     */
     public static final class UIResponse {
-        /**
-         * User cancelled.
-         */
+
+        /** Represents that user cancelled the flow. */
         public static final int BROWSER_CODE_CANCEL = 2001;
 
-        /**
-         * Browser error.
-         */
+        /** Represents that browser error is returned. */
         public static final int BROWSER_CODE_ERROR = 2002;
 
-        /**
-         * Flow complete.
-         */
+        /** Represents that the authorization code is returned successfully. */
         public static final int BROWSER_CODE_COMPLETE = 2003;
 
-        /**
-         * Broker returns full response.
-         */
+        /** Represents that broker successfully returns the response. */
         public static final int TOKEN_BROKER_RESPONSE = 2004;
 
-        /**
-         * Webview throws Authentication exception. It needs to be send to
-         * callback.
-         */
+        /** Webview throws Authentication exception. It needs to be send to callback. */
         public static final int BROWSER_CODE_AUTHENTICATION_EXCEPTION = 2005;
         
         /**
@@ -81,79 +95,114 @@ public class AuthenticationConstants {
         public static final int BROKER_REQUEST_RESUME = 2006;
     }
 
+    /**
+     * Represents the request code.
+     */
     public static final class UIRequest {
+
+        /** Represents the request of browser flow. */
         public static final int BROWSER_FLOW = 1001;
-
-        public static final int TOKEN_FLOW = 1002;
-
-        public static final int BROKER_FLOW = 1003;
     }
 
+    /**
+     * Represents the constant value of oauth2 params.
+     */
     public static final class OAuth2 {
-        /** Core OAuth2 strings. */
+
+        /** String of access token. */
         public static final String ACCESS_TOKEN = "access_token";
 
+        /** String of authority. */
         public static final String AUTHORITY = "authority";
 
+        /** String of authorization code. */
         public static final String AUTHORIZATION_CODE = "authorization_code";
 
+        /** String of client id. */
         public static final String CLIENT_ID = "client_id";
 
-        public static final String CLIENT_SECRET = "client_secret";
-
+        /** String of code. */
         public static final String CODE = "code";
 
+        /** String of error. */
         public static final String ERROR = "error";
 
+        /** String of error description. */
         public static final String ERROR_DESCRIPTION = "error_description";
 
+        /** String of error codes. */
         public static final String ERROR_CODES = "error_codes";
 
+        /** String of expires in. */
         public static final String EXPIRES_IN = "expires_in";
 
+        /** String of grant type. */
         public static final String GRANT_TYPE = "grant_type";
 
+        /** String redirect uri. */
         public static final String REDIRECT_URI = "redirect_uri";
 
+        /** String of refresh token. */
         public static final String REFRESH_TOKEN = "refresh_token";
 
+        /** String of response type. */
         public static final String RESPONSE_TYPE = "response_type";
 
+        /** String of scope. */
         public static final String SCOPE = "scope";
 
+        /** String of state. */
         public static final String STATE = "state";
 
+        /** String of token type. */
         public static final String TOKEN_TYPE = "token_type";
 
+        /** String of id token. */
         static final String ID_TOKEN = "id_token";
 
+        /** String of sub in the id token. */
         static final String ID_TOKEN_SUBJECT = "sub";
 
+        /** String of tenant id in the id token. */
         static final String ID_TOKEN_TENANTID = "tid";
 
+        /** String of UPN in the id token claim. */
         static final String ID_TOKEN_UPN = "upn";
 
+        /** String of given name in the id token claim. */
         static final String ID_TOKEN_GIVEN_NAME = "given_name";
 
+        /** String of family name in the id token claim. */
         static final String ID_TOKEN_FAMILY_NAME = "family_name";
 
+        /** String of unique name. */
         static final String ID_TOKEN_UNIQUE_NAME = "unique_name";
 
+        /** String of email in the id token. */
         static final String ID_TOKEN_EMAIL = "email";
 
+        /** String of identity provider in the id token claim. */
         static final String ID_TOKEN_IDENTITY_PROVIDER = "idp";
 
+        /** String of oid in the id token claim. */
         static final String ID_TOKEN_OBJECT_ID = "oid";
 
+        /** String of password expiration in the id token claim. */
         static final String ID_TOKEN_PASSWORD_EXPIRATION = "pwd_exp";
 
+        /** String of password change url in the id token claim. */
         static final String ID_TOKEN_PASSWORD_CHANGE_URL = "pwd_url";
-        
+
+        /** String of FoCI field returnd in the JSON response from token endpoint. */
         static final String ADAL_CLIENT_FAMILY_ID = "foci";
 
+        /** String of has_chrome sent as extra query param to hide back button in the webview. */
         static final String HAS_CHROME = "haschrome";
     }
 
+    /**
+     * Represents the constants value for Active Directory.
+     */
     public static final class AAD {
 
         /** AAD OAuth2 extension strings. */
@@ -162,150 +211,208 @@ public class AuthenticationConstants {
         /** AAD OAuth2 Challenge strings. */
         public static final String BEARER = "Bearer";
 
+        /** AAD Oauth2 authorization.*/
         public static final String AUTHORIZATION = "authorization";
 
+        /** String of authorization uri. */
         public static final String AUTHORIZATION_URI = "authorization_uri";
 
+        /** AAD Oauth2 string of realm. */
         public static final String REALM = "realm";
 
+        /** String of login hint. */
         public static final String LOGIN_HINT = "login_hint";
-        
+
+        /** String of access denied. */
         public static final String WEB_UI_CANCEL = "access_denied";
 
+        /** String of correlation id. */
         public static final String CORRELATION_ID = "correlation_id";
 
+        /** String of client request id. */
         public static final String CLIENT_REQUEST_ID = "client-request-id";
 
+        /** String of return client request id. */
         public static final String RETURN_CLIENT_REQUEST_ID = "return-client-request-id";
 
+        /** String of prompt. */
         public static final String QUERY_PROMPT = "prompt";
 
+        /** String of prompt behavior as always. */
         public static final String QUERY_PROMPT_VALUE = "login";
 
+        /** String of prompt behavior as refresh session. */
         public static final String QUERY_PROMPT_REFRESH_SESSION_VALUE = "refresh_session";
 
-        public final static String ADAL_ID_PLATFORM = "x-client-SKU";
+        /** String of ADAL platform. */
+        public static final String ADAL_ID_PLATFORM = "x-client-SKU";
 
-        public final static String ADAL_ID_VERSION = "x-client-Ver";
+        /** String of ADAL version. */
+        public static final String ADAL_ID_VERSION = "x-client-Ver";
 
-        public final static String ADAL_ID_CPU = "x-client-CPU";
+        /** String of ADAL id CPU. */
+        public static final String ADAL_ID_CPU = "x-client-CPU";
 
-        public final static String ADAL_ID_OS_VER = "x-client-OS";
+        /** String of client app os version. */
+        public static final String ADAL_ID_OS_VER = "x-client-OS";
 
-        public final static String ADAL_ID_DM = "x-client-DM";
+        /** String of ADAL ID DM. */
+        public static final String ADAL_ID_DM = "x-client-DM";
 
-        public final static String ADAL_ID_PLATFORM_VALUE = "Android";
+        /** String of platform value for the sdk. */
+        public static final String ADAL_ID_PLATFORM_VALUE = "Android";
     }
 
+    /**
+     * Represents the constants for broker.
+     */
     public static final class Broker {
 
+        /** Broker request id. */
         public static final int BROKER_REQUEST_ID = 1177;
 
+        /** String for broker request. */
         public static final String BROKER_REQUEST = "com.microsoft.aadbroker.adal.broker.request";
 
+        /** String for broker request resume. */
         public static final String BROKER_REQUEST_RESUME = "com.microsoft.aadbroker.adal.broker.request.resume";
         
-        /**
-         * Account type string.
-         */
+        /** Account type string. */
         public static final String BROKER_ACCOUNT_TYPE = "com.microsoft.workaccount";
 
+        /** String of account initial name. */
         public static final String ACCOUNT_INITIAL_NAME = "aad";
 
+        /** String of background request message. */
         public static final String BACKGROUND_REQUEST_MESSAGE = "background.request";
 
+        /** String of account default. */
         public static final String ACCOUNT_DEFAULT_NAME = "Default";
-        
+
+        /** String of broker version. */
         public static final String BROKER_VERSION = "broker.version";
-        
+
+        /** String of broker protocl version with PRT support. */
         public static final String BROKER_PROTOCOL_VERSION = "v2";
-        
+
+        /** String of broker result returned. */
         public static final String BROKER_RESULT_RETURNED = "broker.result.returned";
 
-        /**
-         * Authtoken type string.
-         */
+        /** Authtoken type string. */
         public static final String AUTHTOKEN_TYPE = "adal.authtoken.type";
 
+        /** String of broker final url. */
         public static final String BROKER_FINAL_URL = "adal.final.url";
 
+        /** String of account initial request. */
         public static final String ACCOUNT_INITIAL_REQUEST = "account.initial.request";
 
+        /** String of account client id key.*/
         public static final String ACCOUNT_CLIENTID_KEY = "account.clientid.key";
 
-        public static final String ACCOUNT_CLIENT_SECRET_KEY = "account.client.secret.key";
-
+        /** String of account correlation id. */
         public static final String ACCOUNT_CORRELATIONID = "account.correlationid";
 
+        /** String of account prompt. */
         public static final String ACCOUNT_PROMPT = "account.prompt";
 
+        /** String of account extra query param. */
         public static final String ACCOUNT_EXTRA_QUERY_PARAM = "account.extra.query.param";
 
+        /** String of account login hint. */
         public static final String ACCOUNT_LOGIN_HINT = "account.login.hint";
 
+        /** String of account resource. */
         public static final String ACCOUNT_RESOURCE = "account.resource";
 
+        /** String of account redirect. */
         public static final String ACCOUNT_REDIRECT = "account.redirect";
 
+        /** String of account authority. */
         public static final String ACCOUNT_AUTHORITY = "account.authority";
 
+        /** String of account refresh token. */
         public static final String ACCOUNT_REFRESH_TOKEN = "account.refresh.token";
 
+        /** String of account access token. */
         public static final String ACCOUNT_ACCESS_TOKEN = "account.access.token";
 
+        /** String of token expiration data for the broker account. */
         public static final String ACCOUNT_EXPIREDATE = "account.expiredate";
 
+        /** String of token result for the broker account. */
         public static final String ACCOUNT_RESULT = "account.result";
 
+        /** String of account remove tokens. */
         public static final String ACCOUNT_REMOVE_TOKENS = "account.remove.tokens";
 
+        /** String of account remove token value. */
         public static final String ACCOUNT_REMOVE_TOKENS_VALUE = "account.remove.tokens.value";
 
+        /** String of multi resource refresh token. */
         public static final String MULTI_RESOURCE_TOKEN = "account.multi.resource.token";
 
+        /** String of key for account name. */
         public static final String ACCOUNT_NAME = "account.name";
-        
+
+        /** String of key for account id token. */
         public static final String ACCOUNT_IDTOKEN = "account.idtoken";
 
+        /** String of key for user id. */
         public static final String ACCOUNT_USERINFO_USERID = "account.userinfo.userid";
 
+        /** String of key for given name. */
         public static final String ACCOUNT_USERINFO_GIVEN_NAME = "account.userinfo.given.name";
 
+        /** String of key for family name. */
         public static final String ACCOUNT_USERINFO_FAMILY_NAME = "account.userinfo.family.name";
 
+        /** String of key for identity provider. */
         public static final String ACCOUNT_USERINFO_IDENTITY_PROVIDER = "account.userinfo.identity.provider";
 
+        /** String of key for displayable id. */
         public static final String ACCOUNT_USERINFO_USERID_DISPLAYABLE = "account.userinfo.userid.displayable";
 
+        /** String of key for tenant id. */
         public static final String ACCOUNT_USERINFO_TENANTID = "account.userinfo.tenantid";
 
+        /** String of key for adal version. */
         public static final String ADAL_VERSION_KEY = "adal.version.key";
-        
+
+        /** String of key for UIDs in the cache. */
         public static final String ACCOUNT_UID_CACHES = "account.uid.caches";
 
+        /** String of key for user data prefix. */
         public static final String USERDATA_PREFIX = "userdata.prefix";
 
+        /** String of key for UID key. */
         public static final String USERDATA_UID_KEY = "calling.uid.key";
 
+        /** String of key for caller cache keys. */
         public static final String USERDATA_CALLER_CACHEKEYS = "userdata.caller.cachekeys";
 
+        /** String of caller cache key delimiter. */
         public static final String CALLER_CACHEKEY_PREFIX = "|";
 
+        /** String for pkeyauth sent in user agent string. */
         public static final String CLIENT_TLS_NOT_SUPPORTED = " PKeyAuth/1.0";
 
+        /** String of challenge request header. */
         public static final String CHALLENGE_REQUEST_HEADER = "WWW-Authenticate";
 
+        /** String of challenge response header. */
         public static final String CHALLENGE_RESPONSE_HEADER = "Authorization";
 
+        /** String of challenge response type. */
         public static final String CHALLENGE_RESPONSE_TYPE = "PKeyAuth";
 
+        /** String of challenge response token. */
         public static final String CHALLENGE_RESPONSE_TOKEN = "AuthToken";
 
+        /** String of challenge response context. */
         public static final String CHALLENGE_RESPONSE_CONTEXT = "Context";
 
-        /**
-         * Certificate authorities are passed with delimiter.
-         */
+        /** Certificate authorities are passed with delimiter. */
         public static final String CHALLENGE_REQUEST_CERT_AUTH_DELIMETER = ";";
 
         /**
@@ -325,46 +432,60 @@ public class AuthenticationConstants {
          * component.
          */
         public static final String AZURE_AUTHENTICATOR_APP_SIGNATURE = "ho040S3ffZkmxqtQrSwpTVOn9r0=";
-        
+
+        /** Azure Authenticator app signature hash. */
         public static final String AZURE_AUTHENTICATOR_APP_PACKAGE_NAME = "com.azure.authenticator";
 
+        /** The value for pkeyauth redirect. */
         public static final String PKEYAUTH_REDIRECT = "urn:http-auth:PKeyAuth";
 
+        /** Value of pkeyauth sent in the header. */
         public static final String CHALLENGE_TLS_INCAPABLE = "x-ms-PKeyAuth";
 
+        /** Value of supported pkeyauth version. */
         public static final String CHALLENGE_TLS_INCAPABLE_VERSION = "1.0";
 
+        /** Broker redirect prefix. */
         public static final String REDIRECT_PREFIX = "msauth";
 
+        /** Encoded delimiter for redirect. */
         public static final Object REDIRECT_DELIMETER_ENCODED = "%2C";
-        
+
+        /** Prefix of redirect to open external browser. */
         public static final String BROWSER_EXT_PREFIX = "browser://";
-        
+
+        /** Prefix in the redirect for installing broker apps. */
         public static final String BROWSER_EXT_INSTALL_PREFIX = "msauth://";
 
+        /** String for caller package. */
         public static final String CALLER_INFO_PACKAGE = "caller.info.package";
-        
+
+        /** String for ssl prefix. */
         public static final String REDIRECT_SSL_PREFIX = "https://";
     }
 
+    /** ADAL package name. */
     public static final String ADAL_PACKAGE_NAME = "com.microsoft.aad.adal";
-    
+
+    /** Microsoft apps family of client Id. */
     public static final String MS_FAMILY_ID = "1";
 
     /** The Constant ENCODING_UTF8. */
     public static final String ENCODING_UTF8 = "UTF_8";
 
+    /** Bundle message. */
     public static final String BUNDLE_MESSAGE = "Message";
 
+    /** Default access token expiration time in seconds. */
     public static final int DEFAULT_EXPIRATION_TIME_SEC = 3600;
 
-    public static final String AUTHENTICATION_FILE_DIRECTORY = "com.microsoft.aad.adal.authentication";
-    
+    /**
+     * Represents the oauth2 error code.
+     */
     protected static final class OAuth2ErrorCode {
         /**       
          * Oauth2 error code invalid_grant.
          */       
         static final String INVALID_GRANT = "invalid_grant";
-    }     
-
+    }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -32,6 +32,21 @@ public final class AuthenticationConstants {
      */
     private AuthenticationConstants() { }
 
+    /** ADAL package name. */
+    public static final String ADAL_PACKAGE_NAME = "com.microsoft.aad.adal";
+
+    /** Microsoft apps family of client Id. */
+    public static final String MS_FAMILY_ID = "1";
+
+    /** The Constant ENCODING_UTF8. */
+    public static final String ENCODING_UTF8 = "UTF_8";
+
+    /** Bundle message. */
+    public static final String BUNDLE_MESSAGE = "Message";
+
+    /** Default access token expiration time in seconds. */
+    public static final int DEFAULT_EXPIRATION_TIME_SEC = 3600;
+
     /**
      * Holding all the constant value involved in the webview.
      */
@@ -463,21 +478,6 @@ public final class AuthenticationConstants {
         /** String for ssl prefix. */
         public static final String REDIRECT_SSL_PREFIX = "https://";
     }
-
-    /** ADAL package name. */
-    public static final String ADAL_PACKAGE_NAME = "com.microsoft.aad.adal";
-
-    /** Microsoft apps family of client Id. */
-    public static final String MS_FAMILY_ID = "1";
-
-    /** The Constant ENCODING_UTF8. */
-    public static final String ENCODING_UTF8 = "UTF_8";
-
-    /** Bundle message. */
-    public static final String BUNDLE_MESSAGE = "Message";
-
-    /** Default access token expiration time in seconds. */
-    public static final int DEFAULT_EXPIRATION_TIME_SEC = 3600;
 
     /**
      * Represents the oauth2 error code.

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationException.java
@@ -34,9 +34,10 @@ public class AuthenticationException extends Exception {
     private ADALError mCode;
 
     /**
-     * Constructs a new AuthenticationException.
+     * Default constructor for {@link AuthenticationException}.
      */
     public AuthenticationException() {
+        // Default constructor, intentionally empty.
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationException.java
@@ -31,7 +31,7 @@ import android.content.Context;
 public class AuthenticationException extends Exception {
     static final long serialVersionUID = 1;
 
-    protected ADALError mCode;
+    private ADALError mCode;
 
     /**
      * Constructs a new AuthenticationException.

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -46,13 +46,13 @@ abstract class BasicWebViewClient extends WebViewClient {
 
     public static final String BLANK_PAGE = "about:blank";
 
-    protected String mRedirect;
+    private String mRedirect;
     
-    protected String mQueryParam;
+    private String mQueryParam;
 
-    protected AuthenticationRequest mRequest;
+    private AuthenticationRequest mRequest;
     
-    protected Context mCallingContext;
+    private Context mCallingContext;
 
     public BasicWebViewClient() {
         mRedirect = null;
@@ -283,8 +283,9 @@ abstract class BasicWebViewClient extends WebViewClient {
             // can be registered. openLinkInBrowser will launch activity for going to
             // playstore and broker app download page which brought the calling activity down 
             // in the activity stack.
+            final int threadSleepForCallingActivity = 1000;
             try {
-                Thread.sleep(1000);
+                Thread.sleep(threadSleepForCallingActivity);
             } catch (InterruptedException e) {
                 Logger.v(TAG + ":shouldOverrideUrlLoading", "Error occured when having thread sleeping for 1 second");
             }
@@ -299,6 +300,10 @@ abstract class BasicWebViewClient extends WebViewClient {
     public abstract void processRedirectUrl(final WebView view, String url);
 
     public abstract boolean processInvalidUrl(final WebView view, String url);
+
+    final Context getCallingContext() {
+        return mCallingContext;
+    }
     
     protected void openLinkInBrowser(String url) {
         String link = url

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -46,20 +46,14 @@ abstract class BasicWebViewClient extends WebViewClient {
 
     public static final String BLANK_PAGE = "about:blank";
 
-    private String mRedirect;
-    
-    private String mQueryParam;
+    private final String mRedirect;
+    private final AuthenticationRequest mRequest;
+    private final String mQueryParam;
+    private final Context mCallingContext;
 
-    private AuthenticationRequest mRequest;
-    
-    private Context mCallingContext;
 
-    public BasicWebViewClient() {
-        mRedirect = null;
-        mRequest = null;
-    }
-
-    public BasicWebViewClient(Context appContext, String redirect, String queryParam, AuthenticationRequest request) {
+    public BasicWebViewClient(final Context appContext, final String redirect,
+                              final String queryParam, final AuthenticationRequest request) {
         mCallingContext = appContext;
         mRedirect = redirect;
         mRequest = request;
@@ -167,13 +161,13 @@ abstract class BasicWebViewClient extends WebViewClient {
             return;
         }
 
-        if (!StringExtensions.IsNullOrBlank(uri.getQueryParameter(
+        if (StringExtensions.IsNullOrBlank(uri.getQueryParameter(
                 AuthenticationConstants.OAuth2.CODE))) {
-            Logger.v(TAG, "Webview starts loading: " + uri.getHost() + uri.getPath()
-                    + " Auth code is returned for the loading url.");
-        } else {
             Logger.v(TAG, "Webview starts loading: " + uri.getHost() + uri.getPath(),
                     "Full loading url is: " + url, null);
+        } else {
+            Logger.v(TAG, "Webview starts loading: " + uri.getHost() + uri.getPath()
+                    + " Auth code is returned for the loading url.");
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/CacheKey.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CacheKey.java
@@ -71,6 +71,8 @@ public final class CacheKey implements Serializable {
      * @param clientId client identifier
      * @param isMultiResourceRefreshToken true/false for refresh token type
      * @param userId userid provided from {@link UserInfo}
+     * @param familyClientId Family client Id of the app. FoCI feature only applies to Microsoft
+     *                       apps now, by default the id will be "1".
      * @return CacheKey to use in saving token
      */
     public static String createCacheKey(final String authority, final String resource, final String clientId,
@@ -102,7 +104,7 @@ public final class CacheKey implements Serializable {
         
         key.mAuthority = authority.toLowerCase(Locale.US);
         if (key.mAuthority.endsWith("/")) {
-            key.mAuthority = (String)key.mAuthority.subSequence(0, key.mAuthority.length() - 1);
+            key.mAuthority = (String) key.mAuthority.subSequence(0, key.mAuthority.length() - 1);
         }
 
         if (clientId != null) {
@@ -154,23 +156,37 @@ public final class CacheKey implements Serializable {
             throw new AuthenticationException(ADALError.INVALID_TOKEN_CACHE_ITEM, "Cannot create cachekey from given token item");
         }
     }
-    
+
     /**
-     * Create cache key for regular RT entry. 
+     * Create cache key for regular RT entry.
+     * @param authority Authority for the key to store regular RT entry.
+     * @param resource Resource for the key to store regular RT entry.
+     * @param clientId Client id for the key to store regular RT entry.
+     * @param userId User id for the key to store regular RT entry.
+     * @return The cache key for regular RT entry.
      */
-    public static String createCacheKeyForRTEntry(final String authority, final String resource, final String clientId, final String userId) {
+    public static String createCacheKeyForRTEntry(final String authority, final String resource,
+                                                  final String clientId, final String userId) {
         return createCacheKey(authority, resource, clientId, false, userId, null);
     }
-    
+
     /**
-     * Create cache key for MRRT entry. 
+     * Create cache key for MRRT entry.
+     * @param authority The authority used to create the cache key.
+     * @param clientId The client id used to create the cache key.
+     * @param userId The user id used to create the cache key.
+     * @return The cache key for MRRT entry.
      */
     public static String createCacheKeyForMRRT(final String authority, final String clientId, final String userId) {
         return createCacheKey(authority, null, clientId, true, userId, null);
     }
     
     /**
-     * Create cache key for FRT entry. 
+     * Create cache key for FRT entry.
+     * @param authority The authority of the cache key.
+     * @param familyClientId The family client id of the FRT entry cache key.
+     * @param userId The user id of the cache key.
+     * @return The cache key for FRT entry.
      */
     public static String createCacheKeyForFRT(final String authority, final String familyClientId, final String userId) {
         return createCacheKey(authority, null, null, true, userId, familyClientId);
@@ -178,7 +194,6 @@ public final class CacheKey implements Serializable {
 
     /**
      * Gets Authority.
-     * 
      * @return Authority
      */
     public String getAuthority() {
@@ -187,7 +202,6 @@ public final class CacheKey implements Serializable {
 
     /**
      * Gets Resource.
-     * 
      * @return Resource
      */
     public String getResource() {
@@ -196,7 +210,6 @@ public final class CacheKey implements Serializable {
 
     /**
      * Gets ClientId.
-     * 
      * @return ClientId
      */
     public String getClientId() {
@@ -205,7 +218,6 @@ public final class CacheKey implements Serializable {
 
     /**
      * Gets UserId.
-     * 
      * @return UserId
      */
     public String getUserId() {
@@ -214,7 +226,6 @@ public final class CacheKey implements Serializable {
 
     /**
      * Gets status for multi resource refresh token.
-     * 
      * @return status for multi resource refresh token
      */
     public boolean getIsMultipleResourceRefreshToken() {

--- a/adal/src/main/java/com/microsoft/aad/adal/DateTimeAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DateTimeAdapter.java
@@ -43,15 +43,15 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
 
     private static final String TAG = "DateTimeAdapter";
 
-    private final DateFormat enUsFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT,
+    private final DateFormat mEnUsFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT,
             DateFormat.DEFAULT, Locale.US);
 
-    private final DateFormat localFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT,
+    private final DateFormat mLocalFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT,
             DateFormat.DEFAULT);
 
-    private final DateFormat iso8601Format = buildIso8601Format();
-    private final DateFormat enUs24HourFormat = buildEnUs24HourDateFormat();
-    private final DateFormat local24HourFormat = buildLocal24HourDateFormat();
+    private final DateFormat mISO8601Format = buildIso8601Format();
+    private final DateFormat mEnUs24HourFormat = buildEnUs24HourDateFormat();
+    private final DateFormat mLocal24HourFormat = buildLocal24HourDateFormat();
 
     private static DateFormat buildIso8601Format() {
         DateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
@@ -73,9 +73,15 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
         return new SimpleDateFormat("MMM dd, yyyy HH:mm:ss", Locale.getDefault());
     }
 
+    /**
+     * Default constructor for {@link DateTimeAdapter}.
+     */
     public DateTimeAdapter() {
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public synchronized Date deserialize(JsonElement json, Type typeOfT,
             JsonDeserializationContext context) throws JsonParseException {
@@ -86,28 +92,32 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
         // compatibility, we also need to deserialize with old format if failing
         // with iso8601. 
         try {
-            return iso8601Format.parse(jsonString);
+            return mISO8601Format.parse(jsonString);
         } catch (final ParseException ignored) {
+            Logger.v(TAG, "Cannot parse with ISO8601, try again with local format.");
         }
         
         // fallback logic for old date format parsing. 
         try {
-            return localFormat.parse(jsonString);
+            return mLocalFormat.parse(jsonString);
         } catch (final ParseException ignored) {
+            Logger.v(TAG, "Cannot parse with local format, try again with local 24 hour format.");
         }
         
         try {
-            return local24HourFormat.parse(jsonString);
+            return mLocal24HourFormat.parse(jsonString);
         } catch (final ParseException ignored) {
+            Logger.v(TAG, "Cannot parse with local 24 hour format, try again with en us format.");
         }
 
         try {
-            return enUsFormat.parse(jsonString);
+            return mEnUsFormat.parse(jsonString);
         } catch (final ParseException ignored) {
+            Logger.v(TAG, "Cannot parse with en us format, try again with en us 24 hour format.");
         }
 
         try {
-            return enUs24HourFormat.parse(jsonString);
+            return mEnUs24HourFormat.parse(jsonString);
         } catch (final ParseException e) {
             Logger.e(TAG, "Could not parse date: " + e.getMessage(), "",
                     ADALError.DATE_PARSING_FAILURE, e);
@@ -116,9 +126,12 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
         throw new JsonParseException("Could not parse date: " + jsonString);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public synchronized JsonElement serialize(Date src, Type typeOfSrc,
             JsonSerializationContext context) {
-        return new JsonPrimitive(iso8601Format.format(src));
+        return new JsonPrimitive(mISO8601Format.format(src));
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/DateTimeAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DateTimeAdapter.java
@@ -77,6 +77,7 @@ public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerial
      * Default constructor for {@link DateTimeAdapter}.
      */
     public DateTimeAdapter() {
+        // Default constructor, intentionally empty.
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultConnectionService.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultConnectionService.java
@@ -35,7 +35,7 @@ import android.net.NetworkInfo;
  */
 class DefaultConnectionService implements IConnectionService {
 
-    private Context mConnectionContext;
+    private final Context mConnectionContext;
 
     DefaultConnectionService(Context ctx) {
         mConnectionContext = ctx;

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultConnectionService.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultConnectionService.java
@@ -33,7 +33,7 @@ import android.net.NetworkInfo;
  * be removed in the next major version update. 
  * https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/626
  */
-class DefaultConnectionService implements IConnectionService{
+class DefaultConnectionService implements IConnectionService {
 
     private Context mConnectionContext;
 
@@ -42,7 +42,7 @@ class DefaultConnectionService implements IConnectionService{
     }
 
     public boolean isConnectionAvailable() {
-        ConnectivityManager connectivityManager = (ConnectivityManager)mConnectionContext
+        ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
         return activeNetwork != null && activeNetwork.isConnectedOrConnecting();

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -66,7 +66,7 @@ final class Discovery {
      * Sync set of valid hosts to skip query to server if host was verified
      * before.
      */
-    private static final Set<String> sValidHosts = Collections
+    private static final Set<String> VALID_HOSTS = Collections
             .synchronizedSet(new HashSet<String>());
 
     /**
@@ -107,7 +107,7 @@ final class Discovery {
                     new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_CAN_NOT_BE_VALIDED));
         }
 
-        if (!sValidHosts.contains(authorizationEndpoint.getHost().toLowerCase(Locale.US))) {
+        if (!VALID_HOSTS.contains(authorizationEndpoint.getHost().toLowerCase(Locale.US))) {
             // host can be the instance or inside the validated list.
             // Valid hosts will help to skip validation if validated before
             // call Callback and skip the look up
@@ -129,12 +129,12 @@ final class Discovery {
      */
     private void initValidList() {
         // mValidHosts is a sync set
-        if (sValidHosts.size() == 0) {
-            sValidHosts.add("login.windows.net"); // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list 
-            sValidHosts.add("login.microsoftonline.com"); // Microsoft Azure Worldwide
-            sValidHosts.add("login.chinacloudapi.cn"); // Microsoft Azure China
-            sValidHosts.add("login.microsoftonline.de"); // Microsoft Azure Germany
-            sValidHosts.add("login-us.microsoftonline.com"); // Microsoft Azure US Government
+        if (VALID_HOSTS.size() == 0) {
+            VALID_HOSTS.add("login.windows.net"); // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list
+            VALID_HOSTS.add("login.microsoftonline.com"); // Microsoft Azure Worldwide
+            VALID_HOSTS.add("login.chinacloudapi.cn"); // Microsoft Azure China
+            VALID_HOSTS.add("login.microsoftonline.de"); // Microsoft Azure Germany
+            VALID_HOSTS.add("login-us.microsoftonline.com"); // Microsoft Azure US Government
         }
     }
 
@@ -180,16 +180,19 @@ final class Discovery {
 
             // parse discovery response to find tenant info
             final Map<String, String> discoveryResponse = parseResponse(webResponse);
-            if(discoveryResponse.containsKey(AuthenticationConstants.OAuth2.ERROR_CODES)) {
-                final String errorCodes = discoveryResponse.get(AuthenticationConstants.OAuth2.ERROR_CODES);
+            if (discoveryResponse.containsKey(AuthenticationConstants.OAuth2.ERROR_CODES)) {
+                final String errorCodes = discoveryResponse.get(
+                        AuthenticationConstants.OAuth2.ERROR_CODES);
                 ClientMetrics.INSTANCE.setLastError(errorCodes);
-                throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE,
+                throw new AuthenticationException(
+                        ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE,
                         "Fail to valid authority with errors: " + errorCodes);
             }
             
             return (discoveryResponse.containsKey(TENANT_DISCOVERY_ENDPOINT));
         } finally {
-            ClientMetrics.INSTANCE.endClientMetricsRecord(ClientMetricsEndpointType.INSTANCE_DISCOVERY, mCorrelationId);                
+            ClientMetrics.INSTANCE.endClientMetricsRecord(
+                    ClientMetricsEndpointType.INSTANCE_DISCOVERY, mCorrelationId);
         }
     }
 
@@ -203,7 +206,7 @@ final class Discovery {
         if (!StringExtensions.IsNullOrBlank(validHost)) {
             // for comparisons it uses Locale.US, so it needs to be same
             // here
-            sValidHosts.add(validHost.toLowerCase(Locale.US));
+            VALID_HOSTS.add(validHost.toLowerCase(Locale.US));
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -79,7 +79,7 @@ final class Discovery {
     /**
      * interface to use in testing.
      */
-    private IWebRequestHandler mWebrequestHandler;
+    private final IWebRequestHandler mWebrequestHandler;
 
     public Discovery() {
         initValidList();
@@ -129,7 +129,7 @@ final class Discovery {
      */
     private void initValidList() {
         // mValidHosts is a sync set
-        if (VALID_HOSTS.size() == 0) {
+        if (VALID_HOSTS.isEmpty()) {
             VALID_HOSTS.add("login.windows.net"); // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list
             VALID_HOSTS.add("login.microsoftonline.com"); // Microsoft Azure Worldwide
             VALID_HOSTS.add("login.chinacloudapi.cn"); // Microsoft Azure China
@@ -189,7 +189,7 @@ final class Discovery {
                         "Fail to valid authority with errors: " + errorCodes);
             }
             
-            return (discoveryResponse.containsKey(TENANT_DISCOVERY_ENDPOINT));
+            return discoveryResponse.containsKey(TENANT_DISCOVERY_ENDPOINT);
         } finally {
             ClientMetrics.INSTANCE.endClientMetricsRecord(
                     ClientMetricsEndpointType.INSTANCE_DISCOVERY, mCorrelationId);

--- a/adal/src/main/java/com/microsoft/aad/adal/FileTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/FileTokenCacheStore.java
@@ -92,7 +92,7 @@ public class FileTokenCacheStore implements ITokenCacheStore {
                 objectStream.close();
 
                 if (cacheObj instanceof MemoryTokenCacheStore) {
-                    mInMemoryCache = (MemoryTokenCacheStore)cacheObj;
+                    mInMemoryCache = (MemoryTokenCacheStore) cacheObj;
                 } else {
                     Logger.w(TAG, "Existing cache format is wrong", "",
                             ADALError.DEVICE_FILE_CACHE_FORMAT_IS_WRONG);

--- a/adal/src/main/java/com/microsoft/aad/adal/HttpAuthDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HttpAuthDialog.java
@@ -82,8 +82,8 @@ class HttpAuthDialog {
     private void createDialog() {
         LayoutInflater factory = LayoutInflater.from(mContext);
         View v = factory.inflate(R.layout.http_auth_dialog, null);
-        mUsernameView = (EditText)v.findViewById(R.id.editUserName);
-        mPasswordView = (EditText)v.findViewById(R.id.editPassword);
+        mUsernameView = (EditText) v.findViewById(R.id.editUserName);
+        mPasswordView = (EditText) v.findViewById(R.id.editPassword);
         mPasswordView.setOnEditorActionListener(new OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
@@ -112,13 +112,15 @@ class HttpAuthDialog {
                 .setNegativeButton(R.string.http_auth_dialog_cancel,
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int whichButton) {
-                                if (mCancelListener != null)
+                                if (mCancelListener != null) {
                                     mCancelListener.onCancel();
+                                }
                             }
                         }).setOnCancelListener(new DialogInterface.OnCancelListener() {
                     public void onCancel(DialogInterface dialog) {
-                        if (mCancelListener != null)
+                        if (mCancelListener != null) {
                             mCancelListener.onCancel();
+                        }
                     }
                 }).create();
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/HttpUrlConnectionFactory.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HttpUrlConnectionFactory.java
@@ -31,7 +31,12 @@ import java.net.URL;
  * For testability, test case could set mocked {@link HttpURLConnection} 
  * to inject dependency. 
  */
-class HttpUrlConnectionFactory {
+final class HttpUrlConnectionFactory {
+    /**
+     * Private constructor to prevent the class from being initiated.
+     */
+    private HttpUrlConnectionFactory() { }
+
     static HttpURLConnection mockedConnection = null;
     
     static HttpURLConnection createHttpUrlConnection(final URL url) throws IOException {
@@ -39,6 +44,6 @@ class HttpUrlConnectionFactory {
             return mockedConnection;
         }
         
-        return (HttpURLConnection)url.openConnection();
+        return (HttpURLConnection) url.openConnection();
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/HttpUrlConnectionFactory.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HttpUrlConnectionFactory.java
@@ -32,12 +32,13 @@ import java.net.URL;
  * to inject dependency. 
  */
 final class HttpUrlConnectionFactory {
+
+    static HttpURLConnection mockedConnection = null;
+
     /**
      * Private constructor to prevent the class from being initiated.
      */
     private HttpUrlConnectionFactory() { }
-
-    static HttpURLConnection mockedConnection = null;
     
     static HttpURLConnection createHttpUrlConnection(final URL url) throws IOException {
         if (mockedConnection != null) {

--- a/adal/src/main/java/com/microsoft/aad/adal/HttpWebRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HttpWebRequest.java
@@ -94,7 +94,7 @@ class HttpWebRequest {
         final HttpURLConnection connection = HttpUrlConnectionFactory.createHttpUrlConnection(mUrl);
         connection.setConnectTimeout(CONNECT_TIME_OUT);
         // To prevent EOF exception.
-        if (Build.VERSION.SDK_INT > 13) {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB_MR2) {
             connection.setRequestProperty("Connection", "close");
         }
 
@@ -183,18 +183,16 @@ class HttpWebRequest {
     } 
 
     /**
-     * Convert stream into the string
+     * Convert stream into the string.
      *
-     * @param is
-     *            Input stream
+     * @param inputStream {@link InputStream} to be converted to be a string.
      * @return The converted string
-     * @throws IOException
-     *             Thrown when failing to access input stream.
+     * @throws IOException Thrown when failing to access inputStream stream.
      */
-    private static String convertStreamToString(InputStream is) throws IOException {
+    private static String convertStreamToString(InputStream inputStream) throws IOException {
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(is));
+            reader = new BufferedReader(new InputStreamReader(inputStream));
             StringBuilder sb = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
@@ -235,7 +233,7 @@ class HttpWebRequest {
     }
 
     /**
-     * Close the stream safely
+     * Close the stream safely.
      *
      * @param stream stream to be closed
      */

--- a/adal/src/main/java/com/microsoft/aad/adal/HttpWebResponse.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HttpWebResponse.java
@@ -34,20 +34,35 @@ public class HttpWebResponse {
     private final String mResponseBody;
     private final Map<String, List<String>> mResponseHeaders;
 
+    /**
+     * Constructor for {@link HttpWebResponse}.
+     * @param statusCode Status code returned for the http call.
+     * @param responseBody Response body returned from the http network call.
+     * @param responseHeaders Response header for the network call.
+     */
     public HttpWebResponse(int statusCode, String responseBody, Map<String, List<String>> responseHeaders) {
         mStatusCode = statusCode;
         mResponseBody = responseBody;
         mResponseHeaders = responseHeaders;
     }
 
+    /**
+     * @return The status code for the network call.
+     */
     public int getStatusCode() {
         return mStatusCode;
     }
 
+    /**
+     * @return The response headers for the network call.
+     */
     public Map<String, List<String>> getResponseHeaders() {
         return mResponseHeaders;
     }
 
+    /**
+     * @return The response body for the network call.
+     */
     public String getBody() {
         return mResponseBody;
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/IJWSBuilder.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IJWSBuilder.java
@@ -45,6 +45,7 @@ public interface IJWSBuilder {
      * @param pubKey Public Key of the Device Certificate
      * @param x509Certificate X509 certificate
      * @return Signed JWT
+     * @throws AuthenticationException when errors happens for generating signed JWT.
      */
     String generateSignedJWT(String nonce, String submitUrl, RSAPrivateKey privateKey,
             RSAPublicKey pubKey, X509Certificate x509Certificate) throws AuthenticationException;

--- a/adal/src/main/java/com/microsoft/aad/adal/ITokenStoreQuery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ITokenStoreQuery.java
@@ -29,15 +29,36 @@ import java.util.Set;
 
 public interface ITokenStoreQuery {
 
+    /**
+     * @return {@link Iterator} of all the {@link TokenCacheItem}s.
+     */
     Iterator<TokenCacheItem> getAll();
 
+    /**
+     * @return {@link Set} of unique users in the token cache.
+     */
     Set<String> getUniqueUsersWithTokenCache();
 
+    /**
+     * @param resource The resource to retrieve the token for.
+     * @return {@link List} of {@link TokenCacheItem}s for the given resource.
+     */
     List<TokenCacheItem> getTokensForResource(String resource);
 
+    /**
+     * @param userid The user id to retrieve the token for.
+     * @return {@link List} of tokens for the given user id.
+     */
     List<TokenCacheItem> getTokensForUser(String userid);
 
+    /**
+     * Clear tokens for given user.
+     * @param userId The unique user id to clear the token for.
+     */
     void clearTokensForUser(String userId);
 
+    /**
+     * @return A {@link List} of {@link TokenCacheItem}s that are going to expire.
+     */
     List<TokenCacheItem> getTokensAboutToExpire();
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/IWebRequestHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IWebRequestHandler.java
@@ -32,10 +32,30 @@ import java.util.UUID;
  * Webrequest interface to send web requests.
  */
 public interface IWebRequestHandler {
+    /**
+     * Send the http GET request.
+     * @param url {@link URL} for the GET request.
+     * @param headers Map of headers sent in the GET request.
+     * @return {@link HttpWebResponse} containing the status code and response headers.
+     * @throws IOException when error occurs on reading the http response.
+     */
     HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException;
 
+    /**
+     * Send the HTTP POST request.
+     * @param url {@link URL} for the POST request.
+     * @param headers Map of headers sent int the POST request.
+     * @param content The content sent as POST message.
+     * @param contentType Content type of the POST request.
+     * @return {@link HttpWebResponse} containing the status code and response header.
+     * @throws IOException when error occurs on reading the http response.
+     */
     HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
             String contentType) throws IOException;
 
-    void setRequestCorrelationId(UUID mRequestCorrelationId);
+    /**
+     * Set the correlation id for the web request.
+     * @param requestCorrelationId {@link UUID} of the correlation id to set in the web request.
+     */
+    void setRequestCorrelationId(UUID requestCorrelationId);
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/IWebRequestHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IWebRequestHandler.java
@@ -35,7 +35,7 @@ public interface IWebRequestHandler {
     /**
      * Send the http GET request.
      * @param url {@link URL} for the GET request.
-     * @param headers Map of headers sent in the GET request.
+     * @param headers Non-null, and mutable Map of headers sent in the GET request.
      * @return {@link HttpWebResponse} containing the status code and response headers.
      * @throws IOException when error occurs on reading the http response.
      */
@@ -44,7 +44,7 @@ public interface IWebRequestHandler {
     /**
      * Send the HTTP POST request.
      * @param url {@link URL} for the POST request.
-     * @param headers Map of headers sent int the POST request.
+     * @param headers Non-null, and mutable Map of headers sent int the POST request.
      * @param content The content sent as POST message.
      * @param contentType Content type of the POST request.
      * @return {@link HttpWebResponse} containing the status code and response header.

--- a/adal/src/main/java/com/microsoft/aad/adal/JWSBuilder.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/JWSBuilder.java
@@ -114,7 +114,7 @@ class JWSBuilder implements IJWSBuilder {
         Claims claims = new Claims();
         claims.mNonce = nonce;
         claims.mAudience = audience;
-        claims.mIssueAt = (System.currentTimeMillis() / SECONDS_MS);
+        claims.mIssueAt = System.currentTimeMillis() / SECONDS_MS;
 
         JwsHeader header = new JwsHeader();
         header.mAlgorithm = JWS_HEADER_ALG;
@@ -149,9 +149,11 @@ class JWSBuilder implements IJWSBuilder {
             signature = sign(privateKey,
                     signingInput.getBytes(AuthenticationConstants.ENCODING_UTF8));
         } catch (UnsupportedEncodingException e) {
-            throw new AuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED);
+            throw new AuthenticationException(ADALError.ENCODING_IS_NOT_SUPPORTED,
+                    "Unsupported encoding", e);
         } catch (CertificateEncodingException e) {
-            throw new AuthenticationException(ADALError.CERTIFICATE_ENCODING_ERROR);
+            throw new AuthenticationException(ADALError.CERTIFICATE_ENCODING_ERROR,
+                    "Certifiante encoding error", e);
         }
         return signingInput + "." + signature;
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/JWSBuilder.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/JWSBuilder.java
@@ -60,13 +60,13 @@ class JWSBuilder implements IJWSBuilder {
      */
     class Claims {
         @com.google.gson.annotations.SerializedName("aud")
-        protected String mAudience;
+        private String mAudience;
 
         @com.google.gson.annotations.SerializedName("iat")
-        protected long mIssueAt;
+        private long mIssueAt;
 
         @com.google.gson.annotations.SerializedName("nonce")
-        protected String mNonce;
+        private String mNonce;
     }
 
     /**
@@ -74,17 +74,17 @@ class JWSBuilder implements IJWSBuilder {
      */
     class JwsHeader {
         @com.google.gson.annotations.SerializedName("alg")
-        protected String mAlgorithm;
+        private String mAlgorithm;
 
         @com.google.gson.annotations.SerializedName("typ")
-        protected String mType;
+        private String mType;
 
         @com.google.gson.annotations.SerializedName("x5c")
-        protected String[] mCert;
+        private String[] mCert;
     }
 
     /**
-     * 
+     * Generate the signed JWT.
      */
     public String generateSignedJWT(String nonce, String audience, RSAPrivateKey privateKey,
             RSAPublicKey pubKey, X509Certificate cert) throws AuthenticationException {

--- a/adal/src/main/java/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ResourceAuthenticationChallengeException.java
@@ -31,6 +31,11 @@ public class ResourceAuthenticationChallengeException extends AuthenticationExce
 
     static final long serialVersionUID = 1;
 
+    /**
+     * Creates the {@link ResourceAuthenticationChallengeException} with given error message.
+     * @param detailMessage The detailed message to create
+     * {@link ResourceAuthenticationChallengeException}.
+     */
     public ResourceAuthenticationChallengeException(String detailMessage) {
         super(ADALError.RESOURCE_AUTHENTICATION_CHALLENGE_FAILURE, detailMessage);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
@@ -134,6 +134,8 @@ public class StorageHelper {
     
     private static final int KEY_FILE_SIZE = 1024;
 
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+
     private final Context mContext;
     private final SecureRandom mRandom;
 
@@ -308,10 +310,10 @@ public class StorageHelper {
         }
 
         final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
-        if (secretKeyData != null) {
-            mBlobVersion = VERSION_USER_DEFINED;
-        } else {
+        if (secretKeyData == null) {
             mBlobVersion = VERSION_ANDROID_KEY_STORE;
+        } else {
+            mBlobVersion = VERSION_USER_DEFINED;
         }
 
         return getKeyOrCreate(mBlobVersion);
@@ -393,7 +395,7 @@ public class StorageHelper {
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private synchronized KeyPair generateKeyPairFromAndroidKeyStore()
             throws GeneralSecurityException, IOException {
-        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
         keyStore.load(null);
 
         Logger.v(TAG, "Generate KeyPair from AndroidKeyStore");
@@ -405,7 +407,7 @@ public class StorageHelper {
         // self signed cert stored in AndroidKeyStore to asym. encrypt key
         // to a file
         final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA",
-                "AndroidKeyStore");
+                ANDROID_KEY_STORE);
         generator.initialize(getKeyPairGeneratorSpec(mContext, start.getTime(), end.getTime()));
         try {
             return generator.generateKeyPair();
@@ -434,7 +436,7 @@ public class StorageHelper {
         }
 
         Logger.v(TAG, "Reading Key entry");
-        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
         keyStore.load(null);
 
         final KeyStore.PrivateKeyEntry entry;
@@ -460,7 +462,7 @@ public class StorageHelper {
      * Check if KeyPair exists on AndroidKeyStore. 
      */
     private synchronized boolean doesKeyPairExist() throws GeneralSecurityException, IOException {
-        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
         keyStore.load(null);
         
         final boolean isKeyStoreCertAliasExisted;
@@ -597,7 +599,7 @@ public class StorageHelper {
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private synchronized void resetKeyPairFromAndroidKeyStore() throws KeyStoreException,
             NoSuchAlgorithmException, CertificateException, IOException {
-        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
         keyStore.load(null);
         keyStore.deleteEntry(KEY_STORE_CERT_ALIAS);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
@@ -30,7 +30,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.GeneralSecurityException;
@@ -81,12 +80,12 @@ public class StorageHelper {
     private static final String KEY_STORE_CERT_ALIAS = "AdalKey";
 
     /**
-     * Name of the file contains the symmetric key used for encryption/decryption
+     * Name of the file contains the symmetric key used for encryption/decryption.
      */
     private static final String ADALKS = "adalks";
 
     /**
-     * Key spec algorighm.
+     * Key spec algorithm.
      */
     private static final String KEYSPEC_ALGORITHM = "AES";
 
@@ -117,7 +116,7 @@ public class StorageHelper {
     public static final int HMAC_LENGTH = 32;
 
     /**
-     * Indicate that token item is encrypted with the key persisted in AndroidKeyStore 
+     * Indicate that token item is encrypted with the key persisted in AndroidKeyStore.
      */
     public static final String VERSION_ANDROID_KEY_STORE = "A001";
 
@@ -147,18 +146,22 @@ public class StorageHelper {
     private SecretKey mHMACKey = null;
     private SecretKey mSecretKeyFromAndroidKeyStore = null;
 
-    public StorageHelper(Context ctx) {
-        mContext = ctx;
+    /**
+     * Constructor for {@link StorageHelper}.
+     * @param context The {@link Context} to create {@link StorageHelper}.
+     */
+    public StorageHelper(Context context) {
+        mContext = context;
         mRandom = new SecureRandom();
     }
 
     /**
-     * encrypt text with current key based on API level
+     * Encrypt text with current key based on API level.
      *
      * @param clearText Clear text to encrypt. 
      * @return Encrypted blob.
-     * @throws GeneralSecurityException
-     * @throws UnsupportedEncodingException
+     * @throws GeneralSecurityException for key related exceptions.
+     * @throws IOException For general IO related exceptions.
      */
     public String encrypt(final String clearText)
             throws GeneralSecurityException, IOException {
@@ -219,10 +222,11 @@ public class StorageHelper {
      * Decrypt encrypted blob with either user provided key or key persisted in AndroidKeyStore. 
      * @param encryptedBlob The blob to decrypt
      * @return Decrypted clear text.
-     * @throws GeneralSecurityException
-     * @throws IOException
+     * @throws GeneralSecurityException for key related exceptions.
+     * @throws IOException For general IO related exceptions.
      */
-    public String decrypt(final String encryptedBlob) throws GeneralSecurityException, IOException {
+    public String decrypt(final String encryptedBlob)
+            throws GeneralSecurityException, IOException {
         Logger.v(TAG, "Starting decryption");
 
         if (StringExtensions.IsNullOrBlank(encryptedBlob)) {
@@ -291,11 +295,12 @@ public class StorageHelper {
      * Get Secret Key based on API level to use in encryption. Decryption key
      * depends on version# since user can migrate to new Android.OS
      *
-     * @return SecretKey Get Secret Key based on API level to use in encryption
-     * @throws NoSuchAlgorithmException
+     * @return SecretKey Get Secret Key based on API level to use in encryption.
+     * @throws GeneralSecurityException
      * @throws IOException
      */
-    synchronized SecretKey loadSecretKeyForEncryption() throws IOException, GeneralSecurityException {
+    synchronized SecretKey loadSecretKeyForEncryption() throws IOException,
+            GeneralSecurityException {
         // Loading key only once for performance. If API is upgraded, it will
         // restart the device anyway. It will load the correct key for new API.
         if (mKey != null && mHMACKey != null) {
@@ -313,12 +318,13 @@ public class StorageHelper {
     }
 
     /**
-     * load key based on version for migration
+     * load key based on version for migration.
      * 
      * @throws GeneralSecurityException
      * @throws IOException
      */
-    synchronized SecretKey loadSecretKeyForDecryption(String keyVersion) throws GeneralSecurityException, IOException {
+    synchronized SecretKey loadSecretKeyForDecryption(String keyVersion)
+            throws GeneralSecurityException, IOException {
         if (mSecretKeyFromAndroidKeyStore != null) {
             return mSecretKeyFromAndroidKeyStore;
         }
@@ -330,12 +336,14 @@ public class StorageHelper {
      * For API <18 or user provide the key, will return the user supplied key.
      * Supported API >= 18 PrivateKey is stored in AndroidKeyStore. Loads key
      * from the file if it exists. If not exist, it will generate one.
-     * @param keyVersion whether its user defined or from the android key store
-     * @return SecretKey
+     * @param keyVersion The key type of the keys used to encrypt data, could be user provided key
+     *                   or key persisted in the keystore.
+     * @return The {@link SecretKey} used to encrypt data.
      * @throws GeneralSecurityException
      * @throws IOException
      */
-    private synchronized SecretKey getKeyOrCreate(final String keyVersion) throws GeneralSecurityException, IOException {
+    private synchronized SecretKey getKeyOrCreate(final String keyVersion)
+            throws GeneralSecurityException, IOException {
         if (VERSION_USER_DEFINED.equals(keyVersion)) {
             return getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
         }
@@ -383,14 +391,16 @@ public class StorageHelper {
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    private synchronized KeyPair generateKeyPairFromAndroidKeyStore() throws GeneralSecurityException, IOException {
+    private synchronized KeyPair generateKeyPairFromAndroidKeyStore()
+            throws GeneralSecurityException, IOException {
         final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
         keyStore.load(null);
 
         Logger.v(TAG, "Generate KeyPair from AndroidKeyStore");
         final Calendar start = Calendar.getInstance();
         final Calendar end = Calendar.getInstance();
-        end.add(Calendar.YEAR, 100);
+        final int certValidYears = 100;
+        end.add(Calendar.YEAR, certValidYears);
 
         // self signed cert stored in AndroidKeyStore to asym. encrypt key
         // to a file
@@ -429,7 +439,7 @@ public class StorageHelper {
 
         final KeyStore.PrivateKeyEntry entry;
         try {
-            entry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(
+            entry = (KeyStore.PrivateKeyEntry) keyStore.getEntry(
                     KEY_STORE_CERT_ALIAS, null);
         } catch (final RuntimeException e) {
             // There is an issue in android keystore that resets keystore
@@ -496,7 +506,7 @@ public class StorageHelper {
     }
 
     /**
-     * Derive HMAC key from given key
+     * Derive HMAC key from given key.
      * 
      * @param key SecretKey from which HMAC key has to be derived
      * @return SecretKey
@@ -514,7 +524,7 @@ public class StorageHelper {
     }
 
     private char getEncodeVersionLengthPrefix() {
-        return (char)('a' + ENCODE_VERSION.length());
+        return (char) ('a' + ENCODE_VERSION.length());
     }
 
     private void assertHMac(final byte[] digest, final int start, final int end, final byte[] calculated)
@@ -536,7 +546,7 @@ public class StorageHelper {
     }
 
     /**
-     * generate secretKey to store after wrapping with KeyStore
+     * generate secretKey to store after wrapping with KeyStore.
      * 
      * @return SecretKey
      * @throws NoSuchAlgorithmException
@@ -548,7 +558,8 @@ public class StorageHelper {
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    private synchronized SecretKey getUnwrappedSecretKey() throws GeneralSecurityException, IOException {
+    private synchronized SecretKey getUnwrappedSecretKey()
+            throws GeneralSecurityException, IOException {
         Logger.v(TAG, "Reading SecretKey");
 
         final SecretKey unwrappedSecretKey;
@@ -559,7 +570,8 @@ public class StorageHelper {
         } catch (final GeneralSecurityException | IOException ex) {
             // Reset KeyPair info so that new request will generate correct KeyPairs.
             // All tokens with previous SecretKey are not possible to decrypt.
-            Logger.e(TAG, "Unwrap failed for AndroidKeyStore", "", ADALError.ANDROIDKEYSTORE_FAILED, ex);
+            Logger.e(TAG, "Unwrap failed for AndroidKeyStore", "",
+                    ADALError.ANDROIDKEYSTORE_FAILED, ex);
             mKeyPair = null;
             deleteKeyFile();
             resetKeyPairFromAndroidKeyStore();
@@ -572,8 +584,8 @@ public class StorageHelper {
 
     private void deleteKeyFile() {
         // Store secret key in a file after wrapping
-        final File keyFile = new File(mContext.getDir(mContext.getPackageName(), Context.MODE_PRIVATE),
-                ADALKS);
+        final File keyFile = new File(mContext.getDir(mContext.getPackageName(),
+                Context.MODE_PRIVATE), ADALKS);
         if (keyFile.exists()) {
             Logger.v(TAG, "Delete KeyFile");
             if (!keyFile.delete()) {
@@ -603,7 +615,7 @@ public class StorageHelper {
         final Cipher wrapCipher = Cipher.getInstance(WRAP_ALGORITHM);
         wrapCipher.init(Cipher.UNWRAP_MODE, mKeyPair.getPrivate());
         try {
-            return (SecretKey)wrapCipher.unwrap(keyBlob, KEYSPEC_ALGORITHM, Cipher.SECRET_KEY);
+            return (SecretKey) wrapCipher.unwrap(keyBlob, KEYSPEC_ALGORITHM, Cipher.SECRET_KEY);
         } catch (final IllegalArgumentException exception) {
             // There is issue with Android KeyStore when lock screen type is changed which could 
             // potentially wipe out keystore. 
@@ -655,7 +667,7 @@ public class StorageHelper {
         }
     }
     
-    private static class AndroidKeyStoreFailureEvent extends ClientAnalytics.Event {
+    private static final class AndroidKeyStoreFailureEvent extends ClientAnalytics.Event {
         private AndroidKeyStoreFailureEvent(final InstrumentationPropertiesBuilder builder) {
             super(InstrumentationIDs.ANDROIDKEYSTORE_EVENT,
                     builder.add(InstrumentationIDs.EVENT_RESULT, InstrumentationIDs.EVENT_RESULT_FAIL)

--- a/adal/src/main/java/com/microsoft/aad/adal/UsageAuthenticationException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/UsageAuthenticationException.java
@@ -31,7 +31,7 @@ public class UsageAuthenticationException extends AuthenticationException {
 
     /**
      * Constructs a new UsageAuthenticationException with message.
-     * 
+     * @param code The error code for {@link UsageAuthenticationException}.
      * @param msg Detailed message for the reason causing the exception.
      */
     public UsageAuthenticationException(ADALError code, String msg) {
@@ -39,10 +39,10 @@ public class UsageAuthenticationException extends AuthenticationException {
     }
     
     /**
-     * Constructs a new UsageAuthenticationException with message and the cause exception
+     * Constructs a new UsageAuthenticationException with message and the cause exception.
      * 
      * @param code Resource file related error code. Message will be derived
-     *            from resource with using app context
+     *            from resource with using app context.
      * @param msg Detailed message for the reason causing the exception.
      * @param throwable {@link Throwable}
      */

--- a/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
@@ -37,7 +37,7 @@ import java.util.GregorianCalendar;
 public class UserInfo implements Serializable {
 
     /**
-     * universal version identifier for UserInfo class.
+     * Universal version identifier for UserInfo class.
      */
     private static final long serialVersionUID = 8790127561636702672L;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
@@ -59,6 +59,7 @@ public class UserInfo implements Serializable {
      * Default constructor for {@link UserInfo}.
      */
     public UserInfo() {
+        // Default constructor, intentionally empty.
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
@@ -37,7 +37,7 @@ import java.util.GregorianCalendar;
 public class UserInfo implements Serializable {
 
     /**
-     * universal version identifier for UserInfo class
+     * universal version identifier for UserInfo class.
      */
     private static final long serialVersionUID = 8790127561636702672L;
 
@@ -55,14 +55,28 @@ public class UserInfo implements Serializable {
 
     private transient Date mPasswordExpiresOn;
 
+    /**
+     * Default constructor for {@link UserInfo}.
+     */
     public UserInfo() {
-
     }
 
+    /**
+     * Constructor for {@link UserInfo}.
+     * @param upn Upn that is used to construct the {@link UserInfo}.
+     */
     public UserInfo(String upn) {
         mDisplayableId = upn;
     }
 
+    /**
+     * Constructor for {@lin UserInfo}.
+     * @param userid Unique user id for the userInfo.
+     * @param givenName Given name for the userInfo.
+     * @param familyName Family name for the userInfo.
+     * @param identityProvider IdentityProvider for the userInfo.
+     * @param displayableId Displayable for the userInfo.
+     */
     public UserInfo(String userid, String givenName, String familyName, String identityProvider,
             String displayableId) {
         mUniqueId = userid;
@@ -72,6 +86,10 @@ public class UserInfo implements Serializable {
         mDisplayableId = displayableId;
     }
 
+    /**
+     * Constructor for creating {@link UserInfo} from {@link IdToken}.
+     * @param idToken The {@link IdToken} to create {@link UserInfo}.
+     */
     public UserInfo(IdToken idToken) {
 
         mUniqueId = null;
@@ -96,7 +114,7 @@ public class UserInfo implements Serializable {
             // pwd_exp returns seconds to expiration time
             // it returns in seconds. Date accepts milliseconds.
             Calendar expires = new GregorianCalendar();
-            expires.add(Calendar.SECOND, (int)idToken.getPasswordExpiration());
+            expires.add(Calendar.SECOND, (int) idToken.getPasswordExpiration());
             mPasswordExpiresOn = expires.getTime();
         }
 
@@ -106,6 +124,11 @@ public class UserInfo implements Serializable {
         }
     }
 
+    /**
+     * Creates the {@link UserInfo} from the bundle returned from broker.
+     * @param bundle The {@link Bundle} that broker returns.
+     * @return {@link UserInfo} created from the bundle result.
+     */
     static UserInfo getUserInfoFromBrokerResult(final Bundle bundle) {
         // Broker has one user and related to ADFS WPJ user. It does not return
         // idtoken
@@ -130,6 +153,9 @@ public class UserInfo implements Serializable {
         return mUniqueId;
     }
 
+    /**
+     * @param userid The unique user id to set.
+     */
     void setUserId(String userid) {
         mUniqueId = userid;
     }
@@ -170,6 +196,9 @@ public class UserInfo implements Serializable {
         return mDisplayableId;
     }
 
+    /**
+     * @param displayableId The displayable Id to set.
+     */
     void setDisplayableId(String displayableId) {
         mDisplayableId = displayableId;
     }
@@ -191,5 +220,4 @@ public class UserInfo implements Serializable {
     public Date getPasswordExpiresOn() {
         return mPasswordExpiresOn;
     }
-
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/WebRequestHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/WebRequestHandler.java
@@ -58,7 +58,7 @@ public class WebRequestHandler implements IWebRequestHandler {
      * Creates http request.
      */
     public WebRequestHandler() {
-
+        // Default constructor, intentionally empty.
     }
 
     @Override
@@ -83,10 +83,10 @@ public class WebRequestHandler implements IWebRequestHandler {
         return request.send();
     }
 
-    private Map<String, String> updateHeaders(Map<String, String> headers) {
+    private Map<String, String> updateHeaders(final Map<String, String> headers) {
 
         if (headers == null) {
-            headers = new HashMap<>();
+            throw new IllegalArgumentException("headers");
         }
 
         if (mRequestCorrelationId != null) {

--- a/adal/src/main/java/com/microsoft/aad/adal/WebRequestHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/WebRequestHandler.java
@@ -54,13 +54,6 @@ public class WebRequestHandler implements IWebRequestHandler {
 
     private UUID mRequestCorrelationId = null;
 
-    /**
-     * Creates http request.
-     */
-    public WebRequestHandler() {
-        // Default constructor, intentionally empty.
-    }
-
     @Override
     public HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException {
         Logger.v(TAG, "WebRequestHandler thread" + android.os.Process.myTid());
@@ -84,10 +77,6 @@ public class WebRequestHandler implements IWebRequestHandler {
     }
 
     private Map<String, String> updateHeaders(final Map<String, String> headers) {
-
-        if (headers == null) {
-            throw new IllegalArgumentException("headers");
-        }
 
         if (mRequestCorrelationId != null) {
             headers.put(AAD.CLIENT_REQUEST_ID, mRequestCorrelationId.toString());


### PR DESCRIPTION
#682 Cleanup the checkstyle warning for the assigned files on issue 682. 
HttpUrlConncetionFactory still has the warning, to reduce the merge conflicts it could cause in the tests, will move it at the end of the cleanup work. 

Checkstyle also complains the the Logger#Log. We cannot change it since it's public interface. 

PMD: Remove the the rule for java-design, which throws the warning i.e.
1.  avoid if (x != y) else ... I don't think it makes the code any better if we flip it. 
2. using block level instead of method level synchronization. IMO, block level synchronization does help to ensure the code only needs synchronization gets synchronized but it could make the code synchronization in a big block and the code is harder to read. 
I could add the desgin rule back, but i don't think we need to enforce every of them. 

FindBugs unresolved: 
1. Internationalization warning in convertStreamToString. 
Don't see why we need to involve locale here. 
2. unreadfield in JWSBuilder. We only need to create the header and payload and serialize them. Don't need to apply the warning. 
