### PR TITLE
Expand Resiliency Error Codes to all 5xx Status Codes

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -613,7 +613,7 @@ public final class AcquireTokenRequestTest extends AndroidTestCase {
         Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
         Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(Util.getErrorResponseBody("HTTP_GATEWAY_TIMEOUT")),
                 Util.createInputStream(Util.getErrorResponseBody("HTTP_BAD_GATEWAY")));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_GATEWAY_TIMEOUT, HttpURLConnection.HTTP_BAD_GATEWAY);
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_GATEWAY_TIMEOUT, HttpURLConnection.HTTP_NOT_FOUND);
 
         try {
             authContext.acquireTokenSilentSync("resource", "clientid", TEST_USERID);
@@ -765,8 +765,8 @@ public final class AcquireTokenRequestTest extends AndroidTestCase {
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
         Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
-        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(Util.getErrorResponseBody("HTTP_BAD_GATEWAY")));
-        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_GATEWAY);
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(Util.getErrorResponseBody("HTTP_CONFLICT")));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_NOT_FOUND);
 
         try {
             authContext.acquireTokenSilentSync("resource", "clientid", TEST_USERID);
@@ -789,8 +789,8 @@ public final class AcquireTokenRequestTest extends AndroidTestCase {
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUITE), true, true, getExpireDate(EXTEND_MINUS_MINUTE));
         cacheStore.removeItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId", TEST_USERID));
         cacheStore.removeItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId", TEST_UPN));
-        cacheStore.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY,"clientId", TEST_USERID)).setFamilyClientId(AuthenticationConstants.MS_FAMILY_ID);
-        cacheStore.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY,"clientId", TEST_UPN)).setFamilyClientId(AuthenticationConstants.MS_FAMILY_ID);
+        cacheStore.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, "clientId", TEST_USERID)).setFamilyClientId(AuthenticationConstants.MS_FAMILY_ID);
+        cacheStore.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, "clientId", TEST_UPN)).setFamilyClientId(AuthenticationConstants.MS_FAMILY_ID);
         
         final FileMockContext mockContext = createMockContext();
         final AuthenticationContext authContext = new AuthenticationContext(mockContext,

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -64,6 +64,8 @@ class Oauth2 {
 
     private static final int DELAY_TIME_PERIOD = 1000;
 
+    private static final int MAX_RESILIENCY_ERROR_CODE = 600;
+
     private static final String DEFAULT_AUTHORIZE_ENDPOINT = "/oauth2/authorize";
 
     private static final String DEFAULT_TOKEN_ENDPOINT = "/oauth2/token";
@@ -629,25 +631,22 @@ class Oauth2 {
         }
 
         final int statusCode = webResponse.getStatusCode();
-        switch (statusCode) {
-            case HttpURLConnection.HTTP_OK:
-            case HttpURLConnection.HTTP_BAD_REQUEST:
-            case HttpURLConnection.HTTP_UNAUTHORIZED:
-                try {
-                    result = parseJsonResponse(webResponse.getBody());
-                    if (result != null) {
-                        httpEvent.setOauthErrorCode(result.getErrorCode());
-                    }
-                } catch (final JSONException jsonException) {
-                    throw new AuthenticationException(ADALError.SERVER_INVALID_JSON_RESPONSE, "Can't parse server response " + webResponse.getBody(), jsonException);
+
+        if (statusCode == HttpURLConnection.HTTP_OK
+                || statusCode == HttpURLConnection.HTTP_BAD_REQUEST
+                || statusCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            try {
+                result = parseJsonResponse(webResponse.getBody());
+                if (result != null) {
+                    httpEvent.setOauthErrorCode(result.getErrorCode());
                 }
-                break;
-            case HttpURLConnection.HTTP_INTERNAL_ERROR:
-            case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:
-            case HttpURLConnection.HTTP_UNAVAILABLE:
-                throw new ServerRespondingWithRetryableException("Unexpected server response " + webResponse.getBody());
-            default:
-                throw new AuthenticationException(ADALError.SERVER_ERROR, "Unexpected server response " + webResponse.getBody());
+            } catch (final JSONException jsonException) {
+                throw new AuthenticationException(ADALError.SERVER_INVALID_JSON_RESPONSE, "Can't parse server response " + webResponse.getBody(), jsonException);
+            }
+        } else if (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR && statusCode <= MAX_RESILIENCY_ERROR_CODE) {
+            throw new ServerRespondingWithRetryableException("Server Error " + statusCode + " " + webResponse.getBody());
+        } else {
+            throw new AuthenticationException(ADALError.SERVER_ERROR, "Unexpected server response " + statusCode + " " + webResponse.getBody());
         }
 
         // Set correlationId in the result


### PR DESCRIPTION
ISSUE #772
- expand resiliency error codes to all 5xx status codes.
- correpsonding change on the unit tests in AcquireTokenRequestTest.java