### PR TITLE
Fix the Jenkins failure of Gradle build

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -87,11 +87,12 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath = configurations.compile
-    destinationDir = reporting.file("$project.buildDir/outputs/jar/")
+    destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    from javadoc.destinationDir
     destinationDir = reporting.file("$project.buildDir/outputs/jar/")
 }
 


### PR DESCRIPTION
Fix the failure of javadoc generation which caused the failure of code sign on Jenkins.