### PR TITLE
fix the issue that too much memory retained by Telemetry in stress test.

### DIFF
--- a/adal/src/telemetry/java/com/microsoft/aad/adal/Telemetry.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/Telemetry.java
@@ -80,7 +80,7 @@ public final class Telemetry {
             return;
         }
 
-        final String startTime = mEventTracking.get(new Pair<>(requestId, eventName));
+        final String startTime = mEventTracking.remove(new Pair<>(requestId, eventName));
 
         // If we did not get anything back from the dictionary, most likely its a bug that stopEvent was called without
         // a corresponding startEvent


### PR DESCRIPTION
fix https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/908
Previously, in Telemetry, there's no calling on remove the events, so the events piled up in the container 'mEventTracking'. Now I made a change in the 'stopEvent' by removing the event. I watched the memory utilization in the stress test app, the allocated memory is always around 1MB now.