### PR TITLE
Return DEVICE_CONNECTION_IS_NOT_AVAILABLE  error when no network and uses Broker flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ The ADAL SDK for Android gives you the ability to add support for Work Accounts 
 
 A Work Account is an identity you use to get work done no matter if at your business or on a college campus. Anywhere you need to get access to your work life you'll use a Work Account. The Work Account can be tied to an Active Directory server running in your datacenter or live completely in the cloud like when you use Office365. A Work Account will be how your users know that they are accessing their important documents and data backed my Microsoft security.
 
-## ADAL for Android 1.11 Released!
+## ADAL for Android 1.12 Released!
 
 ## Versions
-Current version - 1.11.0
+Current version - 1.12.0
 Minimum recommended version - 1.1.16  
 You can find the changes for each version in the [change log](https://github.com/AzureAD/azure-activedirectory-library-for-android/blob/master/changelog.txt).
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -25,7 +25,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 23
         versionCode 1
-        versionName "1.11.0"
+        versionName "1.12.0"
         project.archivesBaseName = "adal"
         project.version = android.defaultConfig.versionName
     }

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -39,6 +39,7 @@ android {
     sourceSets {
         main {
             manifest.srcFile 'src/main/AndroidManifest.xml'
+            java.srcDirs = ['src/main/java', 'src/main/aidl']
         }
     }
 
@@ -126,6 +127,7 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
+    exclude {'*.aidl'}
     classpath = configurations.compile
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -1,0 +1,309 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import android.accounts.AccountManager;
+import android.accounts.AuthenticatorDescription;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.content.pm.Signature;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.test.ServiceTestCase;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Base64;
+
+import junit.framework.Assert;
+
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Test cases for brokerAccountService and related operations in {@link BrokerProxy}.
+ */
+public final class BrokerAccountServiceTest extends ServiceTestCase<MockBrokerAccountService> {
+    private static ExecutorService sThreadExecutor = Executors.newSingleThreadExecutor();
+    private static final String VALID_AUTHORITY = "https://login.microsoftonline.com";
+
+    private IBinder mIBinder;
+    public BrokerAccountServiceTest() {
+        super(MockBrokerAccountService.class);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        getContext().getCacheDir();
+        System.setProperty("dexmaker.dexcache", getContext().getCacheDir().getPath());
+
+        mIBinder = bindService(new Intent(mContext, MockBrokerAccountService.class));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        AuthenticationSettings.INSTANCE.setBrokerSignature(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE);
+        AuthenticationSettings.INSTANCE.setUseBroker(false);
+    }
+
+    @SmallTest
+    public void testGetBrokerUsers() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        sThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final Context context = getMockContext();
+                try {
+                    final UserInfo[] userInfos = BrokerAccountServiceHandler.getInstance().getBrokerUsers(context);
+                    Assert.assertTrue(userInfos.length == 1);
+
+                    final UserInfo userInfo = userInfos[0];
+                    Assert.assertTrue(userInfo.getDisplayableId().equals(MockBrokerAccountService.DISPLAYABLE));
+                    Assert.assertTrue(userInfo.getUserId().equals(MockBrokerAccountService.UNIQUE_ID));
+                    Assert.assertTrue(userInfo.getFamilyName().equals(MockBrokerAccountService.FAMILY_NAME));
+                    Assert.assertTrue(userInfo.getGivenName().equals(MockBrokerAccountService.GIVEN_NAME));
+                    Assert.assertTrue(userInfo.getIdentityProvider().equals(MockBrokerAccountService.IDENTITY_PROVIDER));
+                } catch (final IOException e) {
+                    fail();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        latch.await();
+    }
+
+    @SmallTest
+    public void testBrokerProxyGetUsers() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        sThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final Context context = getMockContext();
+                final BrokerProxy brokerProxy = new BrokerProxy(context);
+                try {
+                    final UserInfo[] userInfos = brokerProxy.getBrokerUsers();
+                    Assert.assertTrue(userInfos.length == 1);
+
+                    final UserInfo userInfo = userInfos[0];
+                    Assert.assertTrue(userInfo.getDisplayableId().equals(MockBrokerAccountService.DISPLAYABLE));
+                    Assert.assertTrue(userInfo.getUserId().equals(MockBrokerAccountService.UNIQUE_ID));
+                    Assert.assertTrue(userInfo.getFamilyName().equals(MockBrokerAccountService.FAMILY_NAME));
+                    Assert.assertTrue(userInfo.getGivenName().equals(MockBrokerAccountService.GIVEN_NAME));
+                    Assert.assertTrue(userInfo.getIdentityProvider().equals(MockBrokerAccountService.IDENTITY_PROVIDER));
+                } catch (final IOException | OperationCanceledException | AuthenticatorException e) {
+                    fail();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+
+        latch.await();
+    }
+
+    @SmallTest
+    public void testGetAuthToken() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        sThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final Context context = getMockContext();
+                try {
+                    final Bundle bundle = BrokerAccountServiceHandler.getInstance().getAuthToken(context, new Bundle());
+                    Assert.assertTrue(bundle.getString(AccountManager.KEY_AUTHTOKEN).equals(MockBrokerAccountService.ACCESS_TOKEN));
+                } catch (final AuthenticationException e) {
+                    fail();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        latch.await();
+    }
+
+    @SmallTest
+    public void testBrokerProxyGetAuthToken() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        sThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final Context context = getMockContext();
+                final BrokerProxy brokerProxy = new BrokerProxy(context);
+                try {
+                    final AuthenticationResult result = brokerProxy.getAuthTokenInBackground(
+                            AuthenticationContextTest.createAuthenticationRequest(VALID_AUTHORITY, "resource", "clientid", "redirect", "", false));
+                    Assert.assertTrue(result.getAccessToken().equals(MockBrokerAccountService.ACCESS_TOKEN));
+                } catch (final AuthenticationException e) {
+                    fail();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        latch.await();
+    }
+
+    /**
+     * Verify even if GET_ACCOUNTS permission is not granted, if BrokerAccountService exists,
+     * {@link BrokerProxy#canSwitchToBroker()} will return true.
+     */
+    @SmallTest
+    public void testBrokerProxySwitchBrokerPermissionNotGranted()
+            throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
+        final Context context = getMockContext();
+        final PackageManager mockedPackageManager = context.getPackageManager();
+
+        final SignatureData signatureData = getSignature(mContext, getContext().getPackageName());
+        mockPackageManagerBrokerSignatureAndPermission(mockedPackageManager, signatureData.getSignature());
+
+        AuthenticationSettings.INSTANCE.setBrokerSignature(signatureData.getSignatureHash());
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        Assert.assertTrue(brokerProxy.canSwitchToBroker().equals(BrokerProxy.SwitchToBroker.CAN_SWITCH_TO_BROKER));
+    }
+
+    /**
+     * Verify  if GET_ACCOUNTS permission is not granted and BrokerAccountService exists,
+     * {@link BrokerProxy#canSwitchToBroker()} will return false if there is no valid broker app exists.
+     */
+    @SmallTest
+    public void testBrokerProxySwitchToBrokerInvalidBrokerPackageName()
+            throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
+        final Context context = getMockContext();
+        final PackageManager mockedPackageManager = context.getPackageManager();
+
+        final SignatureData signatureData = getSignature(mContext, getContext().getPackageName());
+        mockPackageManagerBrokerSignatureAndPermission(mockedPackageManager, signatureData.getSignature());
+
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        Assert.assertFalse(brokerProxy.canSwitchToBroker().equals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER));
+    }
+
+    private Context getMockContext() {
+        final BrokerAccountServiceContext mockContext = new BrokerAccountServiceContext(getContext());
+
+        final PackageManager mockedPackageManager = Mockito.mock(PackageManager.class);
+        Mockito.when(mockedPackageManager.queryIntentServices(Mockito.any(Intent.class), Mockito.anyInt())).thenReturn(
+                Collections.singletonList(Mockito.mock(ResolveInfo.class)));
+        mockContext.setMockedPackageManager(mockedPackageManager);
+
+        final AccountManager mockedAccountManager = Mockito.mock(AccountManager.class);
+        final AuthenticatorDescription authenticatorDescription = new AuthenticatorDescription(
+                AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE, getContext().getPackageName(), 0, 0, 0, 0);
+        Mockito.when(mockedAccountManager.getAuthenticatorTypes()).thenReturn(new AuthenticatorDescription[] {authenticatorDescription});
+        mockContext.setMockedAccountManager(mockedAccountManager);
+        return mockContext;
+    }
+
+    private void mockPackageManagerBrokerSignatureAndPermission(final PackageManager packageManager, final Signature signature)
+            throws PackageManager.NameNotFoundException {
+        Mockito.when(packageManager.checkPermission(Mockito.contains("android.permission.GET_ACCOUNTS"),
+                Mockito.anyString())).thenReturn(PackageManager.PERMISSION_DENIED);
+
+        final PackageInfo packageInfo = Mockito.mock(PackageInfo.class);
+        packageInfo.signatures = new Signature[] {signature};
+        Mockito.when(packageManager.getPackageInfo(Mockito.anyString(), Mockito.anyInt())).thenReturn(packageInfo);
+
+        Mockito.when(packageManager.checkPermission(Mockito.contains("android.permission.GET_ACCOUNTS"),
+                Mockito.anyString())).thenReturn(PackageManager.PERMISSION_DENIED);
+    }
+
+    private SignatureData getSignature(final Context context, final String packageName)
+            throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
+        PackageInfo info = context.getPackageManager().getPackageInfo(packageName,
+                PackageManager.GET_SIGNATURES);
+
+        // Broker App can be signed with multiple certificates. It will look
+        // all of them
+        // until it finds the correct one for ADAL broker.
+        byte[] signatureByte;
+        String signatureTag;
+        for (final Signature signature : info.signatures) {
+            signatureByte = signature.toByteArray();
+            MessageDigest md = MessageDigest.getInstance("SHA");
+            md.update(signatureByte);
+            signatureTag = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
+            return new SignatureData(new Signature(signatureByte), signatureTag);
+        }
+
+        return null;
+    }
+
+    private static class SignatureData {
+        private Signature mSignature;
+        private String mSignatureHash;
+
+        SignatureData(final Signature signature, final String signatureHash) {
+            mSignature = signature;
+            mSignatureHash = signatureHash;
+        }
+
+        Signature getSignature() {
+            return mSignature;
+        }
+
+        String getSignatureHash() {
+            return mSignatureHash;
+        }
+    }
+
+    final class BrokerAccountServiceContext extends FileMockContext {
+        private final Context mContext;
+        BrokerAccountServiceContext(final Context context) {
+            super(context);
+            mContext = context;
+        }
+
+        @Override
+        public boolean bindService(Intent service, ServiceConnection conn, int flags) {
+            conn.onServiceConnected(new ComponentName(mContext.getPackageName(), "test"), mIBinder);
+            return true;
+        }
+
+        @Override
+        public void unbindService(ServiceConnection connection) {
+            return;
+        }
+    }
+}

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -31,13 +31,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
@@ -103,162 +102,184 @@ public class BrokerProxyTests extends AndroidTestCase {
             mTestTag = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
             break;
         }
