### PR TITLE
Check key by value, rather than by reference. (Closes #852)

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -245,7 +245,7 @@ final class BrokerAccountServiceHandler {
 
         final Map<String, String> requestData = new HashMap<>();
         for (final String key : requestBundleKeys) {
-            if (key == AuthenticationConstants.Browser.REQUEST_ID) {
+            if (key.equals(AuthenticationConstants.Browser.REQUEST_ID)) {
                 requestData.put(key, String.valueOf(requestBundle.getInt(key)));
                 continue;
             }


### PR DESCRIPTION
Found during investigation of #808 -- String comparison should generally be done using `equals()`