### PR TITLE
Removes log message from DefaultTokenCacheStore#decrypt(String, String)

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -140,7 +140,6 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
         } catch (GeneralSecurityException | IOException e) {
             Logger.e(TAG, "Decryption failure", "", ADALError.DECRYPTION_FAILED, e);
             removeItem(key);
-            Logger.v(TAG, String.format("Decryption error, item removed for key: '%s'", key));
         }
 
         return null;


### PR DESCRIPTION
This PR closes #920 and removes logging from the `catch` block within `DefaultTokenCacheStore#decrypt(String, String)`.