### PR TITLE
Fix for handling the permission missing scenario when silent auth is called directly

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -338,9 +338,15 @@ class AcquireTokenRequest {
         }
 
         // If we cannot switch to broker, return the result from local flow.
-        if (mBrokerProxy.canSwitchToBroker(authenticationRequest.getAuthority()) == BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER
+        final BrokerProxy.SwitchToBroker switchToBrokerFlag = mBrokerProxy.canSwitchToBroker(authenticationRequest.getAuthority());
+        if (switchToBrokerFlag == BrokerProxy.SwitchToBroker.CANNOT_SWITCH_TO_BROKER
                 || !mBrokerProxy.verifyUser(authenticationRequest.getLoginHint(), authenticationRequest.getUserId())) {
             return authResult;
+        } else if (switchToBrokerFlag == BrokerProxy.SwitchToBroker.NEED_PERMISSIONS_TO_SWITCH_TO_BROKER) {
+            //For android M and above
+            throw new UsageAuthenticationException(
+                        ADALError.DEVELOPER_BROKER_PERMISSIONS_MISSING,
+                        "Broker related permissions are missing for GET_ACCOUNTS");
         }
 
         // If we can try with broker for silent flow, it indicates ADAL can switch to broker for auth. Even broker does


### PR DESCRIPTION
Fix for handling the permission missing scenario when performing an acquireTokenSilent call.
1. there is a bug that we never check if permissions are granted to use broker when calling acquireTokenSilent directly. Because we assume it will alway do the interactive first where the permission checking is performed. However, this will broken the token share scenario where the acquireTokenSilent is called directly.
2. for the silent call, the flow is to look into the local cache first then go to the broker. So we should check the broker permission only when adal doesn't get any luck in local cache and tries to acquire token silently with broker.

Follow-up question,
1. For both Android <=22 and >=23, should we keep it same checking behavior for the silent call?
2. If BrokerAccountService is supported, then GET_ACCOUNTS permission is no longer needed for both  <=22 and >=23 or not?