### PR TITLE
don't continue with rt request if the token cache item doesn't contain RT

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -628,11 +628,19 @@ public class OauthTests extends AndroidTestCase {
         assertEquals("Token is same", "token", result.getAccessToken());
         assertFalse("MultiResource token", result.getIsMultiResourceRefreshToken());
 
-        // multi resource token
+        // resource returned in JSON response, but RT is not returned.
         response.put(AuthenticationConstants.AAD.RESOURCE, "resource");
         result = Oauth2.processUIResponseParams(response);
         assertEquals("Success status", AuthenticationStatus.Succeeded, result.getStatus());
         assertEquals("Token is same", "token", result.getAccessToken());
+        assertFalse("MultiResource token", result.getIsMultiResourceRefreshToken());
+
+        // resource returned in JSON response and RT is also returned.
+        response.put(AuthenticationConstants.OAuth2.REFRESH_TOKEN, "refresh_token");
+        result = Oauth2.processUIResponseParams(response);
+        assertEquals("Success status", AuthenticationStatus.Succeeded, result.getStatus());
+        assertEquals("Token is same", "token", result.getAccessToken());
+        assertEquals("RT is the same", "refresh_token", result.getRefreshToken());
         assertTrue("MultiResource token", result.getIsMultiResourceRefreshToken());
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -284,6 +284,12 @@ class AcquireTokenSilentHandler {
      */
     private AuthenticationResult acquireTokenWithCachedItem(final TokenCacheItem cachedItem)
             throws AuthenticationException {
+        if (StringExtensions.isNullOrBlank(cachedItem.getRefreshToken())) {
+            Logger.v(TAG, "Token cache item contains empty refresh token, cannot continue refresh "
+                   + "token request", mAuthRequest.getLogInfo(), null);
+            return null;
+        }
+
         final AuthenticationResult result = acquireTokenWithRefreshToken(cachedItem.getRefreshToken());
         
         if (result != null && !result.isExtendedLifeTimeToken()) {

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -255,7 +255,9 @@ class Oauth2 {
                     expiresIn == null || expiresIn.isEmpty() ? AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC
                             : Integer.parseInt(expiresIn));
 
-            if (response.containsKey(AuthenticationConstants.AAD.RESOURCE)) {
+            final String refreshToken = response.get(AuthenticationConstants.OAuth2.REFRESH_TOKEN);
+            if (response.containsKey(AuthenticationConstants.AAD.RESOURCE)
+                    && !StringExtensions.isNullOrBlank(refreshToken)) {
                 isMultiResourceToken = true;
             }
 
@@ -282,8 +284,7 @@ class Oauth2 {
             }
 
             result = new AuthenticationResult(
-                    response.get(AuthenticationConstants.OAuth2.ACCESS_TOKEN),
-                    response.get(AuthenticationConstants.OAuth2.REFRESH_TOKEN), expires.getTime(),
+                    response.get(AuthenticationConstants.OAuth2.ACCESS_TOKEN), refreshToken, expires.getTime(),
                     isMultiResourceToken, userinfo, tenantId, rawIdToken, null);
 
             if (response.containsKey(AuthenticationConstants.OAuth2.EXT_EXPIRES_IN)) {


### PR DESCRIPTION
#695 Outlook is seeing from the Nullpointer exception during silent request. 
To prevent app from crashing, we don't continue the silent request if the token cache item doesn't contain RT. Also, when reading the JSON response from server, we mark the flag isMRRT as true only when server returns resource as well as RT in the JSON response. 

Add unit tests to verify that if no rt exists in the cache, we return the null result. 
