### PR TITLE
Fixing err_cache_miss error #712

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -65,6 +65,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.webkit.ClientCertRequest;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 /**
@@ -368,6 +369,10 @@ public class AuthenticationActivity extends Activity {
         mWebView.getSettings().setDomStorageEnabled(true);
         mWebView.getSettings().setUseWideViewPort(true);
         mWebView.getSettings().setBuiltInZoomControls(true);
+
+        // WebSettings.LOAD_CACHE_ELSE_NETWORK makes the webview go to the server if the cached resource has
+        // expired. This should prevent err_cach_miss errors when hitting back from an page marked no_cache
+        mWebView.getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
         mWebView.setWebViewClient(new CustomWebViewClient());
         mWebView.setVisibility(View.INVISIBLE);
     }


### PR DESCRIPTION
If the auth flow in the webview navigates the user to a MFA page, and the user is unable to answer the MFA prompt, subsequently the user hits the back button, this will lead to an err_cache_miss as the page is attempted to be loaded from the cache. Setting LOAD_CACHE_ELSE_NETWORK let the page to be fetched again from the server.