+
+        mContext = new FileMockContext(getContext());
         AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
         AuthenticationSettings.INSTANCE
                 .setBrokerPackageName(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
         Log.d(TAG, "mTestSignature is set");
     }
 
-    public void testCanSwitchToBrokerInvalidPackage() throws ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException,
-            NoSuchFieldException, NameNotFoundException, NoSuchAlgorithmException {
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String brokerPackage = "wrong";
-        Signature signature = new Signature(mTestSignature);
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, "test", signature, true, null, true);
-
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "canSwitchToBroker");
-        BrokerProxy.SwitchToBroker result = (BrokerProxy.SwitchToBroker) m.invoke(brokerProxy);
-
-        // assert
-        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, result);
+        AuthenticationSettings.INSTANCE.setUseBroker(false);
     }
 
-    public void testCanSwitchToBrokerInvalidAuthenticatorType()
-            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {
+    public void testCanSwitchToBrokerInvalidPackage() throws NameNotFoundException {
+        final String brokerPackage = "wrong";
+        final Signature signature = new Signature(mTestSignature);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(
+                signature, brokerPackage, false));
+        context.setMockedAccountManager(getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE, brokerPackage));
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = "invalid";
-        String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        Signature signature = new Signature(mTestSignature);
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, "test", signature, true, null, true);
-
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "canSwitchToBroker");
-        BrokerProxy.SwitchToBroker result = (BrokerProxy.SwitchToBroker) m.invoke(brokerProxy);
-
-        // assert
-        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, result);
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
     }
 
-    public void testCanSwitchToBrokerInvalidSignature()
-            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {
+    public void testCanSwitchToBrokerInvalidAuthenticatorType() throws NameNotFoundException {
+        final String authenticatorType = "invalid";
+        final String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+        final Signature signature = new Signature(mTestSignature);
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(
+                signature, brokerPackage, false));
+        context.setMockedAccountManager(getMockedAccountManager(authenticatorType, brokerPackage));
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+
+        // assert
+        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
+    }
+
+    public void testCanSwitchToBrokerInvalidSignature() throws NameNotFoundException {
         String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
         String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
         Signature signature = new Signature("74657374696e67");
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, "test", signature, true, null, true);
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "canSwitchToBroker");
-        BrokerProxy.SwitchToBroker result = (BrokerProxy.SwitchToBroker) m.invoke(brokerProxy);
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(
+                signature, brokerPackage, false));
+        context.setMockedAccountManager(getMockedAccountManager(authenticatorType, brokerPackage));
 
-        // assert
-        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, result);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
     }
 
-    public void testCanSwitchToBrokerValid()
-            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {
-
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
+    public void testCanSwitchToBrokerNoAccountChooserActivity() throws NameNotFoundException {
         String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
         String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        String contextPackage = "com.test";
         Signature signature = new Signature(mTestSignature);
-        AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
+
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType, brokerPackage);
+        final PackageManager mockedPackageManager = getMockedPackageManagerWithBrokerAccountServiceDisabled(signature, brokerPackage, true);
+        when(mockedPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.<ResolveInfo>emptyList());
+
+        final Account[] accts = getAccountList("valid", authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(mockedPackageManager);
+
         AuthenticationSettings.INSTANCE.setUseBroker(true);
-        Account[] accts = getAccountList("valid", authenticatorType);
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, contextPackage, signature, true, accts, true);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        assertEquals(BrokerProxy.SwitchToBroker.CAN_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
+    }
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "canSwitchToBroker");
-        BrokerProxy.SwitchToBroker result = (BrokerProxy.SwitchToBroker) m.invoke(brokerProxy);
+    public void testCanSwitchToBrokerWithAccountChooser() throws NameNotFoundException {
+        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+        Signature signature = new Signature(mTestSignature);
 
-        // assert
-        assertEquals(BrokerProxy.SwitchToBroker.CAN_SWITCH_TO_BROKER, result);
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType, brokerPackage);
+        final PackageManager mockedPackageManager = getMockedPackageManagerWithBrokerAccountServiceDisabled(signature, brokerPackage, true);
+        mockIntentActivityQuery(mockedPackageManager);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(mockedPackageManager);
+
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        assertEquals(BrokerProxy.SwitchToBroker.CAN_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
     }
 
     public void testCanSwitchToBrokerValidSkip()
             throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
             IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
         String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
         String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        String contextPackage = "com.test";
         Signature signature = new Signature(mTestSignature);
-        AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
-        Account[] accts = getAccountList("valid", authenticatorType);
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, contextPackage, signature, true, accts, false);
+
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType, brokerPackage);
+        final PackageManager mockedPackageManager = getMockedPackageManagerWithBrokerAccountServiceDisabled(signature, brokerPackage, true);
+        when(mockedPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(null);
+
+        final Account[] accts = getAccountList("valid", authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(mockedPackageManager);
+
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
         AuthenticationSettings.INSTANCE.setUseBroker(false);
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "canSwitchToBroker");
-        BrokerProxy.SwitchToBroker result = (BrokerProxy.SwitchToBroker) m.invoke(brokerProxy);
-
-        // assert
-        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, result);
+        assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
     }
 
-    public void testGetCurrentUser()
-            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        String contextPackage = "com.test";
-        Signature signature = new Signature(mTestSignature);
+    public void testGetCurrentUser() throws NameNotFoundException {
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
         AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
+
         Account[] accts = getAccountList("currentUserName", authenticatorType);
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, contextPackage, signature, true, accts, true);
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType, brokerPackage);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getCurrentUser");
-        String result = (String) m.invoke(brokerProxy);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final String result = brokerProxy.getCurrentUser();
 
         // assert
         assertEquals("Username is not equal", "currentUserName", result);
     }
 
