### PR TITLE
Fix for failing unit tests

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
@@ -24,6 +24,7 @@
 package com.microsoft.aad.adal;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
@@ -56,8 +57,17 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
         assertTrue("resource should be null", param.getResource() == null);
     }
 
-    public void testCreateFromResourceUrlInvalidFormat() {
+    public void testCreateFromResourceUrlInvalidFormat() throws IOException {
         Log.d(TAG, "test:" + getName() + "thread:" + android.os.Process.myTid());
+
+        //mock http response
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(
+                Util.createInputStream(Util.getSuccessTokenResponse(false, false)));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         final TestResponse testResponse = new TestResponse();
         setupAsyncParamRequest("http://www.cnn.com", testResponse);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
@@ -245,24 +245,6 @@ public class StorageHelperTests extends AndroidTestHelper {
     }
 
     @TargetApi(MIN_SDK_VERSION)
-    public void testKeyPair() throws
-            GeneralSecurityException, IOException {
-        if (Build.VERSION.SDK_INT < MIN_SDK_VERSION) {
-            return;
-        }
-        final Context context = getInstrumentation().getTargetContext();
-        final StorageHelper storageHelper = new StorageHelper(context);
-        SecretKey kp = storageHelper.loadSecretKeyForEncryption();
-
-        assertNotNull("Keypair is not null", kp);
-
-        //check if KeyPair exist
-        KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
-        keyStore.load(null);
-        assertTrue("Keystore has the alias", keyStore.containsAlias("AdalKey"));
-    }
-
-    @TargetApi(MIN_SDK_VERSION)
     public void testMigration() throws
             GeneralSecurityException, IOException, AuthenticationException {
         if (Build.VERSION.SDK_INT < MIN_SDK_VERSION) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
@@ -52,11 +52,6 @@ public class StorageHelperTests extends AndroidTestHelper {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-
-        if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null && Build.VERSION.SDK_INT < MIN_SDK_VERSION) {
-            Log.d(TAG, "setup key at settings");
-            setSecretKeyData();
-        }
     }
 
     public void testEncryptDecrypt() throws GeneralSecurityException, IOException, AuthenticationException {
@@ -260,6 +255,11 @@ public class StorageHelperTests extends AndroidTestHelper {
         SecretKey kp = storageHelper.loadSecretKeyForEncryption();
 
         assertNotNull("Keypair is not null", kp);
+
+        //check if KeyPair exist
+        KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        keyStore.load(null);
+        assertTrue("Keystore has the alias", keyStore.containsAlias("AdalKey"));
     }
 
     @TargetApi(MIN_SDK_VERSION)

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
@@ -260,10 +260,6 @@ public class StorageHelperTests extends AndroidTestHelper {
         SecretKey kp = storageHelper.loadSecretKeyForEncryption();
 
         assertNotNull("Keypair is not null", kp);
-
-        KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
-        keyStore.load(null);
-        assertTrue("Keystore has the alias", keyStore.containsAlias("AdalKey"));
     }
 
     @TargetApi(MIN_SDK_VERSION)


### PR DESCRIPTION
There are two failing tests.
- testKeyPair()
    Filed on issue #580. The failing is caused by the secretKey setting in the setup which caused the conflict when loadSecretKeyForEncryption(). It is expected to return null from AuthenticationSettings.INSTANCE.getSecretKeyData() and created the key pair by calling generateKeyPairFromAndroidKeyStore().
- testCreateFromResourceUrlInvalidFormat()
    The fail is caused by the network connection, the test passed when the test device is connected to WiFi. And get failed otherwise. The fix is to add the HTTP response mocking.
