### PR TITLE
Fix the memory leak with static delegate map on auth cancel

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -43,6 +43,7 @@ import com.google.gson.Gson;
 
 import junit.framework.Assert;
 
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -71,6 +72,8 @@ import javax.crypto.spec.SecretKeySpec;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public final class AuthenticationContextTest extends AndroidTestCase {
 
@@ -1657,6 +1660,7 @@ public final class AuthenticationContextTest extends AndroidTestCase {
         authContext.onActivityResult(requestCode, resultCode, data);
 
         // assert
+        verify(Mockito.mock(AuthenticationContext.class), times(1)).removeWaitingRequest(Matchers.anyInt());
         assertTrue("Returns cancel error",
                 callback.getCallbackException() instanceof AuthenticationException);
         assertTrue("Cancel error has message",

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -737,7 +737,7 @@ class AcquireTokenRequest {
                 }
             }
         } finally {
-            if (exc != null && exc.getCode() != ADALError.AUTH_FAILED_CANCELLED) {
+            if (exc != null) {
                 mAuthContext.removeWaitingRequest(requestId);
             }
         }


### PR DESCRIPTION
- When the user cancel the auth flow by clicking the back button, the request should be removed from the static delegate map. Otherwise, it will cause memory leak where the authcontext static map holds the cancelled requests which contains the callback ref.
- the unit test verify the removeWaitingRequest() is called once when error code is auth_failed_cancelled