-    public void testGetBrokerUsers() throws ClassNotFoundException, NoSuchMethodException,
-            InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchFieldException,
-            NameNotFoundException, OperationCanceledException, AuthenticatorException, IOException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        String contextPackage = "com.test";
-        Signature signature = new Signature(mTestSignature);
+    public void testGetBrokerUsers() throws NameNotFoundException, OperationCanceledException, AuthenticatorException,
+            IOException {
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+        final Signature signature = new Signature(mTestSignature);
         AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
+
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType, brokerPackage);
         Account[] accounts = getAccountList("currentUserName", authenticatorType);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        AccountManagerFuture<Bundle> mockResult = mock(AccountManagerFuture.class);
-        Bundle testBundle = new Bundle();
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accounts);
+
+        final AccountManagerFuture<Bundle> mockResult = mock(AccountManagerFuture.class);
+        final Bundle testBundle = new Bundle();
         testBundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID, "userid");
         testBundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME, "given_name");
         testBundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME, "family_name");
         testBundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER, "idp");
         testBundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE, "displayableid_upn");
         when(mockResult.getResult()).thenReturn(testBundle);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accounts);
 
-        Bundle bundle = new Bundle();
+        final Bundle bundle = new Bundle();
         bundle.putBoolean("com.microsoft.workaccount.user.info", true);
-        Context mockContext = getMockContext(signature, brokerPackage, contextPackage, true);
-        when(mockAcctManager.updateCredentials(eq(accounts[0]), eq(AuthenticationConstants.Broker.AUTHTOKEN_TYPE),
+        when(mockedAccountManager.updateCredentials(eq(accounts[0]), eq(AuthenticationConstants.Broker.AUTHTOKEN_TYPE),
                 any(Bundle.class), (Activity) eq(null), (AccountManagerCallback) eq(null), (Handler) eq(null)))
                         .thenReturn(mockResult);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getBrokerUsers");
-        UserInfo[] result = (UserInfo[]) m.invoke(brokerProxy);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final UserInfo[] result = brokerProxy.getBrokerUsers();
 
         // assert
         assertNotNull("It returns one user", result);
@@ -269,20 +290,24 @@ public class BrokerProxyTests extends AndroidTestCase {
             throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
             IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        String contextPackage = "com.test";
-        Signature signature = new Signature(mTestSignature);
-        prepareProxyForTest(brokerProxy, authenticatorType, brokerPackage, contextPackage, signature, false, null, true);
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+        final Signature signature = new Signature(mTestSignature);
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "canSwitchToBroker");
-        BrokerProxy.SwitchToBroker result = (BrokerProxy.SwitchToBroker) m.invoke(brokerProxy);
+        final FileMockContext context = new FileMockContext(getContext());
+        final PackageManager mockedPackageManager = getMockedPackageManagerWithBrokerAccountServiceDisabled(
+                signature, brokerPackage, false);
+        mockIntentActivityQuery(mockedPackageManager);
+        context.setMockedPackageManager(mockedPackageManager);
+
+        context.setMockedAccountManager(getMockedAccountManager(authenticatorType, brokerPackage));
+
+        AuthenticationSettings.INSTANCE.setUseBroker(true);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
 
         // assert
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            assertEquals(BrokerProxy.SwitchToBroker.NEED_PERMISSIONS_TO_SWITCH_TO_BROKER, result);
+            assertEquals(BrokerProxy.SwitchToBroker.NEED_PERMISSIONS_TO_SWITCH_TO_BROKER, brokerProxy.canSwitchToBroker());
         }
     }
 
@@ -314,25 +339,22 @@ public class BrokerProxyTests extends AndroidTestCase {
         assertEquals(BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER, result);
     }
 
