### PR TITLE
Updates buildToolsVersion & supportLibraryVersion to latest @ 25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-25.0.0
+    - build-tools-25.0.3
     - android-25
     - extra
     - extra-android-m2repository

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,14 +4,14 @@ ext {
     minSdkVersion = 14
     targetSdkVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.0"
+    buildToolsVersion = "25.0.3"
 
     // Plugins
     gradleVersion = "2.2.3"
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries
-    supportLibraryVersion = "25.0.0"
+    supportLibraryVersion = "25.3.1"
     junitVersion = "4.12"
     mockitoCoreVersion = "1.10.19"
     dexmakerMockitoVersion = "1.2"


### PR DESCRIPTION
This PR closes #894 by updating the `buildToolsVersions` and `supportLibraryVersion` to the latest API 25 toolsets.
