### PR TITLE
add the pom.xml generation task for the gradle build

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
+apply plugin: 'maven-publish'
 
 group = 'com.microsoft.aad'
 
@@ -76,6 +77,40 @@ dependencies {
 
     // Test Dependencies
     testCompile 'junit:junit:4.12'
+}
+
+
+task createPom  {
+    pom {
+        project {
+            groupId 'com.microsoft.aad'
+            artifactId 'adal-aggregator'
+            version '1.0.0-SNAPSHOT'
+            packaging 'jar'
+            name 'ADAL ANDROID-API'
+            inceptionYear '2013'
+
+            modules {
+                module 'adal'
+                module 'sample'
+                module 'testapp'
+                module 'userappwithbroker'
+            }
+
+            url 'https://github.com/MSOpenTech/azure-activedirectory-library-for-android'
+
+            properties {
+                branch 'master'
+                adalVersion = project.version
+            }
+
+            scm {
+                url "https://github.com/MSOpenTech/azure-activedirectory-library-for-android/tree/master"
+                connection 'scm:git:git://github.com/MSOpenTech/azure-activedirectory-library-for-android.git'
+                developerConnection 'scm:git:https://github.com/MSOpenTech/azure-activedirectory-library-for-android.git'
+            }
+        }
+    }.writeTo("pom.xml")
 }
 
 task sourcesJar(type: Jar) {
@@ -161,4 +196,4 @@ task checkstyle(type: Checkstyle) {
     classpath = files()
 }
 
-assembleDebug.dependsOn 'checkstyle', 'pmd', 'findbugs', 'lint'
+assembleDebug.dependsOn 'checkstyle', 'pmd', 'findbugs', 'lint', 'createPom'

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -84,20 +84,27 @@ task createPom  {
     pom {
         project {
             groupId 'com.microsoft.aad'
-            artifactId 'adal-aggregator'
-            version '1.0.0-SNAPSHOT'
-            packaging 'jar'
-            name 'ADAL ANDROID-API'
-            inceptionYear '2013'
+            artifactId 'adal'
+            version = project.version
+            packaging 'aar'
+            name 'adal'
 
-            modules {
-                module 'adal'
-                module 'sample'
-                module 'testapp'
-                module 'userappwithbroker'
+            description 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+            url 'https://github.com/MSOpenTech/azure-activedirectory-library-for-android'
+
+            developers {
+                developer {
+                    id 'msopentech'
+                    name 'Microsoft Open Technologies, Inc.'
+                }
             }
 
-            url 'https://github.com/MSOpenTech/azure-activedirectory-library-for-android'
+            licenses {
+                license {
+                    name 'Apache License, Version 2.0'
+                }
+            }
+            inceptionYear '2003'
 
             properties {
                 branch 'master'
@@ -106,8 +113,6 @@ task createPom  {
 
             scm {
                 url "https://github.com/MSOpenTech/azure-activedirectory-library-for-android/tree/master"
-                connection 'scm:git:git://github.com/MSOpenTech/azure-activedirectory-library-for-android.git'
-                developerConnection 'scm:git:https://github.com/MSOpenTech/azure-activedirectory-library-for-android.git'
             }
         }
     }.writeTo("pom.xml")

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -115,7 +115,7 @@ task createPom  {
                 url "https://github.com/MSOpenTech/azure-activedirectory-library-for-android/tree/master"
             }
         }
-    }.writeTo("pom.xml")
+    }.writeTo("${archivesBaseName}-${version}.pom")
 }
 
 task sourcesJar(type: Jar) {

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -94,8 +94,8 @@ task createPom  {
 
             developers {
                 developer {
-                    id 'msopentech'
-                    name 'Microsoft Open Technologies, Inc.'
+                    id 'microsoft'
+                    name 'Microsoft'
                 }
             }
 
@@ -104,7 +104,7 @@ task createPom  {
                     name 'Apache License, Version 2.0'
                 }
             }
-            inceptionYear '2003'
+            inceptionYear '2014'
 
             properties {
                 branch 'master'


### PR DESCRIPTION
The aim of this PR is to add the pom.xml generation task 'createPom' for the gradle build. The dir of the generated pom.xml locates under the adal folder.