### PR TITLE
Removes testCoverageEnabled from release builds

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -41,7 +41,6 @@ android {
             testCoverageEnabled true
         }
         release {
-            testCoverageEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }


### PR DESCRIPTION
This commit preserves jacoco test coverage for `debug` builds, disables for `release`