-    public void testGetAuthTokenInBackgroundEmptyAccts()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, NoSuchFieldException {
-
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+    public void testGetAuthTokenInBackgroundEmptyAccts() throws NameNotFoundException {
+        final AuthenticationRequest request = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", "loginhint", PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(new Account[0]);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        final AccountManager mockedAccountManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(new Account[0]);
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
         try {
-            m.invoke(brokerProxy, authRequest);
+            brokerProxy.getAuthTokenInBackground(request);
         } catch (Exception ex) {
             assertTrue("Exception type check", ex.getCause() instanceof AuthenticationException);
             assertEquals("Check error code", ADALError.BROKER_AUTHENTICATOR_BAD_ARGUMENTS,
@@ -341,106 +363,108 @@ public class BrokerProxyTests extends AndroidTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testGetAuthTokenInBackgroundValidAccountEmptyBundle()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, OperationCanceledException, AuthenticatorException,
-            IOException, NoSuchFieldException {
+    public void testGetAuthTokenInBackgroundValidAccountEmptyBundle() throws NameNotFoundException, OperationCanceledException,
+            AuthenticatorException, IOException, AuthenticationException {
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", "loginhint", PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        String acctType = "loginhint";
-        Account[] accts = getAccountList(acctType, authenticatorType);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        Bundle expected = new Bundle();
+        final String acctType = "loginhint";
+
+
+        final FileMockContext context = new FileMockContext(getContext());
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+
+        final Account[] accts = getAccountList(acctType, authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final Bundle expected = new Bundle();
         AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
-        when(mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+        when(mockedAccountManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
                 (AccountManagerCallback<Bundle>) eq(null), any(Handler.class))).thenReturn(mockFuture);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        updateContextToSaveAccount(mockContext, "", "test");
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-        AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
+
+        updateContextToSaveAccount("", "test");
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final AuthenticationResult result = brokerProxy.getAuthTokenInBackground(authRequest);
 
         // assert
         assertNull("token should return null", result.getAccessToken());
     }
 
     @SuppressWarnings("unchecked")
-    public void testGetAuthTokenInBackgroundPositive() throws IllegalAccessException,
-            InvocationTargetException, ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            OperationCanceledException, IOException, NoSuchFieldException, AuthenticatorException {
-
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String acctName = "LoginHint234FDFs";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+    public void testGetAuthTokenInBackgroundPositive() throws NameNotFoundException, OperationCanceledException,
+            AuthenticatorException, IOException, AuthenticationException {
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String acctName = "LoginHint234FDFs";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", acctName.toLowerCase(), PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        // check case sensitivity for account name
-        Account[] accts = getAccountList(acctName, authenticatorType);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        Bundle expected = new Bundle();
+
+        final FileMockContext context = new FileMockContext(getContext());
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+
+        final Account[] accts = getAccountList(acctName, authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final Bundle expected = new Bundle();
         expected.putString(AccountManager.KEY_AUTHTOKEN, "token123");
         AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
-        when(mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
+        when(mockedAccountManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
                 (AccountManagerCallback<Bundle>) eq(null), any(Handler.class))).thenReturn(mockFuture);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        updateContextToSaveAccount(mockContext, "", acctName);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-        AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // assert
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final AuthenticationResult result = brokerProxy.getAuthTokenInBackground(authRequest);
         assertEquals("token is expected", "token123", result.getAccessToken());
     }
 
     @SuppressWarnings("unchecked")
-    public void testGetAuthTokenInBackgroundVerifyUserInfo() throws IllegalAccessException,
-            InvocationTargetException, ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            OperationCanceledException, IOException, NoSuchFieldException, AuthenticatorException {
+    public void testGetAuthTokenInBackgroundVerifyUserInfo() throws NameNotFoundException,
+            OperationCanceledException, IOException, AuthenticationException, AuthenticatorException {
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String acctName = "testAcct123";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
+
         // check case sensitivity for account name
-        Account[] accts = getAccountList(acctName, authenticatorType);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        Bundle expected = new Bundle();
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        final Account[] accounts = getAccountList(acctName, authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accounts);
+
+        final Bundle expected = new Bundle();
         expected.putString(AccountManager.KEY_AUTHTOKEN, "token123");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID, acctName);
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME, "givenName");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME, "familyName");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER, "idp");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE, acctName);
-        AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
+        final AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
-        when(mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
+        when(mockedAccountManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
                 (AccountManagerCallback<Bundle>) eq(null), any(Handler.class))).thenReturn(mockFuture);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        updateContextToSaveAccount(mockContext, "", acctName);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
 
-        // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-        AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
+        updateContextToSaveAccount("", acctName);
+
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final AuthenticationResult result = brokerProxy.getAuthTokenInBackground(authRequest);
 
         // assert
         assertNotNull("userinfo is expected", result.getUserInfo());
@@ -452,19 +476,21 @@ public class BrokerProxyTests extends AndroidTestCase {
     }
 
     public void testGetAuthTokenInBackgroundVerifyAuthenticationResult()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, OperationCanceledException,
-            IOException, NoSuchFieldException, AuthenticatorException {
+            throws NameNotFoundException, OperationCanceledException,
+            IOException, NoSuchFieldException, AuthenticatorException, AuthenticationException {
         final int tokenExpiresDate = 1000;
 
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String acctName = "testAcct123";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/authtest", "resource", "client",
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/authtest", "resource", "client",
                 "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
 
-        Account[] accts = getAccountList(acctName, authenticatorType);
-        Bundle expected = new Bundle();
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        final Account[] accts = getAccountList(acctName, authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final Bundle expected = new Bundle();
         expected.putString(AccountManager.KEY_AUTHTOKEN, "token123");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID, "testTenant");
         expected.putLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE, tokenExpiresDate);
@@ -474,21 +500,19 @@ public class BrokerProxyTests extends AndroidTestCase {
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER, "idp");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE, acctName);
 
-        AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
-        AccountManager mockAcctManager = mock(AccountManager.class);
+        final AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
-        when(mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
+        when(mockedAccountManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
                 (AccountManagerCallback<Bundle>) eq(null), any(Handler.class))).thenReturn(mockFuture);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        updateContextToSaveAccount(mockContext, "", acctName);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-        AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final AuthenticationResult result = brokerProxy.getAuthTokenInBackground(authRequest);
 
         // Make sure what returned from broker is consistent with what returned
         // from adal
@@ -502,18 +526,19 @@ public class BrokerProxyTests extends AndroidTestCase {
         assertEquals("displayable in userinfo is expected", acctName, result.getUserInfo().getDisplayableId());
     }
 
-    public void testGetAuthTokenInBackgroundVerifyAuthenticationResultNotReturnExpires()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, OperationCanceledException,
-            IOException, NoSuchFieldException, AuthenticatorException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        String acctName = "testAcct123";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/authtest", "resource", "client",
+    public void testGetAuthTokenInBackgroundVerifyAuthenticationResultNotReturnExpires() throws NameNotFoundException,
+            AuthenticationException, OperationCanceledException, IOException, NoSuchFieldException, AuthenticatorException {
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/authtest", "resource", "client",
                 "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
 
-        Account[] accts = getAccountList(acctName, authenticatorType);
-        Bundle expected = new Bundle();
+        final AccountManager mockedAccountManager = getMockedAccountManager(authenticatorType,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        final Account[] accts = getAccountList(acctName, authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final Bundle expected = new Bundle();
         expected.putString(AccountManager.KEY_AUTHTOKEN, "token123");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID, "testTenant");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID, acctName);
@@ -522,21 +547,20 @@ public class BrokerProxyTests extends AndroidTestCase {
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER, "idp");
         expected.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE, acctName);
 
-        AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
-        AccountManager mockAcctManager = mock(AccountManager.class);
+        final AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
-        when(mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
+        when(mockedAccountManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
                 (AccountManagerCallback<Bundle>) eq(null), any(Handler.class))).thenReturn(mockFuture);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        updateContextToSaveAccount(mockContext, "", acctName);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
+
+        updateContextToSaveAccount("", acctName);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-        AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final AuthenticationResult result = brokerProxy.getAuthTokenInBackground(authRequest);
 
         final Calendar expires = new GregorianCalendar();
         expires.add(Calendar.SECOND, AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC);
@@ -553,132 +577,146 @@ public class BrokerProxyTests extends AndroidTestCase {
         assertEquals("displayable in userinfo is expected", acctName, result.getUserInfo().getDisplayableId());
     }
 
-    private void setMockProxyForErrorCheck(Object brokerProxy, String acctName, int errCode, String msg)
-            throws NoSuchFieldException, IllegalAccessException, OperationCanceledException,
+    private void setMockProxyForErrorCheck(final AccountManager mockedAccountManager, String acctName, int errCode, String msg)
+            throws OperationCanceledException,
             IOException, AuthenticatorException {
-        String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-        Account[] accts = getAccountList(acctName, authenticatorType);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        Bundle expected = new Bundle();
+        final String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+        final Account[] accts = getAccountList(acctName, authenticatorType);
+        when(mockedAccountManager.getAccountsByType(anyString())).thenReturn(accts);
+
+        final Bundle expected = new Bundle();
         expected.putInt(AccountManager.KEY_ERROR_CODE, errCode);
         expected.putString(AccountManager.KEY_ERROR_MESSAGE, msg);
-        AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
+        final AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
-        when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accts);
-        when(mockAcctManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
+        when(mockedAccountManager.getAuthToken(any(Account.class), anyString(), any(Bundle.class), eq(false),
                 (AccountManagerCallback<Bundle>) eq(null), any(Handler.class))).thenReturn(mockFuture);
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        updateContextToSaveAccount(mockContext, "", acctName);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
+        updateContextToSaveAccount("", acctName);
     }
 
-    public void testGetAuthTokenInBackgroundVerifyErrorMessageBadArgs()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, OperationCanceledException,
-            IOException, NoSuchFieldException, AuthenticatorException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String acctName = "testAcct123";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+    public void testGetAuthTokenInBackgroundVerifyErrorMessageBadArgs() throws NameNotFoundException, OperationCanceledException,
+            IOException, AuthenticatorException {
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        setMockProxyForErrorCheck(brokerProxy, acctName, AccountManager.ERROR_CODE_BAD_ARGUMENTS, "testErrorMessage");
+
+        final AccountManager mockedAccountManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        setMockProxyForErrorCheck(mockedAccountManager, acctName, AccountManager.ERROR_CODE_BAD_ARGUMENTS, "testErrorMessage");
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
         try {
-            Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-            AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+            final BrokerProxy brokerProxy = new BrokerProxy(context);
+            brokerProxy.getAuthTokenInBackground(authRequest);
             Assert.fail("should throw");
         } catch (Exception ex) {
-            assertTrue("Exception type check", ex.getCause() instanceof AuthenticationException);
+            assertTrue("Exception type check", ex instanceof AuthenticationException);
             assertEquals("check error code", ADALError.BROKER_AUTHENTICATOR_BAD_ARGUMENTS,
-                    ((AuthenticationException) ex.getCause()).getCode());
+                    ((AuthenticationException) ex).getCode());
         }
     }
 
     @SuppressLint("InlinedApi")
-    public void testGetAuthTokenInBackgroundVerifyErrorMessageBadAuth()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, OperationCanceledException,
-            IOException, NoSuchFieldException, AuthenticatorException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String acctName = "testAcct123";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
-                "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        setMockProxyForErrorCheck(brokerProxy, acctName, AccountManager.ERROR_CODE_BAD_AUTHENTICATION,
-                "testErrorMessage");
+    public void testGetAuthTokenInBackgroundVerifyErrorMessageBadAuth() throws OperationCanceledException,
+            IOException, NameNotFoundException, AuthenticatorException {
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest",
+                "resource", "client", "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
+
+        final AccountManager mockedAccountManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        setMockProxyForErrorCheck(mockedAccountManager, acctName, AccountManager.ERROR_CODE_BAD_AUTHENTICATION, "testErrorMessage");
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
         try {
-            Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-            AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+            final BrokerProxy brokerProxy = new BrokerProxy(context);
+            brokerProxy.getAuthTokenInBackground(authRequest);
             Assert.fail("should throw");
         } catch (Exception ex) {
-            assertTrue("Exception type check", ex.getCause() instanceof AuthenticationException);
+            assertTrue("Exception type check", ex instanceof AuthenticationException);
             assertEquals("check error code", ADALError.BROKER_AUTHENTICATOR_BAD_AUTHENTICATION,
-                    ((AuthenticationException) ex.getCause()).getCode());
+                    ((AuthenticationException) ex).getCode());
         }
     }
 
-    public void testGetAuthTokenInBackgroundVerifyErrorMessageNotSupported()
-            throws IllegalAccessException, InvocationTargetException, ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, OperationCanceledException,
-            IOException, NoSuchFieldException, AuthenticatorException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        String acctName = "testAcct123";
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+    public void testGetAuthTokenInBackgroundVerifyErrorMessageNotSupported() throws NameNotFoundException,
+            OperationCanceledException, IOException, AuthenticatorException {
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        setMockProxyForErrorCheck(brokerProxy, acctName, AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION,
-                "testErrorMessage");
+
+        final AccountManager mockedAccountManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        setMockProxyForErrorCheck(mockedAccountManager, acctName, AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION, "testErrorMessage");
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
         try {
-            Method m = ReflectionUtils.getTestMethod(brokerProxy, "getAuthTokenInBackground", authRequest.getClass());
-            AuthenticationResult result = (AuthenticationResult) m.invoke(brokerProxy, authRequest);
+            final BrokerProxy brokerProxy = new BrokerProxy(context);
+            brokerProxy.getAuthTokenInBackground(authRequest);
             Assert.fail("should throw");
         } catch (Exception ex) {
-            assertTrue("Exception type check", ex.getCause() instanceof AuthenticationException);
+            assertTrue("Exception type check", ex instanceof AuthenticationException);
             assertEquals("check error code", ADALError.BROKER_AUTHENTICATOR_UNSUPPORTED_OPERATION,
-                    ((AuthenticationException) ex.getCause()).getCode());
+                    ((AuthenticationException) ex).getCode());
         }
     }
 
-    public void testGetIntentForBrokerActivityEmptyIntent() throws ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException,
-            NoSuchFieldException, OperationCanceledException, IOException, AuthenticatorException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+    public void testGetIntentForBrokerActivityEmptyIntent() throws NameNotFoundException, OperationCanceledException,
+            IOException, AuthenticatorException {
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/test", "resource", "client",
                 "redirect", "loginhint", PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        AccountManager mockAcctManager = mock(AccountManager.class);
+        final AccountManager mockAcctManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
         Bundle expected = new Bundle();
-        prepareAddAccount(brokerProxy, mockAcctManager, expected);
+        prepareAddAccount(mockAcctManager, expected);
+
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockAcctManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getIntentForBrokerActivity", authRequest.getClass());
-        Intent intent = (Intent) m.invoke(brokerProxy, authRequest);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest);
 
         // assert
         assertNull("Intent is null", intent);
     }
 
