### PR TITLE
Adds support for silent auth to SPE Ring Telemetry

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpEventTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpEventTest.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.microsoft.aad.adal.TelemetryUtils.CliTelemInfo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -107,9 +108,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingInfoStrangeFormatting() {
-        final String speHeader = "1 , ,, ,";
+        final String speHeaderStr = "1 , ,, ,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -120,9 +122,10 @@ public final class HttpEventTest {
 
     @Test
     public void testEmptySpeRingInfo() {
-        final String speHeader = ",,,,";
+        final String speHeaderStr = ",,,,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -133,9 +136,10 @@ public final class HttpEventTest {
 
     @Test
     public void testVersionOnlySpeRingInfo() {
-        final String speHeader = "1,,,,";
+        final String speHeaderStr = "1,,,,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -146,9 +150,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWithVersionAndAgeOnly() {
-        final String speHeader = "1,,,1234.1234,";
+        final String speHeaderStr = "1,,,1234.1234,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -159,9 +164,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingInfoWithBlankFieldsInnerRing() {
-        final String speHeader = "1,0,0,,I";
+        final String speHeaderStr = "1,0,0,,I";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -172,9 +178,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingInfoWithSubErrorCodeAndAgeOnly() {
-        final String speHeader = "1,,1,1234.1234,";
+        final String speHeaderStr = "1,,1,1234.1234,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -185,9 +192,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWithUnsupportedVersion() {
-        final String speHeader = "2,1,2,3.3,I";
+        final String speHeaderStr = "2,1,2,3.3,I";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -198,9 +206,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWithErrorAndSubError() {
-        final String speHeader = "1,2,3,,";
+        final String speHeaderStr = "1,2,3,,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals("2", dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -211,9 +220,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWithLeadingWhitespaceAgeInner() {
-        final String speHeader = "1,,, 1234.1234,I";
+        final String speHeaderStr = "1,,, 1234.1234,I";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -224,9 +234,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWithVersionAndRingOnly() {
-        final String speHeader = "1,,,,I";
+        final String speHeaderStr = "1,,,,I";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -237,9 +248,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpedRingEmpty() {
-        final String speHeader = "";
+        final String speHeaderStr = "";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -250,9 +262,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWrongLength1() {
-        final String speHeader = ",";
+        final String speHeaderStr = ",";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -263,9 +276,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWrongLength2() {
-        final String speHeader = ",,";
+        final String speHeaderStr = ",,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -276,9 +290,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingWrongLength3() {
-        final String speHeader = ",,,";
+        final String speHeaderStr = ",,,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -289,9 +304,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingTooLong() {
-        final String speHeader = ",,,,,";
+        final String speHeaderStr = ",,,,,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -302,9 +318,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingTooShort() {
-        final String speHeader = "1,00";
+        final String speHeaderStr = "1,00";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -315,9 +332,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingTooShort2() {
-        final String speHeader = "1,0,0";
+        final String speHeaderStr = "1,0,0";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -328,9 +346,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingTooShort3() {
-        final String speHeader = "1,1,1,";
+        final String speHeaderStr = "1,1,1,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -341,9 +360,10 @@ public final class HttpEventTest {
 
     @Test
     public void testSpeRingTooLong2() {
-        final String speHeader = "1,1,1,,,";
+        final String speHeaderStr = "1,1,1,,,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -354,9 +374,10 @@ public final class HttpEventTest {
 
     @Test
     public void testVersionWithMajorMinor() {
-        final String speHeader = "1.2,1,2,12.34,";
+        final String speHeaderStr = "1.2,1,2,12.34,";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -367,9 +388,10 @@ public final class HttpEventTest {
 
     @Test
     public void testVersionWithMajorMinorPatch() {
-        final String speHeader = "1.2.3,1,2,12.34,I";
+        final String speHeaderStr = "1.2.3,1,2,12.34,I";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));
@@ -380,9 +402,10 @@ public final class HttpEventTest {
 
     @Test
     public void testMultiDigitVersionWithMajorMinorPatch() {
-        final String speHeader = "11.22.33,1,2,12.34,I";
+        final String speHeaderStr = "11.22.33,1,2,12.34,I";
+        final CliTelemInfo cliTelemInfo = TelemetryUtils.parseXMsCliTelemHeader(speHeaderStr);
         final HttpEvent event = new HttpEvent(EventStrings.HTTP_EVENT);
-        event.setXMsCliTelemData(speHeader);
+        event.setXMsCliTelemData(cliTelemInfo);
         final Map<String, String> dispatchMap = new HashMap<>();
         event.processEvent(dispatchMap);
         assertEquals(null, dispatchMap.get(EventStrings.SERVER_ERROR_CODE));

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -89,6 +89,8 @@ public class AuthenticationResult implements Serializable {
 
     private Date mExtendedExpiresOn;
 
+    private String mSpeRing;
+
     AuthenticationResult() {
         mCode = null;
     }
@@ -371,5 +373,13 @@ public class AuthenticationResult implements Serializable {
     
     final void setFamilyClientId(final String familyClientId) {
         mFamilyClientId = familyClientId;
+    }
+
+    final String getSpeRing() {
+        return mSpeRing;
+    }
+
+    final void setSpeRing(final String speRing) {
+        mSpeRing = speRing;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -101,6 +101,7 @@ class TokenCacheAccessor {
 
         if (item != null) {
             cacheEvent.setTokenTypeRT(true);
+            cacheEvent.setSpeRing(item.getSpeRing());
         }
         Telemetry.getInstance().stopEvent(mTelemetryRequestId, cacheEvent, EventStrings.TOKEN_CACHE_LOOKUP);
 

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheItem.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheItem.java
@@ -67,6 +67,8 @@ public class TokenCacheItem implements Serializable {
 
     private Date mExtendedExpiresOn;
 
+    private String mSpeRing;
+
     /**
      * Default constructor for cache item.
      */
@@ -87,6 +89,7 @@ public class TokenCacheItem implements Serializable {
         mTenantId = tokenCacheItem.getTenantId();
         mFamilyClientId = tokenCacheItem.getFamilyClientId();
         mExtendedExpiresOn = tokenCacheItem.getExtendedExpiresOn();
+        mSpeRing = tokenCacheItem.getSpeRing();
     }
     
     /**
@@ -112,6 +115,7 @@ public class TokenCacheItem implements Serializable {
         mRefreshtoken = authenticationResult.getRefreshToken();
         mFamilyClientId = authenticationResult.getFamilyClientId();
         mExtendedExpiresOn = authenticationResult.getExtendedExpiresOn();
+        mSpeRing = authenticationResult.getSpeRing();
     }
 
     /**
@@ -145,7 +149,7 @@ public class TokenCacheItem implements Serializable {
     public static TokenCacheItem createMRRTTokenCacheItem(final String authority, final String clientId, final AuthenticationResult authResult) {
         final TokenCacheItem item = new TokenCacheItem(authority, authResult);
         item.setClientId(clientId);
-        
+
         return item;
     }
 
@@ -434,6 +438,14 @@ public class TokenCacheItem implements Serializable {
      */
     boolean isFamilyToken() {
         return !StringExtensions.isNullOrBlank(mFamilyClientId);
+    }
+
+    String getSpeRing() {
+        return mSpeRing;
+    }
+
+    void setSpeRing(final String speRing) {
+        mSpeRing = speRing;
     }
 }
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
@@ -36,6 +36,10 @@ final class CacheEvent extends DefaultEvent {
         setProperty(EventStrings.EVENT_NAME, eventName);
     }
 
+    void setSpeRing(final String speRing) {
+        setProperty(EventStrings.SPE_INFO, speRing.trim());
+    }
+
     void setTokenType(final String tokenType) {
         getEventList().add(Pair.create(EventStrings.TOKEN_TYPE, tokenType));
     }
@@ -84,7 +88,7 @@ final class CacheEvent extends DefaultEvent {
             final String name = eventPair.first;
 
             if (name.equals(EventStrings.TOKEN_TYPE_IS_FRT) || name.equals(EventStrings.TOKEN_TYPE_IS_RT)
-                    || name.equals(EventStrings.TOKEN_TYPE_IS_MRRT)) {
+                    || name.equals(EventStrings.TOKEN_TYPE_IS_MRRT) || name.equals(EventStrings.SPE_INFO)) {
                 dispatchMap.put(name, eventPair.second);
             }
         }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
@@ -37,7 +37,9 @@ final class CacheEvent extends DefaultEvent {
     }
 
     void setSpeRing(final String speRing) {
-        setProperty(EventStrings.SPE_INFO, speRing.trim());
+        if (null != speRing) {
+            setProperty(EventStrings.SPE_INFO, speRing.trim());
+        }
     }
 
     void setTokenType(final String tokenType) {

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -117,19 +117,29 @@ final class HttpEvent extends DefaultEvent {
     }
 
     void setServerErrorCode(final String errorCode) {
-        setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
+        if (null != errorCode) {
+            setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
+        }
     }
 
     void setServerSubErrorCode(final String subErrorCode) {
-        setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
+        if (null != subErrorCode) {
+            setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
+
+        }
     }
 
     void setRefreshTokenAge(final String tokenAge) {
-        setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
+        if (null != tokenAge) {
+            setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
+
+        }
     }
 
     void setSpeRing(final String speRing) {
-        setProperty(EventStrings.SPE_INFO, speRing.trim());
+        if (null != speRing) {
+            setProperty(EventStrings.SPE_INFO, speRing.trim());
+        }
     }
 
     /**

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -28,8 +28,8 @@ import android.util.Pair;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import static com.microsoft.aad.adal.TelemetryUtils.CliTelemInfo;
 
 final class HttpEvent extends DefaultEvent {
 
@@ -92,83 +92,27 @@ final class HttpEvent extends DefaultEvent {
         setProperty(EventStrings.REQUEST_ID_HEADER, requestIdHeader);
     }
 
-    /**
-     * Parses and sets the relevant HttpEvent fields given x-ms-clitelem metadata.
-     *
-     * @param xMsCliTelem the value of the x-ms-clitelem header
-     */
-    void setXMsCliTelemData(final String xMsCliTelem) {
-        // if the header isn't present, do nothing
-        if (StringExtensions.isNullOrBlank(xMsCliTelem)) {
+    void setXMsCliTelemData(final CliTelemInfo cliTelemInfo) {
+        if (null == cliTelemInfo) {
             return;
         }
 
-        // split the header based on the delimiter
-        String[] headerSegments = xMsCliTelem.split(",");
-
-        // make sure the header isn't empty
-        if (0 == headerSegments.length) {
-            Logger.w(TAG, "SPE Ring header missing version field.", null, ADALError.X_MS_CLITELEM_VERSION_UNRECOGNIZED);
-            return;
+        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getServerErrorCode())
+                && !cliTelemInfo.getServerErrorCode().equals("0")) {
+            setServerErrorCode(cliTelemInfo.getServerErrorCode());
         }
 
-        // get the version of this header
-        final String headerVersion = headerSegments[0];
-
-        // declare values tracked by this header
-        String errorCode = null;
-        String subErrorCode = null;
-        String tokenAge = null;
-        String speRing = null;
-
-        if (headerVersion.equals("1")) {
-            // The expected delimiter count of the v1 header
-            final int delimCount = 4;
-
-            // Verify the expected format "<version>, <error_code>, <sub_error_code>, <token_age>, <ring>"
-            Pattern headerFmt = Pattern.compile("^[1-9]+\\.?[0-9|\\.]*,[0-9|\\.]*,[0-9|\\.]*,[^,]*[0-9\\.]*,[^,]*$");
-            Matcher matcher = headerFmt.matcher(xMsCliTelem);
-            if (!matcher.matches()) {
-                Logger.w(TAG, "", "", ADALError.X_MS_CLITELEM_MALFORMED);
-                return;
-            }
-
-            headerSegments = xMsCliTelem.split(",", delimCount + 1);
-
-            final int indexErrorCode = 1;
-            final int indexSubErrorCode = 2;
-            final int indexTokenAge = 3;
-            final int indexSpeInfo = 4;
-
-            // get the error_code
-            errorCode = headerSegments[indexErrorCode];
-
-            // get the sub_error_code
-            subErrorCode = headerSegments[indexSubErrorCode];
-
-            // get the token_age
-            tokenAge = headerSegments[indexTokenAge];
-
-            // get the spe_ring
-            speRing = headerSegments[indexSpeInfo];
-        } else { // unrecognized version
-            Logger.w(TAG, "Unexpected header version: " + headerVersion, null, ADALError.X_MS_CLITELEM_VERSION_UNRECOGNIZED);
-        }
-        // Set the extracted values on the HttpEvent
-        if (!StringExtensions.isNullOrBlank(errorCode) && !errorCode.equals("0")) {
-            setServerErrorCode(errorCode);
+        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getServerSubErrorCode())
+                && !cliTelemInfo.getServerSubErrorCode().equals("0")) {
+            setServerSubErrorCode(cliTelemInfo.getServerSubErrorCode());
         }
 
-        if (!StringExtensions.isNullOrBlank(subErrorCode) && !subErrorCode.equals("0")) {
-            setServerSubErrorCode(subErrorCode);
+        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getRefreshTokenAge())) {
+            setRefreshTokenAge(cliTelemInfo.getRefreshTokenAge());
         }
 
-        if (!StringExtensions.isNullOrBlank(tokenAge)) {
-            setRefreshTokenAge(tokenAge);
-        }
-
-        if (!StringExtensions.isNullOrBlank(speRing)) {
-            setSpeRing(speRing);
+        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getSpeRing())) {
+            setSpeRing(cliTelemInfo.getSpeRing());
         }
     }
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class TelemetryUtils {
+
+    private static final String TAG = TelemetryUtils.class.getSimpleName();
+
+    static class CliTelemInfo {
+
+        private String mVersion;
+        private String mServerErrorCode;
+        private String mServerSubErrorCode;
+        private String mRefreshTokenAge;
+        private String mSpeRing;
+
+        String getVersion() {
+            return mVersion;
+        }
+
+        void setVersion(String mVersion) {
+            this.mVersion = mVersion;
+        }
+
+        String getServerErrorCode() {
+            return mServerErrorCode;
+        }
+
+        void setServerErrorCode(String mServerErrorCode) {
+            this.mServerErrorCode = mServerErrorCode;
+        }
+
+        String getServerSubErrorCode() {
+            return mServerSubErrorCode;
+        }
+
+        void setServerSubErrorCode(String mServerSubErrorCode) {
+            this.mServerSubErrorCode = mServerSubErrorCode;
+        }
+
+        String getRefreshTokenAge() {
+            return mRefreshTokenAge;
+        }
+
+        void setRefreshTokenAge(String mRefreshTokenAge) {
+            this.mRefreshTokenAge = mRefreshTokenAge;
+        }
+
+        String getSpeRing() {
+            return mSpeRing;
+        }
+
+        void setSpeRing(String mSpeRing) {
+            this.mSpeRing = mSpeRing;
+        }
+    }
+
+    static CliTelemInfo parseXMsCliTelemHeader(final String headerValue) {
+        // if the header isn't present, do nothing
+        if (StringExtensions.isNullOrBlank(headerValue)) {
+            return null;
+        }
+
+        // split the header based on the delimiter
+        String[] headerSegments = headerValue.split(",");
+
+        // make sure the header isn't empty
+        if (0 == headerSegments.length) {
+            Logger.w(TAG, "SPE Ring header missing version field.", null, ADALError.X_MS_CLITELEM_VERSION_UNRECOGNIZED);
+            return null;
+        }
+
+        // get the version of this header
+        final String headerVersion = headerSegments[0];
+
+        // The eventual result
+        final CliTelemInfo cliTelemInfo = new CliTelemInfo();
+        cliTelemInfo.setVersion(headerVersion);
+
+        if (headerVersion.equals("1")) {
+            // The expected delimiter count of the v1 header
+            final int delimCount = 4;
+
+            // Verify the expected format "<version>, <error_code>, <sub_error_code>, <token_age>, <ring>"
+            Pattern headerFmt = Pattern.compile("^[1-9]+\\.?[0-9|\\.]*,[0-9|\\.]*,[0-9|\\.]*,[^,]*[0-9\\.]*,[^,]*$");
+            Matcher matcher = headerFmt.matcher(headerValue);
+            if (!matcher.matches()) {
+                Logger.w(TAG, "", "", ADALError.X_MS_CLITELEM_MALFORMED);
+                return null;
+            }
+
+            headerSegments = headerValue.split(",", delimCount + 1);
+
+            // Constants used to identify value position
+            final int indexErrorCode = 1;
+            final int indexSubErrorCode = 2;
+            final int indexTokenAge = 3;
+            final int indexSpeInfo = 4;
+
+            cliTelemInfo.setServerErrorCode(headerSegments[indexErrorCode]);
+            cliTelemInfo.setServerSubErrorCode(headerSegments[indexSubErrorCode]);
+            cliTelemInfo.setRefreshTokenAge(headerSegments[indexTokenAge]);
+            cliTelemInfo.setSpeRing(headerSegments[indexSpeInfo]);
+        } else { // unrecognized version
+            Logger.w(TAG, "Unexpected header version: " + headerVersion, null, ADALError.X_MS_CLITELEM_VERSION_UNRECOGNIZED);
+            return null;
+        }
+
+        return cliTelemInfo;
+    }
+
+}

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
@@ -28,6 +28,10 @@ import java.util.regex.Pattern;
 
 final class TelemetryUtils {
 
+    private TelemetryUtils() {
+        // Intentionally left blank.
+    }
+
     private static final String TAG = TelemetryUtils.class.getSimpleName();
 
     static class CliTelemInfo {


### PR DESCRIPTION
Extension of #955 to add support for silent scenarios.

This change adds in a new intermediate object to separate parsing logic from `HttpEvent` as this data is now shared with `CacheEvent`. The parsing has been extracted to a `TelemetryUtils` class; the parsed data is stored in instances of `TelemetryUtils.CliTelemInfo`

This change adds a new field to `TokenCacheItem`, `AuthenticationResult`, and `CacheEvent` to support serialization/tracking of SPE Ring.

Tests have also been updated to include the new `CliTelemInfo` object.