### PR TITLE
Return DEVICE_CONNECTION_IS_NOT_AVAILABLE error when no network and uses Broker flow

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -159,6 +159,29 @@ public final class BrokerAccountServiceTest extends ServiceTestCase<MockBrokerAc
         latch.await();
     }
 
+    public void testGetAuthTokenVerifyNoNetwork() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        sThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final Context mockContext = getMockContext();
+                final FileMockContext context = new FileMockContext(mockContext);
+                context.setConnectionAvaliable(false);
+
+                try {
+                    final Bundle bundle = BrokerAccountServiceHandler.getInstance().getAuthToken(context, new Bundle());
+                    fail();
+                } catch (final AuthenticationException e) {
+                    Assert.assertTrue(e.getCode() == ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        latch.await();
+
+    }
+
     @SmallTest
     public void testBrokerProxyGetAuthToken() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -673,6 +673,30 @@ public class BrokerProxyTests extends AndroidTestCase {
         }
     }
 
+    public void testGetAuthTokenInBackgroundVerifyErrorNoNetworkConnection() throws NameNotFoundException {
+        final String acctName = "testAcct123";
+        final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
+                "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
+        final FileMockContext context = new FileMockContext(getContext());
+        context.setConnectionAvaliable(false);
+        final AccountManager mockedAccountManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+        context.setMockedAccountManager(mockedAccountManager);
+        context.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
+                AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, true));
+
+        //action
+        try {
+            final BrokerProxy brokerProxy = new BrokerProxy(context);
+            brokerProxy.getAuthTokenInBackground(authRequest);
+            Assert.fail("should throw");
+        } catch (final Exception exception) {
+            assertTrue("Exception type check", exception instanceof AuthenticationException);
+            assertEquals("check error code", ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE,
+                    ((AuthenticationException) exception).getCode());
+        }
+    }
+
     public void testGetIntentForBrokerActivityEmptyIntent() throws NameNotFoundException, OperationCanceledException,
             IOException, AuthenticatorException {
         final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/test", "resource", "client",

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -338,6 +338,10 @@ class BrokerProxy implements IBrokerProxy {
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.AUTH_FAILED_CANCELLED, e);
             } catch (AuthenticatorException e) {
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
+                if (e.getMessage().contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.getDescription())) {
+                    throw new AuthenticationException(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE,
+                            "Received error from broker, errorCode: " + e.getMessage());
+                }
             } catch (IOException e) {
                 // Authenticator gets problem from webrequest or file read/write
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION);
@@ -409,6 +413,9 @@ class BrokerProxy implements IBrokerProxy {
                 break;
             case AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION:
                 adalErrorCode = ADALError.BROKER_AUTHENTICATOR_UNSUPPORTED_OPERATION;
+                break;
+            case AccountManager.ERROR_CODE_NETWORK_ERROR:
+                adalErrorCode = ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE;
                 break;
             default:
                 adalErrorCode = ADALError.BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN;


### PR DESCRIPTION
Ref #707 
The aim of this PR is to return the ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE instead of AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED when a silentAuth with PRT in broker is called while no network connection available.
- get the exception error message from broker and throw the AuthenticationException if the AuthenticatorExceptions is caused by ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE
- add corresponding unit test
- add the testGetAuthTokenVerifyNoNetwork into BrokerAccountServiceTest