### PR TITLE
fix issue #925 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # ./travis.yml for adal android
 
 language: android
-dist: precise
 
 jdk: 
   - oraclejdk8
@@ -14,16 +13,17 @@ android:
     # Travis has a bug that we need to workaround to use sdk 25
     # https://github.com/travis-ci/travis-ci/issues/6059
     - tools
-    - tools
     - platform-tools
+    - tools
     - build-tools-25.0.3
     - android-25
+    - android-21
     - extra
     - extra-android-m2repository
     - extra-google-m2repository
     - addon-google_apis-google-21
     #system images
-    - sys-img-armeabi-v7a-addon-google_apis-google-21
+    - sys-img-armeabi-v7a-android-21
 
 env:
     global:
@@ -45,6 +45,7 @@ cache:
     - $HOME/.android/build-cache
 
 before_script:
+  - android list targets
   - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator


### PR DESCRIPTION
fix https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/925
 to make the travis script independent of the dist of Ubuntu.