### PR TITLE
Disable autocomplete in automation app request EditText

### DIFF
--- a/automationtestapp/src/main/res/layout/activity_request.xml
+++ b/automationtestapp/src/main/res/layout/activity_request.xml
@@ -38,7 +38,8 @@
         android:layout_gravity="center_horizontal"
         android:textCursorDrawable="@drawable/color_cursor"
         android:backgroundTint="@color/colorPrimaryDark"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:inputType="textNoSuggestions" />
 
     <Button
         android:layout_width="wrap_content"


### PR DESCRIPTION
As part of the automation tests, we need to enter a JSON string into the EditBox on the 'request' activity page. Because this is JSON (which contains text such URIs and GUIDs), we should disable any autocomplete functionality (we've had issues with tests failing due to this!).