### PR TITLE
Removing duplicate event entries for acquireTokenSilentSync #863

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -563,21 +563,12 @@ public class AuthenticationContext {
                 new AuthenticationCallback<AuthenticationResult>() {
                     @Override
                     public void onSuccess(AuthenticationResult result) {
-                        apiEvent.setWasApiCallSuccessful(true, null);
-                        apiEvent.setCorrelationId(request.getCorrelationId().toString());
-                        apiEvent.setIdToken(result.getIdToken());
-                        apiEvent.stopTelemetryAndFlush();
-
                         authenticationResult.set(result);
                         latch.countDown();
                     }
 
                     @Override
                     public void onError(Exception exc) {
-                        apiEvent.setWasApiCallSuccessful(false, exc);
-                        apiEvent.setCorrelationId(request.getCorrelationId().toString());
-                        apiEvent.stopTelemetryAndFlush();
-
                         exception.set(exc);
                         latch.countDown();
                     }


### PR DESCRIPTION
API event is already finished in an earlier function, the call to stop event causes a dummy apievent getting inserted into the aggregated map