-    public void testGetIntentForBrokerActivityHasIntent() throws ClassNotFoundException,
-            NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException,
-            NoSuchFieldException, OperationCanceledException, IOException, AuthenticatorException {
-        Object brokerProxy = ReflectionUtils.getInstance("com.microsoft.aad.adal.BrokerProxy");
-        Object authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+    public void testGetIntentForBrokerActivityHasIntent() throws NameNotFoundException, OperationCanceledException,
+            IOException, AuthenticatorException {
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", "loginhint", PromptBehavior.Auto, "", UUID.randomUUID(), false);
-        AccountManager mockAcctManager = mock(AccountManager.class);
-        Bundle expected = new Bundle();
-        Intent expectedIntent = new Intent();
+
+        final AccountManager mockAcctManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        final Bundle expected = new Bundle();
+        final Intent expectedIntent = new Intent();
         expectedIntent.putExtra(AuthenticationConstants.Broker.BROKER_REQUEST,
                 AuthenticationConstants.Broker.BROKER_REQUEST);
         expected.putParcelable(AccountManager.KEY_INTENT, expectedIntent);
+        prepareAddAccount(mockAcctManager, expected);
 
-        prepareAddAccount(brokerProxy, mockAcctManager, expected);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setMockedAccountManager(mockAcctManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
 
         // action
-        Method m = ReflectionUtils.getTestMethod(brokerProxy, "getIntentForBrokerActivity", authRequest.getClass());
-        Intent intent = (Intent) m.invoke(brokerProxy, authRequest);
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest);
 
         // assert
         assertNotNull("intent is not null", intent);
@@ -691,16 +729,19 @@ public class BrokerProxyTests extends AndroidTestCase {
      * reset as always. 
      */
     @SmallTest
-    public void testForcePromptFlagOldBroker() throws OperationCanceledException, IOException, AuthenticatorException {
+    public void testForcePromptFlagOldBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
         final Intent intent = new Intent();
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.FORCE_PROMPT);
         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT, authenticationRequest.getPrompt().name());
-        
-        // mock account manager
-        final AccountManager mockedAccoutManager = getMockedAccountManager(getMockedAccountManagerFuture(intent));
+
+        final AccountManager mockedAccoutManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        mockAddAccountResponse(mockedAccoutManager, getMockedAccountManagerFuture(intent));
         
         final FileMockContext mockedContext = new FileMockContext(getContext());
         mockedContext.setMockedAccountManager(mockedAccoutManager);
+        mockedContext.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
         final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest);
         assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
@@ -711,16 +752,22 @@ public class BrokerProxyTests extends AndroidTestCase {
      * as Force_Prompt. 
      */
     @SmallTest
-    public void testForcePromptNewBroker() throws OperationCanceledException, IOException, AuthenticatorException {
+    public void testForcePromptNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
         final Intent intent = new Intent();
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.FORCE_PROMPT);
         intent.putExtra(AuthenticationConstants.Broker.BROKER_VERSION, AuthenticationConstants.Broker.BROKER_PROTOCOL_VERSION);
         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT, authenticationRequest.getPrompt().name());
         
         // mock account manager
-        final AccountManager mockedAccoutManager = getMockedAccountManager(getMockedAccountManagerFuture(intent));
-        
-        final FileMockContext mockedContext = getMockedContext(mockedAccoutManager);
+        final AccountManager mockedAccoutManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        mockAddAccountResponse(mockedAccoutManager, getMockedAccountManagerFuture(intent));
+
+        final FileMockContext mockedContext = new FileMockContext(getContext());
+        mockedContext.setMockedAccountManager(mockedAccoutManager);
+        mockedContext.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
+
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
         final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest);
         assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.FORCE_PROMPT.name()));
@@ -731,18 +778,25 @@ public class BrokerProxyTests extends AndroidTestCase {
      * as always. 
      */
     @SmallTest
-    public void testPromptAlwaysNewBroker() throws OperationCanceledException, IOException, AuthenticatorException {
+    public void testPromptAlwaysNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
         final Intent intent = new Intent();
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.Always);
         intent.putExtra(AuthenticationConstants.Broker.BROKER_VERSION, AuthenticationConstants.Broker.BROKER_PROTOCOL_VERSION);
         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT, authenticationRequest.getPrompt().name());
         
         // mock account manager
-        final AccountManager mockedAccoutManager = getMockedAccountManager(getMockedAccountManagerFuture(intent));
-        
-        final FileMockContext mockedContext = getMockedContext(mockedAccoutManager);
+        final AccountManager mockedAccoutManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        mockAddAccountResponse(mockedAccoutManager, getMockedAccountManagerFuture(intent));
+
+        final FileMockContext mockedContext = new FileMockContext(getContext());
+        mockedContext.setMockedAccountManager(mockedAccoutManager);
+        mockedContext.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
+
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
         final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest);
+
         assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
     }
     
@@ -780,8 +834,16 @@ public class BrokerProxyTests extends AndroidTestCase {
         return mockedAccoutManager;
     }
 
+    private void mockAddAccountResponse(final AccountManager mockedAccountManager,
+                                        final AccountManagerFuture<Bundle> mockedAccountManagerFuture) {
+        Mockito.when(mockedAccountManager.addAccount(Matchers.anyString(), Mockito.anyString(), Matchers.any(String[].class),
+                Matchers.any(Bundle.class), Matchers.any(Activity.class), Matchers.any(AccountManagerCallback.class),
+                Mockito.any(Handler.class))).thenReturn(mockedAccountManagerFuture);
+
+    }
+
     @SuppressLint("CommitPrefEdits")
