### PR TITLE
Fix potential Activity leak with IWindowComponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,26 +217,22 @@ You can get the jar file from maven the repo and drop into the *libs* folder in 
 10. Finally, ask for a token using that callback:
 
     ```Java
-     mContext.acquireToken(MainActivity.this, resource, clientId, redirect, user_loginhint, PromptBehavior.Auto, "",
+     mContext.acquireToken(MainActivity.this, resource, clientId, redirect, loginHint, PromptBehavior.Auto, "",
                     callback);
     ```
-If you're implementing your authentication logic in a Fragment, you'll need to wrap it in a `IWindowComponent` before passing it as a parameter like this:
+If you're implementing your authentication logic in a Fragment, you'll need to wrap it in a `IWindowComponent` before passing it as a parameter. We provide `ActivityWindowComponent` and `FragmentWindowComponent` classes to simplify this for you, which you can use like this:
 
     ```Java
-    mContext.acquireToken(wrapFragment(MainFragment.this), resource, clientId, redirect, user_loginhint, PromptBehavior.Auto, "",
+    mContext.acquireToken(wrapFragment(MainFragment.this), resource, clientId, redirect, loginHint, PromptBehavior.Auto, "",
                     callback);
                     
-    private IWindowComponent wrapFragment(final Fragment fragment){
-       return new IWindowComponent() {
-          Fragment refFragment = fragment;
-          @Override
-          public void startActivityForResult(Intent intent, int requestCode) {
-             refFragment.startActivityForResult(intent, requestCode);
-          }
-       };
+    private IWindowComponent wrapFragment(final Fragment fragment) {
+       return new FragmentWindowComponent(fragment);
     }
     ```
-
+    
+    If you wish to wrap any other component, you must implement the `IWindowComponent` interface and pass that in as the first parameter to `mContext.acquireToken()`.
+	
 	Explanation of the parameters(Example of those parameters could be found at [Android Native Client Sample](https://github.com/AzureADSamples/NativeClient-Android)):
     
 	* Resource is required and is the resource you are trying to access.
@@ -254,7 +250,9 @@ If you're implementing your authentication logic in a Fragment, you'll need to w
 	```java
 	mContext.acquireTokenSilentSync(String resource, String clientId, String userId);
 	```
-	or 
+	
+	or
+	
 	```java
 	mContext.acquireTokenSilent(String resource, String clientId, String userId, final AuthenticationCallback<AuthenticationResult> callback);
 	```

--- a/adal/src/main/java/com/microsoft/aad/adal/ActivityWindowComponent.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ActivityWindowComponent.java
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import java.lang.ref.WeakReference;
+
+
+public class ActivityWindowComponent implements IWindowComponent {
+
+  private WeakReference<Activity> mActivityRef;
+
+  public ActivityWindowComponent(Activity activity) {
+    mActivityRef = new WeakReference<>(activity);
+  }
+
+  @Override
+  public void startActivityForResult(Intent intent, int requestCode) {
+    // if user closed the app or switched to another activity
+    // activity can die before this method got invoked
+    Activity activity = mActivityRef.get();
+    if (activity != null) {
+      activity.startActivityForResult(intent, requestCode);
+    }
+  }
+
+}

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -816,18 +816,7 @@ public class AuthenticationContext {
             throw new IllegalArgumentException("activity");
         }
 
-        return new IWindowComponent() {
-            private Activity mRefActivity = activity;
-
-            @Override
-            public void startActivityForResult(Intent intent, int requestCode) {
-                // if user closed an app or switched to another activity
-                // mRefActivity can die before this method got invoked
-                if (mRefActivity != null) {
-                    mRefActivity.startActivityForResult(intent, requestCode);
-                }
-            }
-        };
+        return new ActivityWindowComponent(activity);
     }
 
     private boolean checkPreRequirements(final String resource, final String clientId,

--- a/adal/src/main/java/com/microsoft/aad/adal/FragmentWindowComponent.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/FragmentWindowComponent.java
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import android.content.Intent;
+import android.support.v4.app.Fragment;
+
+import java.lang.ref.WeakReference;
+
+
+public class FragmentWindowComponent implements IWindowComponent {
+
+  private WeakReference<Fragment> mFragmentRef;
+
+  public FragmentWindowComponent(Fragment fragment) {
+    mFragmentRef = new WeakReference<>(fragment);
+  }
+
+  @Override
+  public void startActivityForResult(Intent intent, int requestCode) {
+    // if user switched to another activity or left the fragment
+    // fragment can die before this method got invoked
+    Fragment fragment = mFragmentRef.get();
+    if (fragment != null) {
+      fragment.startActivityForResult(intent, requestCode);
+    }
+  }
+
+}

--- a/sample/src/main/java/com/microsoft/aad/adal/hello/LoginFragment.java
+++ b/sample/src/main/java/com/microsoft/aad/adal/hello/LoginFragment.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationContext;
 import com.microsoft.aad.adal.AuthenticationResult;
+import com.microsoft.aad.adal.FragmentWindowComponent;
 import com.microsoft.aad.adal.IWindowComponent;
 import com.microsoft.aad.adal.PromptBehavior;
 
@@ -89,14 +90,7 @@ public class LoginFragment extends Fragment {
     }
 
     private IWindowComponent wrapFragment(final Fragment fragment) {
-        return new IWindowComponent() {
-            Fragment refFragment = fragment;
-
-            @Override
-            public void startActivityForResult(Intent intent, int requestCode) {
-                refFragment.startActivityForResult(intent, requestCode);
-            }
-        };
+        return new FragmentWindowComponent(fragment);
     }
 
     @Override


### PR DESCRIPTION
`AuthenticationContext` creates an anonymous inner `IWindowComponent` class that holds a reference to the Activity parameter. If the point of that anonymous inner class's `mRefActivity` is to ensure that the Activity isn't going to be leaked, then it needs to hold a WeakReference to it instead of just a regular one.

Creating a class to manage that is the easiest solution. For parity I've also created one to wrap a support Fragment, and made those classes public so they can be used by developers using this library.
