### PR TITLE
Foci Token won't have client id in the cache, flip the check 

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -268,7 +268,7 @@ class TokenCacheAccessor {
         final List<TokenCacheItem> regularRTsMatchingRequest = new ArrayList<>();
         while (allItems.hasNext()) {
             final TokenCacheItem tokenCacheItem = allItems.next();
-            if (tokenCacheItem.getAuthority().equalsIgnoreCase(mAuthority) && tokenCacheItem.getClientId().equalsIgnoreCase(clientId)
+            if (tokenCacheItem.getAuthority().equalsIgnoreCase(mAuthority) && clientId.equalsIgnoreCase(tokenCacheItem.getClientId())
                     && resource.equalsIgnoreCase(tokenCacheItem.getResource()) && !tokenCacheItem.getIsMultiResourceRefreshToken()) {
                 regularRTsMatchingRequest.add(tokenCacheItem);
             }


### PR DESCRIPTION


Please make sure every Pull Request has the following information:

<ul>
  <li>https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/902</li>
  <li>Flip the client id check to make sure that if the token cache item doesn't have client id, there won't be any crash.</li>
</ul>
