### PR TITLE
Permission checking for Account Manager when broker is used

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -190,14 +190,13 @@ public final class AuthenticationContextTest extends AndroidTestCase {
             NoSuchPaddingException {
         String authority = "https://github.com/MSOpenTech";
         FileMockContext mockContext = new FileMockContext(getContext());
-        mockContext.setRequestedPermissionName("android.permission.INTERNET");
-        mockContext.setResponsePermissionFlag(PackageManager.PERMISSION_GRANTED);
+        mockContext.addPermission("android.permission.INTERNET");
 
         // no exception
         new AuthenticationContext(mockContext, authority, false);
 
         try {
-            mockContext.setResponsePermissionFlag(PackageManager.PERMISSION_DENIED);
+            mockContext.removePermission("android.permission.INTERNET");
             new AuthenticationContext(mockContext, authority, false);
             Assert.fail("Supposed to fail");
         } catch (Exception e) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/FileMockContext.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/FileMockContext.java
@@ -39,6 +39,8 @@ import android.test.mock.MockPackageManager;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
@@ -54,9 +56,7 @@ class FileMockContext extends MockContext {
 
     private int mFileWriteMode;
 
-    private String mRequestedPermissionName;
-
-    private int mResponsePermissionFlag;
+    private Map<String, Integer> mPermissionMap = new HashMap<String, Integer>();
     
     private boolean mIsConnectionAvaliable = true;
     
@@ -67,8 +67,7 @@ class FileMockContext extends MockContext {
     public FileMockContext(Context context) {
         mContext = context;
         // default
-        mRequestedPermissionName = "android.permission.INTERNET";
-        mResponsePermissionFlag = PackageManager.PERMISSION_GRANTED;
+        mPermissionMap.put("android.permission.INTERNET", PackageManager.PERMISSION_GRANTED);
     }
 
     @Override
@@ -133,12 +132,20 @@ class FileMockContext extends MockContext {
         mMockedAccountManager = mockedAccountManager;
     }
 
-    public void setRequestedPermissionName(String requestedPermissionName) {
-        mRequestedPermissionName = requestedPermissionName;
+    public void addPermission(String permissionName) {
+        mPermissionMap.put(permissionName, PackageManager.PERMISSION_GRANTED);
+    }
+    
+    public void removePermission(String permissionName) {
+        mPermissionMap.remove(permissionName);
     }
 
-    public void setResponsePermissionFlag(int responsePermissionFlag) {
-        mResponsePermissionFlag = responsePermissionFlag;
+    public int checkPermission(String permName, String pkgName) {
+        if (mPermissionMap.containsKey(permName)) {
+            return PackageManager.PERMISSION_GRANTED;
+        }
+
+        return PackageManager.PERMISSION_DENIED;
     }
 
     public void setConnectionAvaliable(boolean connectionAvaliable) {
@@ -181,9 +188,10 @@ class FileMockContext extends MockContext {
 
         @Override
         public int checkPermission(String permName, String pkgName) {
-            if (permName.equals(mRequestedPermissionName)) {
-                return mResponsePermissionFlag;
+            if (mPermissionMap.containsKey(permName)) {
+                return PackageManager.PERMISSION_GRANTED;
             }
+            
             return PackageManager.PERMISSION_DENIED;
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/ApplicationReceiver.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ApplicationReceiver.java
@@ -109,7 +109,7 @@ public class ApplicationReceiver extends BroadcastReceiver {
             // 1) there is saved request in sharedPreference
             // 2) app has the correct configuration to get token from broker
             // 3) the saved request is not timeout
-            if (!StringExtensions.isNullOrBlank(request) && mBrokerProxy.canSwitchToBroker()
+            if (!StringExtensions.isNullOrBlank(request) && mBrokerProxy.canSwitchToBroker() == BrokerProxy.SwitchToBroker.CAN_SWITCH_TO_BROKER
                     && isRequestTimestampValidForResume(dateTimeForSavedRequest)) {
                 Logger.v(TAG + methodName, receivedInstalledPackageName + " is installed, start sending request to broker.");
                 resumeRequestInBroker(context, request);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -65,7 +65,7 @@ public class AuthenticationContext {
 
     private ITokenCacheStore mTokenCacheStore;
 
-    private IBrokerProxy mBrokerProxy = null;
+    private BrokerProxy mBrokerProxy = null;
 
     private boolean mExtendedLifetimeEnabled = false;
 
@@ -257,14 +257,15 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
             String redirectUri, String loginHint,
             AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, loginHint, PromptBehavior.Auto, null,
-                getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        request.setUserIdentifierType(UserIdentifierType.LoginHint);
-        createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, loginHint, PromptBehavior.Auto, null,
+                    getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            request.setUserIdentifierType(UserIdentifierType.LoginHint);
+            createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+        }
     }
 
     /**
@@ -291,14 +292,15 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
             String redirectUri, String loginHint, String extraQueryParameters,
             AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, loginHint, PromptBehavior.Auto, extraQueryParameters,
-                getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        request.setUserIdentifierType(UserIdentifierType.LoginHint);
-        createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, loginHint, PromptBehavior.Auto, extraQueryParameters,
+                    getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            request.setUserIdentifierType(UserIdentifierType.LoginHint);
+            createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+        }
     }
 
     /**
@@ -322,12 +324,13 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
             String redirectUri, PromptBehavior prompt,
             AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, null, prompt, null, getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, null, prompt, null, getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+        }
     }
 
     /**
@@ -351,13 +354,14 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
             String redirectUri, PromptBehavior prompt, String extraQueryParameters,
             AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, null, prompt, extraQueryParameters,
-                getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, null, prompt, extraQueryParameters,
+                    getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+        }
     }
 
     /**
@@ -383,14 +387,15 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
             String redirectUri, String loginHint, PromptBehavior prompt,
             String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        request.setUserIdentifierType(UserIdentifierType.LoginHint);
-        createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                    getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            request.setUserIdentifierType(UserIdentifierType.LoginHint);
+            createAcquireTokenRequest().acquireToken(wrapActivity(activity), false, request, callback);
+        }
     }
 
     /**
@@ -415,14 +420,15 @@ public class AuthenticationContext {
     public void acquireToken(IWindowComponent fragment, String resource, String clientId,
             String redirectUri, String loginHint, PromptBehavior prompt,
             String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        request.setUserIdentifierType(UserIdentifierType.LoginHint);
-        createAcquireTokenRequest().acquireToken(fragment, false, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                    getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            request.setUserIdentifierType(UserIdentifierType.LoginHint);
+            createAcquireTokenRequest().acquireToken(fragment, false, request, callback);
+        }
     }
 
     /**
@@ -448,14 +454,15 @@ public class AuthenticationContext {
     public void acquireToken(String resource, String clientId, String redirectUri,
             String loginHint, PromptBehavior prompt, String extraQueryParameters,
             AuthenticationCallback<AuthenticationResult> callback) {
+        if (checkPreRequirements(resource, clientId, callback)) {
+            redirectUri = getRedirectUri(redirectUri);
 
-        redirectUri = checkInputParameters(resource, clientId, redirectUri, callback);
-
-        final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                getRequestCorrelationId(), getExtendedLifetimeEnabled());
-        request.setUserIdentifierType(UserIdentifierType.LoginHint);
-        createAcquireTokenRequest().acquireToken(null, true, request, callback);
+            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
+                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                    getRequestCorrelationId(), getExtendedLifetimeEnabled());
+            request.setUserIdentifierType(UserIdentifierType.LoginHint);
+            createAcquireTokenRequest().acquireToken(null, true, request, callback);
+        }
     }
 
     /**
@@ -810,7 +817,7 @@ public class AuthenticationContext {
         }
 
         return new IWindowComponent() {
-            Activity mRefActivity = activity;
+            private Activity mRefActivity = activity;
 
             @Override
             public void startActivityForResult(Intent intent, int requestCode) {
@@ -823,8 +830,18 @@ public class AuthenticationContext {
         };
     }
 
-    private String checkInputParameters(final String resource, final String clientId, final String inputRedirectUri,
+    private boolean checkPreRequirements(final String resource, final String clientId,
                                         final AuthenticationCallback<AuthenticationResult> callback) {
+        //check the permissions required for the broker usage
+        if (AuthenticationSettings.INSTANCE.getUseBroker()) {
+            try {
+                mBrokerProxy.verifyBrokerPermissionsAPI22AndLess();
+            } catch (final UsageAuthenticationException exception) {
+                callback.onError(exception);
+                return false;
+            }
+        }
+
         if (mContext == null) {
             throw new IllegalArgumentException("context", new AuthenticationException(
                     ADALError.DEVELOPER_CONTEXT_IS_NOT_PROVIDED));
@@ -842,6 +859,10 @@ public class AuthenticationContext {
             throw new IllegalArgumentException("callback");
         }
 
+        return true;
+    }
+    
+    private String getRedirectUri(String inputRedirectUri) {
         final String redirectUri;
         if (StringExtensions.isNullOrBlank(inputRedirectUri)) {
             redirectUri = mContext.getApplicationContext().getPackageName();
@@ -904,7 +925,7 @@ public class AuthenticationContext {
             throw new IllegalArgumentException("uniqueUserId");
         }
 
-        if (mBrokerProxy.canSwitchToBroker()) {
+        if (mBrokerProxy.canSwitchToBroker() != BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER) {
             throw new UsageAuthenticationException(ADALError.FAIL_TO_EXPORT,
                     "Failed to export the family refresh token cache item because broker is enabled.");
         }
@@ -947,7 +968,7 @@ public class AuthenticationContext {
             throw new IllegalArgumentException("serializedBlob");
         }
 
-        if (mBrokerProxy.canSwitchToBroker()) {
+        if (mBrokerProxy.canSwitchToBroker() != BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER) {
             throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT, "Failed to import the serialized blob "
                     + "because broker is enabled.");
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/IBrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IBrokerProxy.java
@@ -37,7 +37,7 @@ interface IBrokerProxy {
      * @return True package is available and authenticator is installed at
      *         Account manager
      */
-    boolean canSwitchToBroker();
+    BrokerProxy.SwitchToBroker canSwitchToBroker();
     
     boolean verifyUser(String username, String uniqueid);
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -10,8 +10,6 @@
     <suppress checks="Javadoc.*" files=".*Test.java"/>
     <suppress checks="MethodName" files=".*Logger.java"/>
     <suppress checks="MethodName" files=".*LoggerTest.java"/>
-    <suppress checks="MemberName" files="AuthenticationContext.java" lines="813"/>
-    <suppress checks="VisibilityModifier" files="AuthenticationContext.java" lines="813"/>
     <suppress checks="MemberName" files="SSOStateSerializer.java" lines="47"/>
     <suppress checks="HideUtilityClassConstructor" files="ReflectionUtils.java" lines="31"/>
     <!-- suppress this for Log method in test-->


### PR DESCRIPTION
Issue #475 
Check the permissions of Account Manager at the beginning of acquireToken() if when broker is used, so that the lib could detect early if the app has the necessary permissions. If the app does not have the permission, it will throw the UsageAuthenticationException to the callback.

Under broker:
o If target version is lower than 23, calling app has to have the following permissions declared in manifest (http://developer.android.com/reference/android/accounts/AccountManager.html): 
 GET_ACCOUNTS
 USE_CREDENTIALS
 MANAGE_ACOUNTS

Beginning in Android 6.0 (API level 23), users grant permissions to apps while the app is running, not when they install the app.
o If target version is 23, USE_CREDENTIALS and MANAGE_ACCOUNTS are already deprecated. But GET_ACCOUNTS is under protection level "dangerous", calling app is responsible for requesting the run-time permisson. You can reference Runtime permission request for API 23.

*Permission Checking Implementation Spec*

For Android version below M
For Android below 6.0 (API level 23), users grant permissions when they install the app (in the Manifest). So the function "CheckForPermissionAPI22orBelow" should do the following.
- check the GET_ACCOUNTS, USE_CREDENTIALS and MANAGE_ACOUNTS permissions upfront in acquireToken
- throw the UsageAuthenticationException to tell the developer that the permission need to be set in the manifest
- pass the exception into callBack

For Android.version >= M
Beginning in Android 6.0 (API level 23), users grant permissions to apps while the app is running, not when they install the app. So the function "CheckForPermissionAPI23orAbove" should do the following.
- check the permissions only when it is necessary, so we only check the GET_ACCOUNTS permission when broker is called
- check the permission at the end of canSwitchToBroker
- throw the UsageAuthenticationException and pass it to callback