### PR TITLE
Restrict changes to additive, set tests to use old flow

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
@@ -66,7 +66,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL testingURL = new URL("https://login.somewhere.com/path");
         try {
-            discovery.validateAuthority(testingURL, null);
+            discovery.validateAuthority(testingURL);
         } catch (final AuthenticationException e) {
             fail("non-expected exception. ");
         } finally {
@@ -84,21 +84,21 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL endpointFull = new URL("https://login.windows.net/common/oauth2/authorize");
         try {
-            discovery.validateAuthority(endpointFull, null);
+            discovery.validateAuthority(endpointFull);
         } catch (final AuthenticationException e) {
             fail("unexpected exception. ");
         }
 
         final URL endpointInstanceRight = new URL("https://login.windows.net/something/something");
         try {
-            discovery.validateAuthority(endpointInstanceRight, null);
+            discovery.validateAuthority(endpointInstanceRight);
         } catch (final AuthenticationException e) {
             fail("unexpected exception.");
         }
 
         final URL endpointInstanceOnly = new URL("https://login.windows.net");
         try {
-            discovery.validateAuthority(endpointInstanceOnly, null);
+            discovery.validateAuthority(endpointInstanceOnly);
         } catch (final AuthenticationException e) {
             assertNotNull(e);
             assertTrue(e.getCode() == ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE);
@@ -119,7 +119,7 @@ public class DiscoveryTests extends AndroidTestHelper {
                 HttpURLConnection.HTTP_BAD_REQUEST);
 
         try {
-            discovery.validateAuthority(endpointFull, null);
+            discovery.validateAuthority(endpointFull);
             fail();
         } catch (AuthenticationException e) {
             assertNotNull(e);
@@ -140,7 +140,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL endpointFull = new URL("https://login.invalidlogin.net/common/oauth2/authorize");
         try {
-            discovery.validateAuthority(endpointFull, null);
+            discovery.validateAuthority(endpointFull);
             fail();
         } catch (final AuthenticationException e) {
             assertNotNull(e);
@@ -155,7 +155,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL endpointFull = new URL("http://login.windows.net/common");
         try {
-            discovery.validateAuthority(endpointFull, null);
+            discovery.validateAuthority(endpointFull);
             fail();
         } catch (final AuthenticationException e) {
             assertNotNull(e);
@@ -165,7 +165,7 @@ public class DiscoveryTests extends AndroidTestHelper {
         final URL endpointWithQueryParams = new URL(
                 "https://login.windows.net/common?resource=2343&client_id=234");
         try {
-            discovery.validateAuthority(endpointWithQueryParams, null);
+            discovery.validateAuthority(endpointWithQueryParams);
             fail();
         } catch (final AuthenticationException e) {
             assertNotNull(e);
@@ -175,7 +175,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL endpointWithFragment = new URL("https://login.windows.net/common#token=23434");
         try {
-            discovery.validateAuthority(endpointWithFragment, null);
+            discovery.validateAuthority(endpointWithFragment);
             fail();
         } catch (final AuthenticationException e) {
             assertNotNull(e);
@@ -184,7 +184,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL adfsEndpoint = new URL("https://fs.ade2eadfs30.com/adfs");
         try {
-            discovery.validateAuthority(adfsEndpoint, null);
+            discovery.validateAuthority(adfsEndpoint);
         } catch (final AuthenticationException e) {
             assertNotNull(e);
             assertTrue(e.getCode() == ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE);
@@ -192,7 +192,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL endpointWithInvalidPath = new URL("https://login.windows.net/common/test/test");
         try {
-            discovery.validateAuthority(endpointWithInvalidPath, null);
+            discovery.validateAuthority(endpointWithInvalidPath);
         } catch (final AuthenticationException e) {
             fail();
         }
@@ -215,7 +215,7 @@ public class DiscoveryTests extends AndroidTestHelper {
         Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         try {
-            discovery.validateAuthority(endpointFull, null);
+            discovery.validateAuthority(endpointFull);
         } catch (final AuthenticationException e) {
             fail();
         } finally {
@@ -226,7 +226,7 @@ public class DiscoveryTests extends AndroidTestHelper {
         // case sensitivity check
         final URL endpointCaseDifferent = new URL("https://logiN.Windows-PPE.Net/Common");
         try {
-            discovery.validateAuthority(endpointCaseDifferent, null);
+            discovery.validateAuthority(endpointCaseDifferent);
         } catch (final AuthenticationException e) {
             fail();
         }
@@ -241,10 +241,10 @@ public class DiscoveryTests extends AndroidTestHelper {
 
         final URL endpointTest = new URL("https://login.test-direct-add.net/common");
         try {
-            discovery.validateAuthority(endpointTest, null);
+            discovery.validateAuthority(endpointTest);
 
             HttpUrlConnectionFactory.setMockedHttpUrlConnection(null);
-            discovery.validateAuthority(endpointTest, null);
+            discovery.validateAuthority(endpointTest);
         } catch (final AuthenticationException e) {
             fail();
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -216,13 +216,13 @@ class AcquireTokenRequest {
 
     /**
      * 1. For Silent flow, we should always try to look local cache first.
-     * i> If valid AT is returned from cache, use it.
-     * ii> If no valid AT is returned, but RT is returned, use the RT.
-     * iii> If RT request fails, and if we can talk to broker, go to broker and check if there is a valid token.
+     *    i> If valid AT is returned from cache, use it.
+     *    ii> If no valid AT is returned, but RT is returned, use the RT.
+     *    iii> If RT request fails, and if we can talk to broker, go to broker and check if there is a valid token.
      * 2. For Non-Silent flow.
-     * i> Do silent cache lookup first, same as 1.
-     * a) If we can talk to broker, go to broker for auth.
-     * b) If not, launch webview with embedded flow.
+     *    i> Do silent cache lookup first, same as 1.
+     *       a) If we can talk to broker, go to broker for auth.
+     *       b) If not, launch webview with embedded flow.
      * If silent request succeeds, we'll return the token back via callback.
      * If silent request fails and no prompt is allowed, we'll return the exception back via callback.
      * If silent request fails and prompt is allowed, we'll prompt the user and launch webview.

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -185,21 +185,44 @@ class AcquireTokenRequest {
 
         Logger.v(TAG, "Start validating authority");
         mDiscovery.setCorrelationId(mAuthContext.getRequestCorrelationId());
-        mDiscovery.validateAuthority(authorityUrl, domain);
+
+        verifyAuthorityValidInstance(authorityUrl);
+
+        if (UrlExtensions.isADFSAuthority(authorityUrl)) {
+            if (StringExtensions.isNullOrBlank(domain)) {
+                throw new IllegalArgumentException("Cannot validate AD FS Authority with domain [null]");
+            }
+            mDiscovery.validateAuthorityADFS(authorityUrl, domain);
+        } else {
+            mDiscovery.validateAuthority(authorityUrl);
+        }
 
         Logger.v(TAG, "The passe in authority is valid.");
         mAuthContext.setIsAuthorityValidated(true);
     }
 
+    private void verifyAuthorityValidInstance(URL authorizationEndpoint) throws AuthenticationException {
+        // For comparison purposes, convert to lowercase Locale.US
+        // getProtocol returns scheme and it is available if it is absolute url
+        // Authority is in the form of https://Instance/tenant/somepath
+        if (authorizationEndpoint == null || StringExtensions.isNullOrBlank(authorizationEndpoint.getHost())
+                || !authorizationEndpoint.getProtocol().equals("https")
+                || !StringExtensions.isNullOrBlank(authorizationEndpoint.getQuery())
+                || !StringExtensions.isNullOrBlank(authorizationEndpoint.getRef())
+                || StringExtensions.isNullOrBlank(authorizationEndpoint.getPath())) {
+            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE);
+        }
+    }
+
     /**
      * 1. For Silent flow, we should always try to look local cache first.
-     *    i> If valid AT is returned from cache, use it.
-     *    ii> If no valid AT is returned, but RT is returned, use the RT.
-     *    iii> If RT request fails, and if we can talk to broker, go to broker and check if there is a valid token.
+     * i> If valid AT is returned from cache, use it.
+     * ii> If no valid AT is returned, but RT is returned, use the RT.
+     * iii> If RT request fails, and if we can talk to broker, go to broker and check if there is a valid token.
      * 2. For Non-Silent flow.
-     *    i> Do silent cache lookup first, same as 1.
-     *       a) If we can talk to broker, go to broker for auth.
-     *       b) If not, launch webview with embedded flow.
+     * i> Do silent cache lookup first, same as 1.
+     * a) If we can talk to broker, go to broker for auth.
+     * b) If not, launch webview with embedded flow.
      * If silent request succeeds, we'll return the token back via callback.
      * If silent request fails and no prompt is allowed, we'll return the exception back via callback.
      * If silent request fails and prompt is allowed, we'll prompt the user and launch webview.
@@ -272,7 +295,7 @@ class AcquireTokenRequest {
 
 
     private boolean shouldTrySilentFlow(final AuthenticationRequest authenticationRequest) {
-       return authenticationRequest.getPrompt() == PromptBehavior.Auto || authenticationRequest.isSilent();
+        return authenticationRequest.getPrompt() == PromptBehavior.Auto || authenticationRequest.isSilent();
     }
 
     /**
@@ -429,7 +452,7 @@ class AcquireTokenRequest {
                     = new AcquireTokenInteractiveRequest(mContext, authenticationRequest, mTokenCacheAccessor);
             acquireTokenInteractiveRequest.acquireToken(activity,
                     useDialog ? new AuthenticationDialog(getHandler(), mContext, this, authenticationRequest)
-                    : null);
+                            : null);
         }
     }
 
@@ -505,7 +528,7 @@ class AcquireTokenRequest {
      * Activity class. This method is called at UI thread.
      *
      * @param resultCode Result code set from the activity.
-     * @param data {@link Intent}
+     * @param data       {@link Intent}
      */
     void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         final String methodName = ":onActivityResult";
@@ -564,8 +587,8 @@ class AcquireTokenRequest {
                             "User cancelled the flow RequestId:" + requestId + correlationInfo));
                 } else if (resultCode == AuthenticationConstants.UIResponse.BROKER_REQUEST_RESUME) {
                     Logger.v(TAG + methodName, "Device needs to have broker installed, waiting the broker "
-                        + "installation. Once broker is installed, request will be resumed and result "
-                        + "will be received");
+                            + "installation. Once broker is installed, request will be resumed and result "
+                            + "will be received");
 
                     //Register the broker resume result receiver with intent filter as broker_request_resume and
                     // specific app package name
@@ -765,7 +788,8 @@ class AcquireTokenRequest {
      * Responsible for receiving message from broker indicating the broker has completed the token acquisition.
      */
     protected class BrokerResumeResultReceiver extends BroadcastReceiver {
-        public BrokerResumeResultReceiver() { }
+        public BrokerResumeResultReceiver() {
+        }
 
         private boolean mReceivedResultFromBroker = false;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -86,26 +86,13 @@ final class Discovery {
         mWebrequestHandler = new WebRequestHandler();
     }
 
-    public void validateAuthority(final URL authorizationEndpoint, final String domain) throws AuthenticationException {
-        // For comparison purposes, convert to lowercase Locale.US
-        // getProtocol returns scheme and it is available if it is absolute url
-        // Authority is in the form of https://Instance/tenant/somepath
-        if (authorizationEndpoint == null || StringExtensions.isNullOrBlank(authorizationEndpoint.getHost())
-                || !authorizationEndpoint.getProtocol().equals("https")
-                || !StringExtensions.isNullOrBlank(authorizationEndpoint.getQuery())
-                || !StringExtensions.isNullOrBlank(authorizationEndpoint.getRef())
-                || StringExtensions.isNullOrBlank(authorizationEndpoint.getPath())) {
-            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE);
-        }
+    public void validateAuthorityADFS(final URL authorizationEndpoint, final String domain)
+            throws AuthenticationException {
+        validateADFS(authorizationEndpoint, domain);
+        validateAuthority(authorizationEndpoint);
+    }
 
-        if (UrlExtensions.isADFSAuthority(authorizationEndpoint)) {
-            if (StringExtensions.isNullOrBlank(domain)) {
-                throw new IllegalArgumentException("Cannot validate AD FS Authority with domain [null]");
-            }
-
-            validateADFS(authorizationEndpoint, domain);
-        }
-
+    public void validateAuthority(final URL authorizationEndpoint) throws AuthenticationException {
         if (!VALID_HOSTS.contains(authorizationEndpoint.getHost().toLowerCase(Locale.US))) {
             // host can be the instance or inside the validated list.
             // Valid hosts will help to skip validation if validated before
@@ -115,7 +102,8 @@ final class Discovery {
         }
     }
 
-    private void validateADFS(URL authorizationEndpoint, String domain) throws AuthenticationException {
+    private void validateADFS(URL authorizationEndpoint, String domain)
+            throws AuthenticationException {
         final DrsMetadata drsMetadata = new DrsMetadataRequestor().requestDrsDiscovery(domain);
         new AdfsWebFingerValidator().validateAuthority(authorizationEndpoint, drsMetadata);
     }


### PR DESCRIPTION
This PR restricts the changes of AD FS validation to be purely additive. It sets tests to use the original, not AD FS validation flow.