### PR TITLE
manual merge PR 696 from dev to service branch

### DIFF
--- a/src/src/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/src/src/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -266,6 +266,12 @@ class AcquireTokenSilentHandler {
      */
     private AuthenticationResult acquireTokenWithCachedItem(final TokenCacheItem cachedItem)
             throws AuthenticationException {
+        if (StringExtensions.IsNullOrBlank(cachedItem.getRefreshToken())) {
+            Logger.v(TAG, "Token cache item contains empty refresh token, cannot continue refresh "
+                   + "token request", mAuthRequest.getLogInfo(), null);
+            return null;
+        }
+
         final AuthenticationResult result = acquireTokenWithRefreshToken(cachedItem.getRefreshToken());
         
         if (result != null) {

--- a/src/src/com/microsoft/aad/adal/Oauth2.java
+++ b/src/src/com/microsoft/aad/adal/Oauth2.java
@@ -239,7 +239,9 @@ class Oauth2 {
                     expires_in == null || expires_in.isEmpty() ? AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC
                             : Integer.parseInt(expires_in));
 
-            if (response.containsKey(AuthenticationConstants.AAD.RESOURCE)) {
+            final String refreshToken = response.get(AuthenticationConstants.OAuth2.REFRESH_TOKEN);
+            if (response.containsKey(AuthenticationConstants.AAD.RESOURCE)
+                    && !StringExtensions.IsNullOrBlank(refreshToken)) {
                 isMultiResourcetoken = true;
             }
 
@@ -265,8 +267,7 @@ class Oauth2 {
             }
 
             result = new AuthenticationResult(
-                    response.get(AuthenticationConstants.OAuth2.ACCESS_TOKEN),
-                    response.get(AuthenticationConstants.OAuth2.REFRESH_TOKEN), expires.getTime(),
+                    response.get(AuthenticationConstants.OAuth2.ACCESS_TOKEN), refreshToken, expires.getTime(),
                     isMultiResourcetoken, userinfo, tenantId, rawIdToken);
             
             //Set family client id on authentication result for TokenCacheItem to pick up

--- a/tests/Functional/src/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -684,6 +684,106 @@ public final class AcquireTokenSilentHandlerTest extends AndroidTestCase{
         clearCache(mockCache);
     }
 
+    @SmallTest
+    public void testMRRTItemNotContainRT() {
+        FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        // Add MRRT in the cache
+        final TokenCacheItem mrrtTokenCacheItem = Util.getTokenCacheItem(VALID_AUTHORITY, resource,
+                clientId, TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        mrrtTokenCacheItem.setRefreshToken(null);
+        mrrtTokenCacheItem.setResource(null);
+        mrrtTokenCacheItem.setFamilyClientId("familyClientId");
+        mrrtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        saveTokenIntoCache(mockedCache, mrrtTokenCacheItem);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest(
+                VALID_AUTHORITY, resource, clientId);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        try {
+            final AuthenticationResult authenticationResult = acquireTokenSilentHandler.getAccessToken();
+            assertNull(authenticationResult);
+        } catch (AuthenticationException authException) {
+            fail("Unexpected Exception");
+        }
+
+        // verify MRRT entry exist
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_UPN)));
+
+        clearCache(mockedCache);
+    }
+
+    @SmallTest
+    public void testAllTokenItemNotContainRT() {
+        FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        // Add regular RT item without RT in the cache
+        final TokenCacheItem rtTokenCacheItem = Util.getTokenCacheItem(VALID_AUTHORITY, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        rtTokenCacheItem.setRefreshToken(null);
+        rtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        saveTokenIntoCache(mockedCache, rtTokenCacheItem);
+
+        // Add MRRT in the cache
+        final TokenCacheItem mrrtTokenCacheItem = Util.getTokenCacheItem(VALID_AUTHORITY, resource,
+                clientId, TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        mrrtTokenCacheItem.setRefreshToken(null);
+        mrrtTokenCacheItem.setResource(null);
+        mrrtTokenCacheItem.setFamilyClientId("familyId");
+        mrrtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        saveTokenIntoCache(mockedCache, mrrtTokenCacheItem);
+
+        // Add FRT item into cache without rt
+        final TokenCacheItem frtTokenCacheItem = Util.getTokenCacheItem(VALID_AUTHORITY, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        frtTokenCacheItem.setClientId(null);
+        frtTokenCacheItem.setRefreshToken(null);
+        frtTokenCacheItem.setResource(null);
+        frtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        frtTokenCacheItem.setFamilyClientId("familyId");
+        saveTokenIntoCache(mockedCache, frtTokenCacheItem);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest(
+                VALID_AUTHORITY, resource, clientId);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        try {
+            final AuthenticationResult authenticationResult = acquireTokenSilentHandler.getAccessToken();
+            assertNull(authenticationResult);
+        } catch (AuthenticationException authException) {
+            fail("Unexpected Exception");
+        }
+
+        // verify RT entry exist
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId,
+                TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId,
+                TEST_IDTOKEN_UPN)));
+
+        // verify MRRT entry exist
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_UPN)));
+
+        // verify FRT entry exist
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForFRT(VALID_AUTHORITY, "familyId", TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForFRT(VALID_AUTHORITY, "familyId", TEST_IDTOKEN_UPN)));
+        clearCache(mockedCache);
+    }
+
     private void saveTokenIntoCache(final ITokenCacheStore mockedCache, final TokenCacheItem token) {
         if (!StringExtensions.IsNullOrBlank(token.getResource())) {
             mockedCache.setItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, token.getResource(), token.getClientId(), 

--- a/tests/Functional/src/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -1327,6 +1327,35 @@ public class AuthenticationContextTest extends AndroidTestCase {
         clearCache(context);
     }
 
+    @SmallTest
+    public void testSilentRequestTokenItemNotContainRT() throws InterruptedException {
+        final FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        // Add MRRT in the cache
+        final TokenCacheItem mrrtTokenCacheItem = Util.getTokenCacheItem(VALID_AUTHORITY, resource,
+                clientId, TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        mrrtTokenCacheItem.setRefreshToken(null);
+        mrrtTokenCacheItem.setResource(null);
+        mrrtTokenCacheItem.setFamilyClientId("familyClientId");
+        mrrtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        mockedCache.setItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_USERID), mrrtTokenCacheItem);
+        mockedCache.setItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_UPN), mrrtTokenCacheItem);
+
+        final AuthenticationContext context = getAuthenticationContext(mockContext,
+                VALID_AUTHORITY, false, mockedCache);
+        try {
+            context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_USERID);
+            fail("Expecting exception to be thrown");
+        } catch (final AuthenticationException e) {
+            assertTrue(e.getCode() == ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
+        } finally {
+            clearCache(context);
+        }
+    }
+
     private void verifyRefreshTokenResponse(ITokenCacheStore mockCache, Exception resultException,
             AuthenticationResult result) {
         assertNull("Error is null", resultException);

--- a/tests/Functional/src/com/microsoft/aad/adal/OauthTests.java
+++ b/tests/Functional/src/com/microsoft/aad/adal/OauthTests.java
@@ -636,11 +636,19 @@ public class OauthTests extends AndroidTestCase {
         assertEquals("Token is same", "token", result.getAccessToken());
         assertFalse("MultiResource token", result.getIsMultiResourceRefreshToken());
 
-        // multi resource token
+        // resource returned in JSON response, but RT is not returned.
         response.put(AuthenticationConstants.AAD.RESOURCE, "resource");
         result = (AuthenticationResult)m.invoke(null, response);
         assertEquals("Success status", AuthenticationStatus.Succeeded, result.getStatus());
         assertEquals("Token is same", "token", result.getAccessToken());
+        assertFalse("MultiResource token", result.getIsMultiResourceRefreshToken());
+        
+        // resource returned in JSON response and RT is also returned.
+        response.put(AuthenticationConstants.OAuth2.REFRESH_TOKEN, "refresh_token");
+        result = (AuthenticationResult)m.invoke(null, response);
+        assertEquals("Success status", AuthenticationStatus.Succeeded, result.getStatus());
+        assertEquals("Token is same", "token", result.getAccessToken());
+        assertEquals("RT is the same", "refresh_token", result.getRefreshToken());
         assertTrue("MultiResource token", result.getIsMultiResourceRefreshToken());
     }
 


### PR DESCRIPTION
manual merge PR 696 from dev to servicing branch. 
For issue 695: outlook is seeing empty refresh token stored in token cache item, it's only in outlook dogfood build, no user report yet, there isn't too much diagnostic info to tell the root cause. The fix is to prevent outlook from crashing in this case. 