### PR TITLE
Working around java8 enforcements around javadoc #793

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -140,7 +140,13 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     exclude '**/*.aidl'
-    options.addStringOption('Xdoclint:none', '-quiet')
+    if (JavaVersion.current().isJava8Compatible()) {
+        allprojects {
+            tasks.withType(Javadoc) {
+                options.addStringOption('Xdoclint:none', '-quiet')
+            }
+        }
+    }
     classpath = configurations.compile
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
     failOnError = false

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -139,7 +139,8 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    exclude {'*.aidl'}
+    exclude '**/*.aidl'
+    options.addStringOption('Xdoclint:none', '-quiet')
     classpath = configurations.compile
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
     failOnError = false


### PR DESCRIPTION
Java8 has a lot stricter checks of javadoc, adding the xdoclint to none.
Also seems the exclude syntax has been changed.