### PR TITLE
Force Travis-CI to use Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # ./travis.yml for adal android
 
 language: android
+dist: precise
 
 jdk: 
   - oraclejdk8


### PR DESCRIPTION
Fork of #923 which forces `dist: precise` per [Trusty as default Linux is coming](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default)