### PR TITLE
Integrates JaCoCo for Code Coverage Metrics

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.library'
+// Add JaCoCo for coverage metrics
+apply plugin: 'jacoco'
 // This plugin publishes adal in to the local maven repo
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'findbugs'
@@ -35,6 +37,9 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
@@ -104,6 +109,24 @@ dependencies {
     javadocDeps 'com.android.support:support-v4:25.0.0'
 }
 
+task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    jacocoClasspath = configurations['androidJacocoAnt']
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = files(["${buildDir}/jacoco/testDebugUnitTest.exec",
+                           "${buildDir}/outputs/code-coverage/connected/coverage.ec"
+    ])
+}
 
 task createPom  {
     pom {

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -41,6 +41,7 @@ android {
             testCoverageEnabled true
         }
         release {
+            testCoverageEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }


### PR DESCRIPTION
Run with `./gradlew createDebugCoverageReport`

Report will generate at `adal/build/reports/coverage/debug/index.html`