### PR TITLE
Adds Tracking of SPE Ring to HttpEvent

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpEventTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpEventTest.java
@@ -235,6 +235,7 @@ public final class HttpEventTest {
         assertEquals("I", dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpedRingEmpty() {
         final String speHeader = "";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -247,6 +248,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingWrongLength1() {
         final String speHeader = ",";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -259,6 +261,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingWrongLength2() {
         final String speHeader = ",,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -271,6 +274,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingWrongLength3() {
         final String speHeader = ",,,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -283,6 +287,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingTooLong() {
         final String speHeader = ",,,,,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -295,6 +300,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingTooShort() {
         final String speHeader = "1,00";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -307,6 +313,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingTooShort2() {
         final String speHeader = "1,0,0";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -319,6 +326,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingTooShort3() {
         final String speHeader = "1,1,1,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -331,6 +339,7 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
     public void testSpeRingTooLong2() {
         final String speHeader = "1,1,1,,,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
@@ -343,4 +352,42 @@ public final class HttpEventTest {
         assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
+    @Test
+    public void testVersionWithMajorMinor() {
+        final String speHeader = "1.2,1,2,12.34,";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    @Test
+    public void testVersionWithMajorMinorPatch() {
+        final String speHeader = "1.2.3,1,2,12.34,I";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    @Test
+    public void testMultiDigitVersionWithMajorMinorPatch() {
+        final String speHeader = "11.22.33,1,2,12.34,I";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpEventTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpEventTest.java
@@ -109,7 +109,7 @@ public final class HttpEventTest {
     public void testSpeRingInfoStrangeFormatting() {
         final String speHeader = "1 , ,, ,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -119,10 +119,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testEmptySpeRingInfo(){
+    public void testEmptySpeRingInfo() {
         final String speHeader = ",,,,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -132,10 +132,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testVersionOnlySpeRingInfo(){
+    public void testVersionOnlySpeRingInfo() {
         final String speHeader = "1,,,,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -145,10 +145,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testSpeRingWithVersionAndAgeOnly(){
+    public void testSpeRingWithVersionAndAgeOnly() {
         final String speHeader = "1,,,1234.1234,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -158,10 +158,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testSpeRingInfoWithBlankFieldsInnerRing(){
+    public void testSpeRingInfoWithBlankFieldsInnerRing() {
         final String speHeader = "1,0,0,,I";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -171,10 +171,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testSpeRingInfoWithSubErrorCodeAndAgeOnly(){
+    public void testSpeRingInfoWithSubErrorCodeAndAgeOnly() {
         final String speHeader = "1,,1,1234.1234,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -184,10 +184,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testSpeRingWithUnsupportedVersion(){
+    public void testSpeRingWithUnsupportedVersion() {
         final String speHeader = "2,1,2,3.3,I";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -200,7 +200,7 @@ public final class HttpEventTest {
     public void testSpeRingWithErrorAndSubError() {
         final String speHeader = "1,2,3,,";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals("2", dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -210,10 +210,10 @@ public final class HttpEventTest {
     }
 
     @Test
-    public void testSpeRingWithLeadingWhitespaceAgeInner(){
+    public void testSpeRingWithLeadingWhitespaceAgeInner() {
         final String speHeader = "1,,, 1234.1234,I";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -226,13 +226,121 @@ public final class HttpEventTest {
     public void testSpeRingWithVersionAndRingOnly() {
         final String speHeader = "1,,,,I";
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setSpeRingInfo(speHeader);
+        event.setXMsCliTelemData(speHeader);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
         assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
         assertEquals("I", dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpedRingEmpty() {
+        final String speHeader = "";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingWrongLength1() {
+        final String speHeader = ",";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingWrongLength2() {
+        final String speHeader = ",,";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingWrongLength3() {
+        final String speHeader = ",,,";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingTooLong() {
+        final String speHeader = ",,,,,";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingTooShort() {
+        final String speHeader = "1,00";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingTooShort2() {
+        final String speHeader = "1,0,0";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingTooShort3() {
+        final String speHeader = "1,1,1,";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
+    }
+
+    public void testSpeRingTooLong2() {
+        final String speHeader = "1,1,1,,,";
+        final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
+        event.setXMsCliTelemData(speHeader);
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.SERVER_SUBERROR_CODE));
+        assertEquals(null, dispatchMap.get(EventStrings.TOKEN_AGE));
+        assertEquals(null, dispatchMap.get(EventStrings.SPE_INFO));
     }
 
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
@@ -575,7 +575,12 @@ public enum ADALError {
     /**
      *  Broker is not installed. The process is kicked off to to install broker but ADAL cannot wait for it to finish.
      */
-    BROKER_APP_INSTALLATION_STARTED("Broker app installation started");
+    BROKER_APP_INSTALLATION_STARTED("Broker app installation started"),
+
+    /**
+     * The version field of x-ms-clitelem contained an unknown or unsupported value.
+     */
+    X_MS_CLITELEM_VERSION_UNRECOGNIZED("Unrecognized x-ms-clitelem header version");
 
     private String mDescription;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
@@ -580,7 +580,12 @@ public enum ADALError {
     /**
      * The version field of x-ms-clitelem contained an unknown or unsupported value.
      */
-    X_MS_CLITELEM_VERSION_UNRECOGNIZED("Unrecognized x-ms-clitelem header version");
+    X_MS_CLITELEM_VERSION_UNRECOGNIZED("Unrecognized x-ms-clitelem header version"),
+
+    /**
+     * The value of the x-ms-clitelem header contained malformed data.
+     */
+    X_MS_CLITELEM_MALFORMED("Malformed x-ms-clitelem header");
 
     private String mDescription;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -510,6 +510,11 @@ public final class AuthenticationConstants {
          * @see <a href="https://tools.ietf.org/html/rfc1945#appendix-D.2.1">RFC-1945</a>
          */
         static final String ACCEPT = "Accept";
+
+        /**
+         * Header used to track SPE Ring for telemetry
+         */
+        static final String X_MS_CLITELEM = "x-ms-clitelem";
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -596,25 +596,29 @@ class Oauth2 {
             final int indexTokenAge = 3;
             final int indexSpeInfo = 4;
 
+            // get the error_code
             if (headerSegments.length >= indexErrorCode + 1) {
                 errorCode = headerSegments[indexErrorCode];
             }
 
+            // get the sub_error_code
             if (headerSegments.length >= indexSubErrorCode + 1) {
                 subErrorCode = headerSegments[indexSubErrorCode];
             }
 
+            // get the token_age
             if (headerSegments.length >= indexTokenAge + 1) {
                 tokenAge = headerSegments[indexTokenAge];
             }
 
+            // get the spe_ring
             if (headerSegments.length >= indexSpeInfo + 1) {
                 speRing = headerSegments[indexSpeInfo];
             }
         } else { // unrecognized version
             Logger.w(TAG, "Unexpected header version: " + headerVersion, null, null);
         }
-
+        // Set the extracted values on the HttpEvent
         if (!StringExtensions.isNullOrBlank(errorCode) && !errorCode.equals("0")) {
             httpEvent.setSpeRingErrorCode(errorCode);
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -457,24 +457,19 @@ class Oauth2 {
             HttpWebResponse response = mWebRequestHandler.sendPost(authority, headers,
                     requestMessage.getBytes(AuthenticationConstants.ENCODING_UTF8),
                     "application/x-www-form-urlencoded");
-            final Map<String, List<String>> responseHeaders = response.getResponseHeaders();
-
-            if (null != responseHeaders && null != responseHeaders.get(X_MS_CLITELEM) && !responseHeaders.get(X_MS_CLITELEM).isEmpty()) {
-                httpEvent.setXMsCliTelemData(responseHeaders.get(X_MS_CLITELEM).get(0));
-            }
 
             httpEvent.setResponseCode(response.getStatusCode());
             httpEvent.setCorrelationId(mRequest.getCorrelationId().toString());
             stopHttpEvent(httpEvent);
 
             if (response.getStatusCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
-                if (responseHeaders != null
-                        && responseHeaders.containsKey(
+                if (response.getResponseHeaders() != null
+                        && response.getResponseHeaders().containsKey(
                                 AuthenticationConstants.Broker.CHALLENGE_REQUEST_HEADER)) {
 
                     // Device certificate challenge will send challenge request
                     // in 401 header.
-                    String challengeHeader = responseHeaders
+                    String challengeHeader = response.getResponseHeaders()
                             .get(AuthenticationConstants.Broker.CHALLENGE_REQUEST_HEADER).get(0);
                     Logger.v(TAG, "Device certificate challenge request:" + challengeHeader);
                     if (!StringExtensions.isNullOrBlank(challengeHeader)) {
@@ -641,6 +636,10 @@ class Oauth2 {
                     Logger.v(TAG, "x-ms-request-id: " + listOfHeaders.get(0));
                     httpEvent.setRequestIdHeader(listOfHeaders.get(0));
                 }
+            }
+
+            if (null != webResponse.getResponseHeaders().get(X_MS_CLITELEM) && !webResponse.getResponseHeaders().get(X_MS_CLITELEM).isEmpty()) {
+                httpEvent.setXMsCliTelemData(webResponse.getResponseHeaders().get(X_MS_CLITELEM).get(0));
             }
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -459,8 +459,8 @@ class Oauth2 {
                     "application/x-www-form-urlencoded");
             final Map<String, List<String>> responseHeaders = response.getResponseHeaders();
 
-            if (null != responseHeaders && null != responseHeaders.get(X_MS_CLITELEM)) {
-                httpEvent.setSpeRingInfo(responseHeaders.get(X_MS_CLITELEM).get(0));
+            if (null != responseHeaders && null != responseHeaders.get(X_MS_CLITELEM) && !responseHeaders.get(X_MS_CLITELEM).isEmpty()) {
+                httpEvent.setXMsCliTelemData(responseHeaders.get(X_MS_CLITELEM).get(0));
             }
 
             httpEvent.setResponseCode(response.getStatusCode());

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -146,7 +146,7 @@ final class EventStrings {
 
     static final String SERVER_SUBERROR_CODE = EVENT_PREFIX + "server_sub_error_code";
 
-    static final String TOKEN_AGE = EVENT_PREFIX + "token_age";
+    static final String TOKEN_AGE = EVENT_PREFIX + "rt_age";
 
     static final String SPE_INFO = EVENT_PREFIX + "spe_info";
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -24,139 +24,149 @@
 package com.microsoft.aad.adal;
 
 final class EventStrings {
-    static final String EVENT_NAME = "Microsoft.ADAL.event_name";
+    private static final String EVENT_PREFIX = "Microsoft.ADAL.";
+
+    static final String EVENT_NAME = EVENT_PREFIX + "event_name";
 
     // Event names
-    static final String API_EVENT = "Microsoft.ADAL.api_event";
+    static final String API_EVENT = EVENT_PREFIX + "api_event";
 
-    static final String AUTHORITY_VALIDATION_EVENT = "Microsoft.ADAL.authority_validation";
+    static final String AUTHORITY_VALIDATION_EVENT = EVENT_PREFIX + "authority_validation";
 
-    static final String HTTP_EVENT = "Microsoft.ADAL.http_event";
+    static final String HTTP_EVENT = EVENT_PREFIX + "http_event";
 
-    static final String BROKER_EVENT = "Microsoft.ADAL.broker_event";
+    static final String BROKER_EVENT = EVENT_PREFIX + "broker_event";
 
-    static final String UI_EVENT = "Microsoft.ADAL.ui_event";
+    static final String UI_EVENT = EVENT_PREFIX + "ui_event";
 
-    static final String TOKEN_CACHE_LOOKUP = "Microsoft.ADAL.token_cache_lookup";
+    static final String TOKEN_CACHE_LOOKUP = EVENT_PREFIX + "token_cache_lookup";
 
-    static final String TOKEN_CACHE_WRITE = "Microsoft.ADAL.token_cache_write";
+    static final String TOKEN_CACHE_WRITE = EVENT_PREFIX + "token_cache_write";
 
-    static final String TOKEN_CACHE_DELETE = "Microsoft.ADAL.token_cache_delete";
+    static final String TOKEN_CACHE_DELETE = EVENT_PREFIX + "token_cache_delete";
 
-    static final String BROKER_REQUEST_SILENT = "Microsoft.ADAL.broker_request_silent";
+    static final String BROKER_REQUEST_SILENT = EVENT_PREFIX + "broker_request_silent";
 
-    static final String BROKER_REQUEST_INTERACTIVE = "Microsoft.ADAL.broker_request_interactive";
+    static final String BROKER_REQUEST_INTERACTIVE = EVENT_PREFIX + "broker_request_interactive";
 
     // Event Parameter names
-    static final String APPLICATION_NAME = "Microsoft.ADAL.application_name";
+    static final String APPLICATION_NAME = EVENT_PREFIX + "application_name";
 
-    static final String APPLICATION_VERSION = "Microsoft.ADAL.application_version";
+    static final String APPLICATION_VERSION = EVENT_PREFIX + "application_version";
 
-    static final String CLIENT_ID = "Microsoft.ADAL.client_id";
+    static final String CLIENT_ID = EVENT_PREFIX + "client_id";
 
-    static final String AUTHORITY_NAME = "Microsoft.ADAL.authority";
+    static final String AUTHORITY_NAME = EVENT_PREFIX + "authority";
 
-    static final String AUTHORITY_TYPE = "Microsoft.ADAL.authority_type";
+    static final String AUTHORITY_TYPE = EVENT_PREFIX + "authority_type";
 
-    static final String API_DEPRECATED = "Microsoft.ADAL.is_deprecated"; // Android only
+    static final String API_DEPRECATED = EVENT_PREFIX + "is_deprecated"; // Android only
 
-    static final String AUTHORITY_VALIDATION = "Microsoft.ADAL.authority_validation_status";
+    static final String AUTHORITY_VALIDATION = EVENT_PREFIX + "authority_validation_status";
 
-    static final String PROMPT_BEHAVIOR = "Microsoft.ADAL.prompt_behavior";
+    static final String PROMPT_BEHAVIOR = EVENT_PREFIX + "prompt_behavior";
 
-    static final String EXTENDED_EXPIRES_ON_SETTING = "Microsoft.ADAL.extended_expires_on_setting";
+    static final String EXTENDED_EXPIRES_ON_SETTING = EVENT_PREFIX + "extended_expires_on_setting";
 
-    static final String WAS_SUCCESSFUL = "Microsoft.ADAL.is_successful";
+    static final String WAS_SUCCESSFUL = EVENT_PREFIX + "is_successful";
 
-    static final String API_ERROR_CODE = "Microsoft.ADAL.api_error_code";
+    static final String API_ERROR_CODE = EVENT_PREFIX + "api_error_code";
 
-    static final String OAUTH_ERROR_CODE = "Microsoft.ADAL.oauth_error_code";
+    static final String OAUTH_ERROR_CODE = EVENT_PREFIX + "oauth_error_code";
 
-    static final String IDP_NAME = "Microsoft.ADAL.idp";
+    static final String IDP_NAME = EVENT_PREFIX + "idp";
 
-    static final String TENANT_ID = "Microsoft.ADAL.tenant_id";
+    static final String TENANT_ID = EVENT_PREFIX + "tenant_id";
 
-    static final String LOGIN_HINT = "Microsoft.ADAL.login_hint";
+    static final String LOGIN_HINT = EVENT_PREFIX + "login_hint";
 
-    static final String USER_ID = "Microsoft.ADAL.user_id";
+    static final String USER_ID = EVENT_PREFIX + "user_id";
 
-    static final String CORRELATION_ID = "Microsoft.ADAL.correlation_id";
+    static final String CORRELATION_ID = EVENT_PREFIX + "correlation_id";
 
-    static final String DEVICE_ID = "Microsoft.ADAL.device_id";
+    static final String DEVICE_ID = EVENT_PREFIX + "device_id";
 
-    static final String REQUEST_ID = "Microsoft.ADAL.request_id";
+    static final String REQUEST_ID = EVENT_PREFIX + "request_id";
 
-    static final String START_TIME = "Microsoft.ADAL.start_time";
+    static final String START_TIME = EVENT_PREFIX + "start_time";
 
-    static final String STOP_TIME = "Microsoft.ADAL.stop_time";
+    static final String STOP_TIME = EVENT_PREFIX + "stop_time";
 
-    static final String RESPONSE_TIME = "Microsoft.ADAL.response_time";
+    static final String RESPONSE_TIME = EVENT_PREFIX + "response_time";
 
-    static final String REDIRECT_COUNT = "Microsoft.ADAL.redirect_count"; // Android only
+    static final String REDIRECT_COUNT = EVENT_PREFIX + "redirect_count"; // Android only
 
-    static final String NTLM = "Microsoft.ADAL.ntlm";
+    static final String NTLM = EVENT_PREFIX + "ntlm";
 
-    static final String USER_CANCEL = "Microsoft.ADAL.user_cancel";
+    static final String USER_CANCEL = EVENT_PREFIX + "user_cancel";
 
-    static final String BROKER_APP = "Microsoft.ADAL.broker_app";
+    static final String BROKER_APP = EVENT_PREFIX + "broker_app";
 
-    static final String BROKER_VERSION = "Microsoft.ADAL.broker_version";
+    static final String BROKER_VERSION = EVENT_PREFIX + "broker_version";
 
-    static final String BROKER_APP_USED = "Microsoft.ADAL.broker_app_used";
+    static final String BROKER_APP_USED = EVENT_PREFIX + "broker_app_used";
 
-    static final String TOKEN_TYPE = "Microsoft.ADAL.token_type";
+    static final String TOKEN_TYPE = EVENT_PREFIX + "token_type";
 
-    static final String TOKEN_TYPE_IS_RT = "Microsoft.ADAL.is_rt";
+    static final String TOKEN_TYPE_IS_RT = EVENT_PREFIX + "is_rt";
 
-    static final String TOKEN_TYPE_IS_MRRT = "Microsoft.ADAL.is_mrrt";
+    static final String TOKEN_TYPE_IS_MRRT = EVENT_PREFIX + "is_mrrt";
 
-    static final String TOKEN_TYPE_IS_FRT = "Microsoft.ADAL.is_frt";
+    static final String TOKEN_TYPE_IS_FRT = EVENT_PREFIX + "is_frt";
 
-    static final String TOKEN_TYPE_RT = "Microsoft.ADAL.rt"; // Android only
+    static final String TOKEN_TYPE_RT = EVENT_PREFIX + "rt"; // Android only
 
-    static final String TOKEN_TYPE_MRRT = "Microsoft.ADAL.mrrt"; // Android only
+    static final String TOKEN_TYPE_MRRT = EVENT_PREFIX + "mrrt"; // Android only
 
-    static final String TOKEN_TYPE_FRT = "Microsoft.ADAL.frt"; // Android only
+    static final String TOKEN_TYPE_FRT = EVENT_PREFIX + "frt"; // Android only
 
-    static final String CACHE_EVENT_COUNT = "Microsoft.ADAL.cache_event_count";
+    static final String CACHE_EVENT_COUNT = EVENT_PREFIX + "cache_event_count";
 
-    static final String UI_EVENT_COUNT = "Microsoft.ADAL.ui_event_count";
+    static final String UI_EVENT_COUNT = EVENT_PREFIX + "ui_event_count";
 
-    static final String HTTP_EVENT_COUNT = "Microsoft.ADAL.http_event_count";
+    static final String HTTP_EVENT_COUNT = EVENT_PREFIX + "http_event_count";
 
-    static final String HTTP_PATH = "Microsoft.ADAL.http_path";
+    static final String HTTP_PATH = EVENT_PREFIX + "http_path";
 
-    static final String HTTP_USER_AGENT = "Microsoft.ADAL.user_agent";
+    static final String HTTP_USER_AGENT = EVENT_PREFIX + "user_agent";
 
-    static final String HTTP_METHOD = "Microsoft.ADAL.method";
+    static final String HTTP_METHOD = EVENT_PREFIX + "method";
 
-    static final String HTTP_METHOD_POST = "Microsoft.ADAL.post";
+    static final String HTTP_METHOD_POST = EVENT_PREFIX + "post";
 
-    static final String HTTP_QUERY_PARAMETERS = "Microsoft.ADAL.query_params";
+    static final String HTTP_QUERY_PARAMETERS = EVENT_PREFIX + "query_params";
 
-    static final String HTTP_RESPONSE_CODE = "Microsoft.ADAL.response_code";
+    static final String HTTP_RESPONSE_CODE = EVENT_PREFIX + "response_code";
 
-    static final String HTTP_API_VERSION = "Microsoft.ADAL.api_version";
+    static final String HTTP_API_VERSION = EVENT_PREFIX + "api_version";
 
-    static final String REQUEST_ID_HEADER = "Microsoft.ADAL.x_ms_request_id";
+    static final String REQUEST_ID_HEADER = EVENT_PREFIX + "x_ms_request_id";
+
+    static final String SERVER_ERROR_CODE = EVENT_PREFIX + "server_error_code";
+
+    static final String SERVER_SUBERROR_CODE = EVENT_PREFIX + "server_sub_error_code";
+
+    static final String TOKEN_AGE = EVENT_PREFIX + "token_age";
+
+    static final String SPE_INFO = EVENT_PREFIX + "spe_info";
 
     // Parameter values
     static final String AUTHORITY_TYPE_ADFS = "adfs";
-    static final String AUTHORITY_TYPE_AAD = "Microsoft.ADAL.aad";
+    static final String AUTHORITY_TYPE_AAD = EVENT_PREFIX + "aad";
 
-    static final String AUTHORITY_VALIDATION_SUCCESS = "Microsoft.ADAL.authority_validation_status_success";
-    static final String AUTHORITY_VALIDATION_FAILURE = "Microsoft.ADAL.authority_validation_status_failure";
-    static final String AUTHORITY_VALIDATION_NOT_DONE = "Microsoft.ADAL.authority_validation_status_not_done";
+    static final String AUTHORITY_VALIDATION_SUCCESS = EVENT_PREFIX + "authority_validation_status_success";
+    static final String AUTHORITY_VALIDATION_FAILURE = EVENT_PREFIX + "authority_validation_status_failure";
+    static final String AUTHORITY_VALIDATION_NOT_DONE = EVENT_PREFIX + "authority_validation_status_not_done";
 
     // Broker account service related events
-    static final String BROKER_ACCOUNT_SERVICE_STARTS_BINDING = "Microsoft.ADAL.broker_account_service_starts_binding";
+    static final String BROKER_ACCOUNT_SERVICE_STARTS_BINDING = EVENT_PREFIX + "broker_account_service_starts_binding";
 
-    static final String BROKER_ACCOUNT_SERVICE_BINDING_SUCCEED = "Microsoft.ADAL.broker_account_service_binding_succeed";
+    static final String BROKER_ACCOUNT_SERVICE_BINDING_SUCCEED = EVENT_PREFIX + "broker_account_service_binding_succeed";
 
-    static final String BROKER_ACCOUNT_SERVICE_CONNECTED = "Microsoft.ADAL.broker_account_service_connected";
+    static final String BROKER_ACCOUNT_SERVICE_CONNECTED = EVENT_PREFIX + "broker_account_service_connected";
 
     // API ID
-    static final String API_ID = "Microsoft.ADAL.api_id";
+    static final String API_ID = EVENT_PREFIX + "api_id";
 
     static final String ACQUIRE_TOKEN_SILENT_SYNC = "1";
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -154,15 +154,15 @@ final class HttpEvent extends DefaultEvent {
         }
         // Set the extracted values on the HttpEvent
         if (!StringExtensions.isNullOrBlank(errorCode) && !errorCode.equals("0")) {
-            setSpeRingErrorCode(errorCode);
+            setServerErrorCode(errorCode);
         }
 
         if (!StringExtensions.isNullOrBlank(subErrorCode) && !subErrorCode.equals("0")) {
-            setSpeRingSubErrorCode(subErrorCode);
+            setServerSubErrorCode(subErrorCode);
         }
 
         if (!StringExtensions.isNullOrBlank(tokenAge)) {
-            setSpeRingTokenAge(tokenAge);
+            setRefreshTokenAge(tokenAge);
         }
 
         if (!StringExtensions.isNullOrBlank(speRing)) {
@@ -170,15 +170,15 @@ final class HttpEvent extends DefaultEvent {
         }
     }
 
-    void setSpeRingErrorCode(final String errorCode) {
+    void setServerErrorCode(final String errorCode) {
         setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
     }
 
-    void setSpeRingSubErrorCode(final String subErrorCode) {
+    void setServerSubErrorCode(final String subErrorCode) {
         setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
     }
 
-    void setSpeRingTokenAge(final String tokenAge) {
+    void setRefreshTokenAge(final String tokenAge) {
         setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
     }
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -28,6 +28,8 @@ import android.util.Pair;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 final class HttpEvent extends DefaultEvent {
 
@@ -124,12 +126,14 @@ final class HttpEvent extends DefaultEvent {
             final int delimCount = 4;
 
             // Verify the expected format "<version>, <error_code>, <sub_error_code>, <token_age>, <ring>"
-            if (delimCount != xMsCliTelem.length() - xMsCliTelem.replace(",", "").length()) {
+            Pattern headerFmt = Pattern.compile("^[1-9]+\\.?[0-9|\\.]*,[0-9|\\.]*,[0-9|\\.]*,[^,]*[0-9\\.]*,[^,]*$");
+            Matcher matcher = headerFmt.matcher(xMsCliTelem);
+            if (!matcher.matches()) {
                 Logger.w(TAG, "", "", ADALError.X_MS_CLITELEM_MALFORMED);
                 return;
             }
 
-            headerSegments = xMsCliTelem.split(",", 5);
+            headerSegments = xMsCliTelem.split(",", delimCount + 1);
 
             final int indexErrorCode = 1;
             final int indexSubErrorCode = 2;

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -222,6 +222,22 @@ final class HttpEvent extends DefaultEvent {
             dispatchMap.put(EventStrings.REQUEST_ID_HEADER, "");
         }
 
+        if (dispatchMap.containsKey(EventStrings.SERVER_ERROR_CODE)) {
+            dispatchMap.put(EventStrings.SERVER_ERROR_CODE, "");
+        }
+
+        if (dispatchMap.containsKey(EventStrings.SERVER_SUBERROR_CODE)) {
+            dispatchMap.put(EventStrings.SERVER_SUBERROR_CODE, "");
+        }
+
+        if (dispatchMap.containsKey(EventStrings.TOKEN_AGE)) {
+            dispatchMap.put(EventStrings.TOKEN_AGE, "");
+        }
+
+        if (dispatchMap.containsKey(EventStrings.SPE_INFO)) {
+            dispatchMap.put(EventStrings.SPE_INFO, "");
+        }
+
         final List<Pair<String, String>> eventList = getEventList();
         for (Pair<String, String> eventPair : eventList) {
             final String name = eventPair.first;

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -99,8 +99,6 @@ final class HttpEvent extends DefaultEvent {
         // if the header isn't present, do nothing
         if (StringExtensions.isNullOrBlank(xMsCliTelem)) {
             return;
-        } else {
-            Logger.d(TAG, "Parsing x-ms-clitelem header: " + xMsCliTelem);
         }
 
         // split the header based on the delimiter

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -87,6 +87,22 @@ final class HttpEvent extends DefaultEvent {
         setProperty(EventStrings.REQUEST_ID_HEADER, requestIdHeader);
     }
 
+    void setSpeRingErrorCode(final String errorCode) {
+        setProperty(EventStrings.SERVER_ERROR_CODE, errorCode);
+    }
+
+    void setSpeRingSubErrorCode(final String subErrorCode) {
+        setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode);
+    }
+
+    void setSpeRingTokenAge(final String tokenAge) {
+        setProperty(EventStrings.TOKEN_AGE, tokenAge);
+    }
+
+    void setSpeRingInfo(final String speRing) {
+        setProperty(EventStrings.SPE_INFO, speRing);
+    }
+
     /**
      * Each event chooses which of its members get picked on aggregation.
      * Http event adds an event count field
@@ -94,13 +110,13 @@ final class HttpEvent extends DefaultEvent {
      */
     @Override
     public void processEvent(final Map<String, String> dispatchMap) {
-        final Object countObject = dispatchMap.get(EventStrings.HTTP_EVENT_COUNT);
+        final String countObject = dispatchMap.get(EventStrings.HTTP_EVENT_COUNT);
 
         if (countObject == null) {
             dispatchMap.put(EventStrings.HTTP_EVENT_COUNT, "1");
         } else {
             dispatchMap.put(EventStrings.HTTP_EVENT_COUNT,
-                    Integer.toString(Integer.parseInt((String) countObject) + 1));
+                    Integer.toString(Integer.parseInt(countObject) + 1));
         }
 
         // If there was a previous entry clear out its fields.
@@ -124,8 +140,14 @@ final class HttpEvent extends DefaultEvent {
         for (Pair<String, String> eventPair : eventList) {
             final String name = eventPair.first;
 
-            if (name.equals(EventStrings.HTTP_RESPONSE_CODE) || name.equals(EventStrings.REQUEST_ID_HEADER)
-                    || name.equals(EventStrings.OAUTH_ERROR_CODE) || name.equals(EventStrings.HTTP_PATH)) {
+            if (name.equals(EventStrings.HTTP_RESPONSE_CODE)
+                    || name.equals(EventStrings.REQUEST_ID_HEADER)
+                    || name.equals(EventStrings.OAUTH_ERROR_CODE)
+                    || name.equals(EventStrings.HTTP_PATH)
+                    || name.equals(EventStrings.SERVER_ERROR_CODE)
+                    || name.equals(EventStrings.SERVER_SUBERROR_CODE)
+                    || name.equals(EventStrings.TOKEN_AGE)
+                    || name.equals(EventStrings.SPE_INFO)) {
                 dispatchMap.put(name, eventPair.second);
             }
         }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -223,19 +223,19 @@ final class HttpEvent extends DefaultEvent {
         }
 
         if (dispatchMap.containsKey(EventStrings.SERVER_ERROR_CODE)) {
-            dispatchMap.put(EventStrings.SERVER_ERROR_CODE, "");
+            dispatchMap.remove(EventStrings.SERVER_ERROR_CODE);
         }
 
         if (dispatchMap.containsKey(EventStrings.SERVER_SUBERROR_CODE)) {
-            dispatchMap.put(EventStrings.SERVER_SUBERROR_CODE, "");
+            dispatchMap.remove(EventStrings.SERVER_SUBERROR_CODE);
         }
 
         if (dispatchMap.containsKey(EventStrings.TOKEN_AGE)) {
-            dispatchMap.put(EventStrings.TOKEN_AGE, "");
+            dispatchMap.remove(EventStrings.TOKEN_AGE);
         }
 
         if (dispatchMap.containsKey(EventStrings.SPE_INFO)) {
-            dispatchMap.put(EventStrings.SPE_INFO, "");
+            dispatchMap.remove(EventStrings.SPE_INFO);
         }
 
         final List<Pair<String, String>> eventList = getEventList();

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -101,6 +101,12 @@ final class HttpEvent extends DefaultEvent {
         // split the header based on the delimiter
         final String[] headerSegments = xMsCliTelem.split(",");
 
+        // make sure the header isn't empty
+        if (0 == headerSegments.length) {
+            Logger.w(TAG, "SPE Ring header missing version field.", null, ADALError.X_MS_CLITELEM_VERSION_UNRECOGNIZED);
+            return;
+        }
+
         // get the version of this header
         final String headerVersion = headerSegments[0];
 
@@ -157,19 +163,19 @@ final class HttpEvent extends DefaultEvent {
     }
 
     void setSpeRingErrorCode(final String errorCode) {
-        setProperty(EventStrings.SERVER_ERROR_CODE, errorCode);
+        setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
     }
 
     void setSpeRingSubErrorCode(final String subErrorCode) {
-        setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode);
+        setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
     }
 
     void setSpeRingTokenAge(final String tokenAge) {
-        setProperty(EventStrings.TOKEN_AGE, tokenAge);
+        setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
     }
 
     void setSpeRing(final String speRing) {
-        setProperty(EventStrings.SPE_INFO, speRing);
+        setProperty(EventStrings.SPE_INFO, speRing.trim());
     }
 
     /**

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.13.2
+-------------
+Add telemetry to capture x-ms-clitelem header (tracks errors, suberrors, rt age, and SPE ring)
+
 Version 1.13.0
 -------------
 Add support for sending conditional access claims to acquire token call


### PR DESCRIPTION
This PR adds support for tracking the `SPE Ring` to Telemetry via new parsing/setters on `HttpEvent`, and minor modifications to `OAuth2`