### PR TITLE
Adding *.pom to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ integration_tests.properties
 *.ipr
 *.iws
 .idea/
+*.pom


### PR DESCRIPTION
@weijjia I took the liberty of adding `*.pom` to `./gitignore` to support the general case instead of adding it to `./adal/.gitignore`. If you'd prefer to do this one way or another, feel free to let me know 😄 