-    private void updateContextToSaveAccount(Context mockContext, String initialList, String savingAccount) {
+    private void updateContextToSaveAccount(String initialList, String savingAccount) {
         SharedPreferences mockPrefs = mock(SharedPreferences.class);
         when(mockPrefs.getString(anyString(), Mockito.eq(""))).thenReturn(initialList);
         Editor mockEditor = mock(Editor.class);
@@ -789,20 +851,15 @@ public class BrokerProxyTests extends AndroidTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private void prepareAddAccount(Object brokerProxy, AccountManager mockAcctManager, Bundle expected)
-            throws OperationCanceledException, IOException, NoSuchFieldException,
-            IllegalAccessException, AuthenticatorException {
-        AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
+    private void prepareAddAccount(final AccountManager mockAcctManager, final Bundle expected)
+            throws OperationCanceledException, IOException, AuthenticatorException {
+        final AccountManagerFuture<Bundle> mockFuture = mock(AccountManagerFuture.class);
         when(mockFuture.getResult()).thenReturn(expected);
         when(mockAcctManager.addAccount(anyString(), anyString(), (String[]) eq(null), any(Bundle.class),
                 (Activity) eq(null), (AccountManagerCallback<Bundle>) eq(null), any(Handler.class)))
                         .thenReturn(mockFuture);
         when(mockAcctManager.getAccountsByType(anyString()))
                 .thenReturn(getAccountList("test", AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE));
-        Context mockContext = mock(Context.class);
-        when(mockContext.getMainLooper()).thenReturn(null);
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
     }
 
     private Account[] getAccountList(String accountname, String authenticatorType) {
@@ -812,9 +869,7 @@ public class BrokerProxyTests extends AndroidTestCase {
         return accts;
     }
 
-    private void prepareProxyForTest(Object brokerProxy, String authenticatorType, String brokerPackage,
-            String contextPackage, Signature signature, boolean permissionStatus, Account[] accounts, boolean useBroker)
-                    throws NoSuchFieldException, IllegalAccessException, NameNotFoundException {
+    private AccountManager getMockedAccountManager(final String authenticatorType, final String brokerPackage) {
         final AccountManager mockAcctManager = Mockito.mock(AccountManager.class);
         final AuthenticatorDescription authenticatorDescription
                 = new AuthenticatorDescription(authenticatorType,
@@ -822,15 +877,10 @@ public class BrokerProxyTests extends AndroidTestCase {
         final AuthenticatorDescription mockedAuthenticator = Mockito.spy(authenticatorDescription);
         final AuthenticatorDescription[] mockedAuthenticatorTypes
                 = new AuthenticatorDescription[] {mockedAuthenticator};
-        Context mockContext = getMockContext(signature, brokerPackage, contextPackage, permissionStatus);
-        AuthenticationSettings.INSTANCE.setUseBroker(useBroker);
+
         Mockito.when(mockAcctManager.getAuthenticatorTypes()).thenReturn(mockedAuthenticatorTypes);
-        Mockito.when(mockAcctManager.getAccountsByType(anyString())).thenReturn(accounts);
 
-        ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
-        ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
-
-
+        return mockAcctManager;
     }
 
     private Context getMockContext(final Signature signature, final String brokerPackageName,
@@ -867,18 +917,27 @@ public class BrokerProxyTests extends AndroidTestCase {
         return items;
     }
 
-    private static Object createAuthenticationRequest(String authority, String resource, String client, String redirect,
-            String loginhint, PromptBehavior prompt, String extraQueryParams, UUID correlationId, boolean isExtendedLifetimeEnabled)
-                    throws ClassNotFoundException, NoSuchMethodException,
-                    InstantiationException, IllegalAccessException, InvocationTargetException {
-
-        Class<?> c = Class.forName("com.microsoft.aad.adal.AuthenticationRequest");
-
-        Constructor<?> constructor = c.getDeclaredConstructor(String.class, String.class, String.class, String.class,
-                String.class, PromptBehavior.class, String.class, UUID.class, boolean.class);
-        constructor.setAccessible(true);
-        Object o = constructor.newInstance(authority, resource, client, redirect, loginhint, prompt, extraQueryParams,
+    private static AuthenticationRequest createAuthenticationRequest(final String authority, final String resource, final String client,
+                                                                     final String redirect, final String loginHint, PromptBehavior prompt,
+                                                                     final String extraQueryParams, final UUID correlationId,
+                                                                     boolean isExtendedLifetimeEnabled) {
+        return new AuthenticationRequest(authority, resource, client, redirect, loginHint, prompt, extraQueryParams,
                 correlationId, isExtendedLifetimeEnabled);
-        return o;
+    }
+
+    private PackageManager getMockedPackageManagerWithBrokerAccountServiceDisabled(final Signature signature,
+                                                                                   final String brokerPackageName,
+                                                                                   boolean permission) throws NameNotFoundException {
+        final PackageManager mockedPackageManager = getPackageManager(signature, brokerPackageName, permission);
+        when(mockedPackageManager.queryIntentServices(Mockito.any(Intent.class), Mockito.anyInt())).thenReturn(null);
+
+        return mockedPackageManager;
+    }
+
+    private void mockIntentActivityQuery(final PackageManager mockedPackageManager) {
+        final List<ResolveInfo> activities = new ArrayList<>(1);
+        activities.add(Mockito.mock(ResolveInfo.class));
+        when(mockedPackageManager.queryIntentActivities(Mockito.any(Intent.class), Mockito.anyInt()))
+                .thenReturn(activities);
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockBrokerAccountService.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockBrokerAccountService.java
@@ -1,0 +1,94 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import android.accounts.AccountManager;
+import android.app.Service;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.RemoteException;
+
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+/**
+ * Mocked broker account service for testing purpose.
+ */
+public class MockBrokerAccountService extends Service {
+    public static final String DISPLAYABLE = "some displayable";
+    public static final String UNIQUE_ID = "some uniqueid";
+    public static final String FAMILY_NAME = "family name";
+    public static final String GIVEN_NAME = "given name";
+    public static final String IDENTITY_PROVIDER = "some idp";
+    public static final String ACCESS_TOKEN = "some access token";
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mBinder;
+
+    }
+
+    private final IBrokerAccountService.Stub mBinder = new IBrokerAccountService.Stub() {
+
+        @Override
+        public IBinder asBinder() {
+            return null;
+        }
+
+        @Override
+        public synchronized Bundle getBrokerUsers() throws RemoteException {
+            final Bundle bundle = new Bundle();
+            bundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID, UNIQUE_ID);
+            bundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE, DISPLAYABLE);
+            bundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME, FAMILY_NAME);
+            bundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME, GIVEN_NAME);
+            bundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER, IDENTITY_PROVIDER);
+
+            final Bundle resultBundle = new Bundle();
+            resultBundle.putBundle("test.name", bundle);
+
+            return resultBundle;
+        }
+
+        @Override
+        public synchronized Bundle acquireTokenSilently(Map requestParameters) throws RemoteException {
+            final Bundle bundle = new Bundle();
+            bundle.putString(AccountManager.KEY_AUTHTOKEN, ACCESS_TOKEN);
+
+            return bundle;
+        }
+
+        @Override
+        public Intent getIntentForInteractiveRequest() throws RemoteException {
+            return Mockito.mock(Intent.class);
+        }
+
+        @Override
+        public void removeAccounts() throws RemoteException {
+            return;
+        }
+    };
+}

--- a/adal/src/main/aidl/com/microsoft/aad/adal/IBrokerAccountService.aidl
+++ b/adal/src/main/aidl/com/microsoft/aad/adal/IBrokerAccountService.aidl
@@ -1,0 +1,17 @@
+package com.microsoft.aad.adal;
+
+/**
+ * Broker Account service APIs provided by the broker app. Those APIs will be responsible for interacting with the
+ * account manager API. Calling app does not need to request for contacts permission if the broker installed on the
+ * device has the support for the bound service.
+ */
+interface IBrokerAccountService {
+
+    Bundle getBrokerUsers();
+    
+    Bundle acquireTokenSilently(in Map requestParameters);
+    
+    Intent getIntentForInteractiveRequest();
+
+    void removeAccounts();
+}

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1047,7 +1047,7 @@ public class AuthenticationContext {
         // Package manager does not report for ADAL
         // AndroidManifest files are not merged, so it is returning hard coded
         // value
-        return "1.11.0";
+        return "1.12.0";
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -1,0 +1,363 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.RemoteException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Internal class to handle the interaction with BrokerAccountService declared in the broker itelf.
+ */
+final class BrokerAccountServiceHandler {
+    private static final String TAG = BrokerAccountServiceHandler.class.getSimpleName();
+    private static final String BROKER_ACCOUNT_SERVICE_INTENT_FILTER = "com.microsoft.workaccount.BrokerAccount";
+
+    private ConcurrentMap<BrokerAccountServiceConnection, CallbackExecutor<BrokerAccountServiceConnection>> mPendingConnections = new ConcurrentHashMap<>();
+    private static ExecutorService sThreadExecutor = Executors.newCachedThreadPool();
+
+    private static final class InstanceHolder {
+        static final BrokerAccountServiceHandler INSTANCE = new BrokerAccountServiceHandler();
+    }
+
+    public static BrokerAccountServiceHandler getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+    /**
+     * Private constructor to prevent class from being instantiate.
+     */
+    private BrokerAccountServiceHandler() { }
+
+    /**
+     * Get Broker users is a blocking call, cannot be executed on the main thread.
+     * @return An array of {@link UserInfo}s in the broker. If no user exists in the broker, empty array will be returned.
+     */
+    UserInfo[] getBrokerUsers(final Context context) throws IOException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AtomicReference<Bundle> userBundle = new AtomicReference<>(null);
+        final AtomicReference<Throwable> exception = new AtomicReference<>(null);
+
+        performAsyncCallOnBound(context, new Callback<BrokerAccountServiceConnection>() {
+            @Override
+            public void onSuccess(BrokerAccountServiceConnection connection) {
+                final IBrokerAccountService brokerAccountService = connection.getBrokerAccountServiceProvider();
+                try {
+                    userBundle.set(brokerAccountService.getBrokerUsers());
+                } catch (final RemoteException ex) {
+                    exception.set(ex);
+                }
+
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                exception.set(throwable);
+                countDownLatch.countDown();
+            }
+        });
+
+        try {
+            countDownLatch.await();
+        } catch (final InterruptedException e) {
+            exception.set(e);
+        }
+
+        final Throwable exceptionForRetrievingBrokerUsers = exception.getAndSet(null);
+        if (exceptionForRetrievingBrokerUsers != null) {
+            throw new IOException(exceptionForRetrievingBrokerUsers.getMessage(), exceptionForRetrievingBrokerUsers);
+        }
+
+        final Bundle userBundleResult = userBundle.getAndSet(null);
+        return convertUserInfoBundleToArray(userBundleResult);
+    }
+
+    /**
+     * Silently acquire the token from BrokerAccountService.
+     * @param context The application {@link Context}.
+     * @param requestBundle The request data for the silent request.
+     * @return The {@link Bundle} result from the BrokerAccountService.
+     * @throws {@link AuthenticationException} if failed to get token from the service.
+     */
+    public Bundle getAuthToken(final Context context, final Bundle requestBundle) throws AuthenticationException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AtomicReference<Bundle> bundleResult = new AtomicReference<>(null);
+        final AtomicReference<Throwable> exception = new AtomicReference<>(null);
+
+        bindToBrokerAccountService(context, new Callback<BrokerAccountServiceConnection>() {
+            @Override
+            public void onSuccess(BrokerAccountServiceConnection result) {
+                final IBrokerAccountService brokerAccountService = result.getBrokerAccountServiceProvider();
+                try {
+                    bundleResult.set(brokerAccountService.acquireTokenSilently(prepareGetAuthTokenRequestData(context, requestBundle)));
+                } catch (final RemoteException remoteException) {
+                    exception.set(remoteException);
+                }
+
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                exception.set(throwable);
+                countDownLatch.countDown();
+            }
+        });
+
+        try {
+            countDownLatch.await();
+        } catch (final InterruptedException e) {
+            exception.set(e);
+        }
+
+        final Throwable throwable = exception.getAndSet(null);
+        if (throwable != null) {
+            throw new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, throwable.getMessage(), throwable);
+        }
+
+        return bundleResult.getAndSet(null);
+    }
+
+    /**
+     * Get the intent for launching the interactive request with broker.
+     * @param context The application {@link Context}.
+     * @return The {@link Intent} to launch the interactive request.
+     */
+    public Intent getIntentForInteractiveRequest(final Context context) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AtomicReference<Intent> bundleResult = new AtomicReference<>(null);
+        final AtomicReference<Throwable> exception = new AtomicReference<>(null);
+
+        bindToBrokerAccountService(context, new Callback<BrokerAccountServiceConnection>() {
+            @Override
+            public void onSuccess(BrokerAccountServiceConnection result) {
+                final IBrokerAccountService brokerAccountService = result.getBrokerAccountServiceProvider();
+                try {
+                    bundleResult.set(brokerAccountService.getIntentForInteractiveRequest());
+                } catch (final RemoteException remoteException) {
+                    exception.set(remoteException);
+                }
+
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                exception.set(throwable);
+                countDownLatch.countDown();
+            }
+        });
+
+        try {
+            countDownLatch.await();
+        } catch (final InterruptedException e) {
+            exception.set(e);
+        }
+
+        final Throwable throwable = exception.getAndSet(null);
+        if (throwable != null) {
+            Logger.e(TAG, "Didn't receive the activity to launch from broker: " + throwable.getMessage(), "", null, throwable);
+        }
+
+        return bundleResult.getAndSet(null);
+    }
+
+    /**
+     * Removing all the accounts from broker.
+     * @param context The application {@link Context}.
+     */
+    public void removeAccounts(final Context context) {
+        bindToBrokerAccountService(context, new Callback<BrokerAccountServiceConnection>() {
+            @Override
+            public void onSuccess(BrokerAccountServiceConnection result) {
+                try {
+                    result.getBrokerAccountServiceProvider().removeAccounts();
+                } catch (final RemoteException remoteException) {
+                    Logger.e(TAG, "Encounter exception when removing accounts from broker",
+                            remoteException.getMessage(), null, remoteException);
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                Logger.e(TAG, "Encounter exception when removing accounts from broker",
+                        throwable.getMessage(), null, throwable);
+            }
+        });
+    }
+
+    public static Intent getIntentForBrokerAccountService(final Context context) {
+        final BrokerProxy brokerProxy = new BrokerProxy(context);
+        final String brokerAppName = brokerProxy.getCurrentActiveBrokerPackageName();
+        if (brokerAppName == null) {
+            Logger.v(TAG, "No recognized broker is installed on the device.");
+            return null;
+        }
+
+        final Intent brokerAccountServiceToBind = new Intent(BROKER_ACCOUNT_SERVICE_INTENT_FILTER);
+        brokerAccountServiceToBind.setPackage(brokerAppName);
+        brokerAccountServiceToBind.setClassName(brokerAppName, "com.microsoft.aad.adal.BrokerAccountService");
+
+        return brokerAccountServiceToBind;
+    }
+
+    private Map<String, String> prepareGetAuthTokenRequestData(final Context context, final Bundle requestBundle) {
+        final Set<String> requestBundleKeys = requestBundle.keySet();
+
+        final Map<String, String> requestData = new HashMap<>();
+        for (final String key : requestBundleKeys) {
+            if (key == AuthenticationConstants.Browser.REQUEST_ID) {
+                requestData.put(key, String.valueOf(requestBundle.getInt(key)));
+                continue;
+            }
+            requestData.put(key, requestBundle.getString(key));
+        }
+        requestData.put(AuthenticationConstants.Broker.CALLER_INFO_PACKAGE, context.getPackageName());
+
+        return requestData;
+    }
+
+    private UserInfo[] convertUserInfoBundleToArray(final Bundle usersBundle) {
+        if (usersBundle == null) {
+            Logger.v(TAG, "No user info returned from broker account service.");
+            return new UserInfo[] {};
+        }
+
+        final ArrayList<UserInfo> brokerUsers = new ArrayList<>();
+        final Set<String> users = usersBundle.keySet();
+        for (final String user : users) {
+            final Bundle userBundle = usersBundle.getBundle(user);
+            final String userId = userBundle.getString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID);
+            final String givenName = userBundle.getString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME);
+            final String familyName = userBundle.getString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME);
+            final String identityProvider = userBundle.getString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER);
+            final String displayableId = userBundle.getString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE);
+
+            brokerUsers.add(new UserInfo(userId, givenName, familyName, identityProvider, displayableId));
+        }
+
+        return brokerUsers.toArray(new UserInfo[brokerUsers.size()]);
+    }
+
+    private void performAsyncCallOnBound(final Context context, final Callback<BrokerAccountServiceConnection> callback) {
+        bindToBrokerAccountService(context, new Callback<BrokerAccountServiceConnection>() {
+            @Override
+            public void onSuccess(final BrokerAccountServiceConnection result) {
+                if (Looper.myLooper() != Looper.getMainLooper()) {
+                    callback.onSuccess(result);
+                    result.unBindService(context);
+                } else {
+                    sThreadExecutor.execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onSuccess(result);
+                            result.unBindService(context);
+                        }
+                    });
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                callback.onError(throwable);
+            }
+        });
+    }
+
+    private void bindToBrokerAccountService(final Context context, final Callback<BrokerAccountServiceConnection> callback) {
+        Logger.v(TAG, "Binding to BrokerAccountService for caller uid: " + android.os.Process.myUid());
+        final Intent brokerAccountServiceToBind = getIntentForBrokerAccountService(context);
+
+        final BrokerAccountServiceConnection connection = new BrokerAccountServiceConnection();
+        final CallbackExecutor<BrokerAccountServiceConnection> callbackExecutor = new CallbackExecutor<>(callback);
+        mPendingConnections.put(connection, callbackExecutor);
+        context.bindService(brokerAccountServiceToBind, connection, Context.BIND_AUTO_CREATE);
+    }
+
+    private class BrokerAccountServiceConnection implements android.content.ServiceConnection {
+        private IBrokerAccountService mBrokerAccountService;
+        private boolean mBound;
+
+        public IBrokerAccountService getBrokerAccountServiceProvider() {
+            return mBrokerAccountService;
+        }
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            Logger.v(TAG, "Broker Account service is connected.");
+            mBrokerAccountService = IBrokerAccountService.Stub.asInterface(service);
+            mBound = true;
+            final CallbackExecutor<BrokerAccountServiceConnection> callbackExecutor = mPendingConnections.remove(this);
+            if (callbackExecutor != null) {
+                callbackExecutor.onSuccess(this);
+            } else {
+                Logger.v(TAG, "No callback is found.");
+            }
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            Logger.v(TAG, "Broker Account service is disconnected.");
+            mBound = false;
+        }
+
+        public void unBindService(final Context context) {
+            // Service disconnect is async operation, in case of race condition, having the service binding check queued up
+            // in main message looper and unbind it.
+            final Handler handler = new Handler(Looper.getMainLooper());
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    if (mBound) {
+                        context.unbindService(BrokerAccountServiceConnection.this);
+                        mBound = false;
+                    }
+                }
+            });
+        }
+    }
+}

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -293,6 +293,7 @@ class BrokerProxy implements IBrokerProxy {
             throws AuthenticationException {
 
         verifyNotOnMainThread();
+        HttpWebRequest.throwIfNetworkNotAvaliable(mContext);
 
         final Bundle requestBundle = getBrokerOptions(request);
 
@@ -338,9 +339,6 @@ class BrokerProxy implements IBrokerProxy {
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.AUTH_FAILED_CANCELLED, e);
             } catch (AuthenticatorException e) {
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
-                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.toString())) {
-                    throw new AuthenticationException(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE, e.getMessage());
-                }
             } catch (IOException e) {
                 // Authenticator gets problem from webrequest or file read/write
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -338,6 +338,9 @@ class BrokerProxy implements IBrokerProxy {
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.AUTH_FAILED_CANCELLED, e);
             } catch (AuthenticatorException e) {
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
+                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.toString())) {
+                    throw new AuthenticationException(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE, e.getMessage());
+                }
             } catch (IOException e) {
                 // Authenticator gets problem from webrequest or file read/write
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION);

