### PR TITLE
Coverage file is now found via wildcard

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -124,8 +124,9 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
 
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
-    executionData = files(["${buildDir}/jacoco/testDebugUnitTest.exec",
-                           "${buildDir}/outputs/code-coverage/connected/coverage.ec"
+    executionData = fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code-coverage/connected/*coverage.ec"
     ])
 }
 


### PR DESCRIPTION
This closes #881 and is the ADAL equivalent of [MSAL/#207](https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/207)

Gradle `2.2+` generates the `.ec` coverage file per scheme `<device> - <major_ver>-coverage.ec`

This PR updates `task jacocoTestReport` to accept a wildcard `*coverage.ec` file.