### PR TITLE
issue 741: remove the appended query string when responding to pkeyauth challenge

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -107,9 +107,6 @@ public class AuthenticationActivity extends Activity {
     private final IWebRequestHandler mWebRequestHandler = new WebRequestHandler();
 
     private final IJWSBuilder mJWSBuilder = new JWSBuilder();
-
-    private String mQueryParameters;
-
     private boolean mPkeyAuthRedirect = false;
     private StorageHelper mStorageHelper;
 
@@ -209,7 +206,6 @@ public class AuthenticationActivity extends Activity {
         try {
             Oauth2 oauth = new Oauth2(mAuthRequest);
             mStartUrl = oauth.getCodeRequestUrl();
-            mQueryParameters = oauth.getAuthorizationEndpointQueryParameters();
         } catch (UnsupportedEncodingException e) {
             Log.d(TAG, e.getMessage());
             Intent resultIntent = new Intent();
@@ -586,7 +582,7 @@ public class AuthenticationActivity extends Activity {
     class CustomWebViewClient extends BasicWebViewClient {
 
         public CustomWebViewClient() {
-            super(AuthenticationActivity.this, mRedirectUrl, mQueryParameters, mAuthRequest);
+            super(AuthenticationActivity.this, mRedirectUrl, mAuthRequest);
         }
 
         public void processRedirectUrl(final WebView view, String url) {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -144,12 +144,8 @@ class AuthenticationDialog {
                 try {
                     Oauth2 oauth = new Oauth2(mRequest);
                     final String startUrl = oauth.getCodeRequestUrl();
-                    final String queryParameters = oauth.getAuthorizationEndpointQueryParameters();
                     final String stopRedirect = mRequest.getRedirectUri();
-                    mWebView.setWebViewClient(new DialogWebViewClient(mContext, stopRedirect,
-                            queryParameters, mRequest
-
-                    ));
+                    mWebView.setWebViewClient(new DialogWebViewClient(mContext, stopRedirect, mRequest));
                     mWebView.post(new Runnable() {
                         @Override
                         public void run() {
@@ -197,9 +193,9 @@ class AuthenticationDialog {
 
     class DialogWebViewClient extends BasicWebViewClient {
 
-        public DialogWebViewClient(Context ctx, String stopRedirect, String queryParam,
+        public DialogWebViewClient(Context ctx, String stopRedirect,
                 AuthenticationRequest request) {
-            super(ctx, stopRedirect, queryParam, request);
+            super(ctx, stopRedirect, request);
         }
 
         public void showSpinner(final boolean status) {

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -48,16 +48,14 @@ abstract class BasicWebViewClient extends WebViewClient {
 
     private final String mRedirect;
     private final AuthenticationRequest mRequest;
-    private final String mQueryParam;
     private final Context mCallingContext;
 
 
     public BasicWebViewClient(final Context appContext, final String redirect,
-                              final String queryParam, final AuthenticationRequest request) {
+                              final AuthenticationRequest request) {
         mCallingContext = appContext;
         mRedirect = redirect;
         mRequest = request;
-        mQueryParam = queryParam;
     }
 
     public abstract void showSpinner(boolean status);
@@ -196,12 +194,6 @@ abstract class BasicWebViewClient extends WebViewClient {
                             @Override
                             public void run() {
                                 String loadUrl = challengeResponse.getSubmitUrl();
-                                HashMap<String, String> parameters = StringExtensions
-                                        .getUrlParameters(challengeResponse.getSubmitUrl());
-                                if (!parameters
-                                        .containsKey(AuthenticationConstants.OAuth2.CLIENT_ID)) {
-                                    loadUrl = loadUrl + "?" + mQueryParam;
-                                }
                                 Logger.v(TAG, "Respond to pkeyAuth challenge", "Challenge submit url:" 
                                         + challengeResponse.getSubmitUrl(), null);
                                 view.loadUrl(loadUrl, headers);


### PR DESCRIPTION
Issue #741: ADFS 2016 returns the full url for pkeyauth challenge. When ADAL receives the challenge and responds to it, it tries to add all the query string sent in the original authorize request back to the submit url, which adds an extra "?". Server explicitly sends back the submit uri, there is no need for us to append query parameter. 