--- a/adal/src/main/java/com/microsoft/aad/adal/Callback.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Callback.java
@@ -1,0 +1,41 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+/**
+ * ADAL internal Callback for handling asynchronous call.
+ */
+interface Callback<T> {
+    /**
+     * Will be invoked if event triggered is correctly processed.
+     * @param result The success result.
+     */
+    void onSuccess(T result);
+
+    /**
+     * Will be invoked for the error case.
+     * @param throwable The {@link Throwable} for the error case.
+     */
+    void onError(Throwable throwable);
+}

--- a/adal/src/main/java/com/microsoft/aad/adal/CallbackExecutor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CallbackExecutor.java
@@ -1,0 +1,84 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * ADAL internal class for handling callback to be executed on the correct thread and message queue.
+ */
+final class CallbackExecutor<T> {
+    private static final String TAG = CallbackExecutor.class.getSimpleName();
+
+    private final AtomicReference<Callback<T>> mCallbackReference = new AtomicReference<>(null);
+    private final Handler mHandler;
+
+    CallbackExecutor(final Callback<T> callback) {
+        // check if the current thread has the looper; if so, create Handler with the current thread looper to send message
+        // back to the correct thread.
+        mHandler = Looper.myLooper() == null ? null : new Handler();
+        mCallbackReference.set(callback);
+    }
+
+    public void onSuccess(final T result) {
+        final Callback<T> callback = mCallbackReference.getAndSet(null);
+        if (callback == null) {
+            Logger.v(TAG, "Callback does not exist.");
+            return;
+        }
+
+        if (mHandler == null) {
+            callback.onSuccess(result);
+        } else {
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    callback.onSuccess(result);
+                }
+            });
+        }
+    }
+
+    public void onError(final Throwable throwable) {
+        final Callback<T> callback = mCallbackReference.getAndSet(null);
+        if (callback == null) {
+            Logger.v(TAG, "Callback does not exist.");
+            return;
+        }
+
+        if (mHandler == null) {
+            callback.onError(throwable);
+        } else {
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    callback.onError(throwable);
+                }
+            });
+        }
+    }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.12.0
+--------------
+Add bound service to remove requirement for contacts permission when talking to broker.
+
 Version 1.11.0
 --------------
 AuthRequest no longer waits for broker to install for broker auth.

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -23,24 +23,8 @@
 
 package com.microsoft.aad.adal.example.userappwithbroker;
 
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-import javax.crypto.spec.SecretKeySpec;
-
-import com.microsoft.aad.adal.ADALError;
-import com.microsoft.aad.adal.AuthenticationCallback;
-import com.microsoft.aad.adal.AuthenticationContext;
-import com.microsoft.aad.adal.AuthenticationResult;
-import com.microsoft.aad.adal.AuthenticationSettings;
-import com.microsoft.aad.adal.Logger;
-import com.microsoft.aad.adal.PromptBehavior;
-
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -58,6 +42,26 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
+
+import com.microsoft.aad.adal.ADALError;
+import com.microsoft.aad.adal.AuthenticationCallback;
+import com.microsoft.aad.adal.AuthenticationContext;
+import com.microsoft.aad.adal.AuthenticationResult;
+import com.microsoft.aad.adal.AuthenticationSettings;
+import com.microsoft.aad.adal.Logger;
+import com.microsoft.aad.adal.PromptBehavior;
+import com.microsoft.aad.adal.UserInfo;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * Sample for acquiring token via broker. 
@@ -156,6 +160,29 @@ public class MainActivity extends Activity {
                     showMessage("Cannot make acquire token silent call for "
                             + "resource 2 since no user unique id is passed.");
                 }
