### PR TITLE
Removing the reciever from Android manifest to circumvent a crash 

### DIFF
--- a/adal/src/main/AndroidManifest.xml
+++ b/adal/src/main/AndroidManifest.xml
@@ -12,14 +12,6 @@
         <activity android:name="com.microsoft.aad.adal.AuthenticationActivity" >
         </activity>
         
-        <receiver
-            android:name = "com.microsoft.aad.adal.ApplicationReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.PACKAGE_ADDED"/>
-                <action android:name="android.intent.action.PACKAGE_INSTALL"/>
-                <data android:scheme="package"/>
-            </intent-filter>
-        </receiver> 
     </application>
     
     


### PR DESCRIPTION
As a part of removing ADFS validation for broker we introduced a crash when CP is installed. This crash is triggered by the application receiver. This fix disables the receiver.