### PR TITLE
return a different error message other than 'AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED' when communcation with broker fails.

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -151,7 +151,10 @@ final class BrokerAccountServiceHandler {
 
         final Throwable throwable = exception.getAndSet(null);
         if (throwable != null) {
-            throw new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, throwable.getMessage(), throwable);
+            ADALError error = throwable instanceof RemoteException
+                    ? ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING
+                    : ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED;
+            throw new AuthenticationException(error, throwable.getMessage(), throwable);
         }
 
         return bundleResult.getAndSet(null);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -315,15 +315,12 @@ class BrokerProxy implements IBrokerProxy {
         final Bundle bundleResult;
         if (isBrokerAccountServiceSupported()) {
             bundleResult = BrokerAccountServiceHandler.getInstance().getAuthToken(mContext, requestBundle, brokerEvent);
-            if (bundleResult == null) {
-                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, request.getLogInfo() + " -- No result returned from getAuthTokenInBackground");
-            }
         } else {
             bundleResult = getAuthTokenFromAccountManager(request, requestBundle);
-            if (bundleResult == null) {
-                Logger.v(TAG, "No bundle result returned from broker for silent request.");
-                return null;
-            }
+        }
+        if (bundleResult == null) {
+            Logger.v(TAG, "No bundle result returned from broker for silent request.");
+            return null;
         }
 
         return getResultFromBrokerResponse(bundleResult, request);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -315,12 +315,15 @@ class BrokerProxy implements IBrokerProxy {
         final Bundle bundleResult;
         if (isBrokerAccountServiceSupported()) {
             bundleResult = BrokerAccountServiceHandler.getInstance().getAuthToken(mContext, requestBundle, brokerEvent);
+            if (bundleResult == null) {
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, request.getLogInfo() + " -- No result returned from getAuthTokenInBackground");
+            }
         } else {
             bundleResult = getAuthTokenFromAccountManager(request, requestBundle);
-        }
-        if (bundleResult == null) {
-            Logger.v(TAG, "No bundle result returned from broker for silent request.");
-            return null;
+            if (bundleResult == null) {
+                Logger.v(TAG, "No bundle result returned from broker for silent request.");
+                return null;
+            }
         }
 
         return getResultFromBrokerResponse(bundleResult, request);


### PR DESCRIPTION
return a different error message other than 'AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED' when communcation with broker fails.


fix https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/901#issue-243075944