+            }
+        });
+
+        Button buttonForGetBrokerUsers = (Button) findViewById(R.id.GetBrokerUsers);
+        buttonForGetBrokerUsers.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            final UserInfo[] users = mAuthContext.getBrokerUsers();
+                            String displayMessage = "Broker users list length: " + users.length + "; ";
+                            for (final UserInfo userInfo : users) {
+                                displayMessage += "account name: " + userInfo.getDisplayableId() + ";";
+                            }
+
+                            showMessage(displayMessage);
+                        } catch (final IOException | OperationCanceledException | AuthenticatorException e) {
+                            Logger.v(TAG, "Error occurred when retrieving broker users.");
+                        }
+                    }
+                }).start();
             }
         });
 

--- a/userappwithbroker/src/main/res/layout/activity_main.xml
+++ b/userappwithbroker/src/main/res/layout/activity_main.xml
@@ -47,12 +47,20 @@
         android:layout_centerHorizontal="true"
         android:text="@string/AcquireTokenSilentForR2" />
 
+    <Button
+        android:id="@+id/GetBrokerUsers"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/AcquireTokenSilentForR2"
+        android:layout_centerHorizontal="true"
+        android:text="@string/GetBrokerUsers" />
+
     <EditText
         android:id="@+id/editTextUsername"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:layout_below="@+id/AcquireTokenSilentForR2"
+        android:layout_below="@+id/GetBrokerUsers"
         android:ems="10"
         android:hint="@string/login_hint" >
 

--- a/userappwithbroker/src/main/res/values/strings.xml
+++ b/userappwithbroker/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="AcquireTokenSilentForR2">AcquireToken Silent For Resource2</string>
     <string name="clear_tokens">Clear Tokens</string>
     <string name="login_hint">someone@contoso.com</string>
+    <string name="GetBrokerUsers">GetBrokerUsers</string>
 </resources>


### PR DESCRIPTION
Ref #707 
The aim of this PR is to return the ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE instead of AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED  when a silentAuth with PRT in broker is called while no network connection available.

To-do
- add unit test
- add version checking