### PR TITLE
 authority validation update cache

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -47,7 +47,7 @@ android {
     }
     buildTypes {
         debug {
-//            testCoverageEnabled true
+            testCoverageEnabled true
         }
         release {
             minifyEnabled false

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -47,7 +47,7 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled true
+//            testCoverageEnabled true
         }
         release {
             minifyEnabled false

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -25,12 +25,12 @@ package com.microsoft.aad.adal;
 import android.content.Context;
 import android.os.Build;
 import android.support.test.filters.SdkSuppress;
-import android.test.suitebuilder.annotation.SmallTest;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.SmallTest;
 
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,9 +42,11 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.UUID;
 
 import javax.crypto.SecretKey;
@@ -52,7 +54,6 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import static android.R.attr.minSdkVersion;
 import static android.support.test.InstrumentationRegistry.getContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -94,6 +95,11 @@ public final class AcquireTokenSilentHandlerTest {
             SecretKey secretKey = new SecretKeySpec(tempkey.getEncoded(), "AES");
             AuthenticationSettings.INSTANCE.setSecretKey(secretKey.getEncoded());
         }
+    }
+
+    @After
+    public void tearDown() {
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
     }
 
     /**
@@ -880,21 +886,357 @@ public final class AcquireTokenSilentHandlerTest {
         clearCache(mockedCache);
     }
 
+    @Test
+    public void testRTExistedInPreferredCache() throws IOException {
+        final FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        clearCache(mockedCache);
+
+        updateAuthorityMetadataCache();
+        // insert token with authority as preferred cache
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        // Add regular RT item without RT in the cache
+        final String preferredCacheAuthority = "https://preferred.cache/test.onmicrosoft.com";
+        final String rtForPreferredCache = "rt with preferred cache";
+        final TokenCacheItem rtTokenCacheItem = Util.getTokenCacheItem(preferredCacheAuthority, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        rtTokenCacheItem.setRefreshToken(rtForPreferredCache);
+        rtTokenCacheItem.setIsMultiResourceRefreshToken(false);
+        saveTokenIntoCache(mockedCache, rtTokenCacheItem);
+
+        // insert token with authority as aliased host
+        final String testHostAuthority = "https://test.host/test.onmicrosoft.com";
+        final TokenCacheItem itemWithTestHost = Util.getTokenCacheItem(testHostAuthority, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        itemWithTestHost.setRefreshToken("rt with test host");
+        saveTokenIntoCache(mockedCache, itemWithTestHost);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest(testHostAuthority, resource, clientId, false);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        // inject mocked web request handler
+        final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(rtForPreferredCache, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(false, false), null));
+
+        acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
+
+        try {
+            final AuthenticationResult result = acquireTokenSilentHandler.getAccessToken();
+            assertNotNull(result);
+            assertNotNull(result.getAccessToken());
+        } catch (final AuthenticationException e) {
+            fail();
+        }
+
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(
+                        Util.getPoseMessage(rtForPreferredCache, clientId, resource)), Mockito.anyString());
+
+        // verify token items
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheAuthority, resource, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheAuthority, resource, clientId, TEST_IDTOKEN_UPN)));
+        clearCache(mockedCache);
+    }
+
+    @Test
+    public void testMRRTExistInPreferredLocation() throws IOException {
+        final FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        clearCache(mockedCache);
+
+        updateAuthorityMetadataCache();
+        // insert token with authority as preferred cache
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        final String preferredCacheAuthority = "https://preferred.cache/test.onmicrosoft.com";
+        final String mrrtForPreferredCache = "rt with preferred cache";
+        final TokenCacheItem mrrtTokenCacheItem = Util.getTokenCacheItem(preferredCacheAuthority, null, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        mrrtTokenCacheItem.setRefreshToken(mrrtForPreferredCache);
+        mrrtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        saveTokenIntoCache(mockedCache, mrrtTokenCacheItem);
+
+        final String testHostAuthority = "https://test.host/test.onmicrosoft.com";
+        final TokenCacheItem mrrtWithTestHost = Util.getTokenCacheItem(testHostAuthority, null, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        mrrtWithTestHost.setRefreshToken("rt with test host");
+        saveTokenIntoCache(mockedCache, mrrtWithTestHost);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest(testHostAuthority, resource, clientId, false);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        // inject mocked web request handler
+        final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtForPreferredCache, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(false, false), null));
+
+        acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
+
+        try {
+            final AuthenticationResult result = acquireTokenSilentHandler.getAccessToken();
+            assertNotNull(result);
+            assertNotNull(result.getAccessToken());
+        } catch (final AuthenticationException e) {
+            fail();
+        }
+
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(
+                        Util.getPoseMessage(mrrtForPreferredCache, clientId, resource)), Mockito.anyString());
+
+        // verify token items
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(preferredCacheAuthority, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(preferredCacheAuthority, clientId, TEST_IDTOKEN_UPN)));
+        clearCache(mockedCache);
+    }
+
+    @Test
+    public void testFRTExistedInPreferredLocation() throws IOException {
+        final FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        clearCache(mockedCache);
+
+        updateAuthorityMetadataCache();
+        // insert token with authority as preferred cache
+        final String resource = "resource";
+        final String clientId = "clientId";
+        final String familyClientId = "1";
+
+        final String preferredCacheAuthority = "https://preferred.cache/test.onmicrosoft.com";
+        final String frtForPreferredCache = "frt with preferred cache";
+        final TokenCacheItem frtTokenCacheItem = Util.getTokenCacheItem(preferredCacheAuthority, null, null,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        frtTokenCacheItem.setRefreshToken(frtForPreferredCache);
+        frtTokenCacheItem.setIsMultiResourceRefreshToken(true);
+        frtTokenCacheItem.setFamilyClientId(familyClientId);
+        saveTokenIntoCache(mockedCache, frtTokenCacheItem);
+
+        final String testHostAuthority = "https://test.host/test.onmicrosoft.com";
+        final TokenCacheItem frtWithTestHost = Util.getTokenCacheItem(testHostAuthority, null, null,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        frtWithTestHost.setRefreshToken("frt with test host");
+        frtWithTestHost.setFamilyClientId(familyClientId);
+        saveTokenIntoCache(mockedCache, frtWithTestHost);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest(testHostAuthority, resource, clientId, false);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        // inject mocked web request handler
+        final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(frtForPreferredCache, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(true, true), null));
+
+        acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
+
+        try {
+            final AuthenticationResult result = acquireTokenSilentHandler.getAccessToken();
+            assertNotNull(result);
+            assertNotNull(result.getAccessToken());
+        } catch (final AuthenticationException e) {
+            fail();
+        }
+
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(
+                        Util.getPoseMessage(frtForPreferredCache, clientId, resource)), Mockito.anyString());
+
+        // verify token items
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForFRT(preferredCacheAuthority, familyClientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForFRT(preferredCacheAuthority, familyClientId, TEST_IDTOKEN_UPN)));
+        clearCache(mockedCache);
+    }
+
+    /**
+     * If a token is not present for preferred_cache, but available for the developer specified authority, as well as other alias,
+     * the developer specified authority token is used.
+     */
+    @Test
+    public void testTokenPresentForPassedInAuthorityAndOtherAliasedHost() throws IOException {
+        final FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        clearCache(mockedCache);
+
+        updateAuthorityMetadataCache();
+        // insert token with authority as other aliased host
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        // Add regular RT item without RT in the cache
+        final String aliasedAuthority = "https://test.alias/test.onmicrosoft.com";
+        final String rtForAliashedHost = "rt with aliased authority";
+        final TokenCacheItem rtTokenCacheItem = Util.getTokenCacheItem(aliasedAuthority, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        rtTokenCacheItem.setRefreshToken(rtForAliashedHost);
+        rtTokenCacheItem.setIsMultiResourceRefreshToken(false);
+        saveTokenIntoCache(mockedCache, rtTokenCacheItem);
+
+        // insert token with authority as aliased host
+        final String testHostAuthority = "https://test.host/test.onmicrosoft.com";
+        final String rtForTestHost = "rt for test host";
+        final TokenCacheItem itemWithTestHost = Util.getTokenCacheItem(testHostAuthority, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        itemWithTestHost.setRefreshToken(rtForTestHost);
+        saveTokenIntoCache(mockedCache, itemWithTestHost);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest(testHostAuthority, resource, clientId, false);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        // inject mocked web request handler
+        final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
+        // MRRT request fails with invalid_grant
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(Util.getPoseMessage(rtForTestHost, clientId, resource)),
+                Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(false, false), null));
+
+        acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
+
+        try {
+            final AuthenticationResult result = acquireTokenSilentHandler.getAccessToken();
+            assertNotNull(result);
+            assertNotNull(result.getAccessToken());
+        } catch (final AuthenticationException e) {
+            fail();
+        }
+
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(),
+                AdditionalMatchers.aryEq(
+                        Util.getPoseMessage(rtForTestHost, clientId, resource)), Mockito.anyString());
+
+        // verify token items
+        final String preferredCacheLocation = "https://preferred.cache/test.onmicrosoft.com";
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheLocation, resource, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheLocation, resource, clientId, TEST_IDTOKEN_UPN)));
+        clearCache(mockedCache);
+    }
+
+    @Test
+    public void testTokenForAliasedAuthorityPresent() throws IOException {
+        final FileMockContext mockContext = new FileMockContext(getContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        clearCache(mockedCache);
+
+        updateAuthorityMetadataCache();
+        // insert token with authority as other aliased host
+        final String resource = "resource";
+        final String clientId = "clientId";
+
+        // Add regular RT item without RT in the cache
+        final String aliasedAuthority = "https://test.alias/test.onmicrosoft.com";
+        final String rtForAliashedHost = "rt with aliased authority";
+        final TokenCacheItem rtTokenCacheItem = Util.getTokenCacheItem(aliasedAuthority, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        rtTokenCacheItem.setRefreshToken(rtForAliashedHost);
+        rtTokenCacheItem.setIsMultiResourceRefreshToken(false);
+        saveTokenIntoCache(mockedCache, rtTokenCacheItem);
+
+        // insert token with authority as aliased host
+        final String preferredNetworkAuthority = "https://preferred.network/test.onmicrosoft.com";
+        final String rtForPreferredNetwork = "rt for preferred network";
+        final TokenCacheItem itemWithPreferredNetwork = Util.getTokenCacheItem(preferredNetworkAuthority, resource, clientId,
+                TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        itemWithPreferredNetwork.setRefreshToken(rtForPreferredNetwork);
+        saveTokenIntoCache(mockedCache, itemWithPreferredNetwork);
+
+        final AuthenticationRequest authenticationRequest = getAuthenticationRequest("https://test.host/test.onmicrosoft.com", resource, clientId, false);
+        authenticationRequest.setUserIdentifierType(UserIdentifierType.UniqueId);
+        authenticationRequest.setUserId(TEST_IDTOKEN_USERID);
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = getAcquireTokenHandler(mockContext,
+                authenticationRequest, mockedCache);
+
+        // inject mocked web request handler
+        final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
+        // MRRT request fails with invalid_grant
+        Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.anyMap(),
+                (byte[]) Mockito.any(), Mockito.anyString())).thenReturn(
+                new HttpWebResponse(HttpURLConnection.HTTP_OK,
+                        Util.getSuccessTokenResponse(false, false), null));
+
+        acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
+
+        try {
+            final AuthenticationResult result = acquireTokenSilentHandler.getAccessToken();
+            assertNotNull(result);
+            assertNotNull(result.getAccessToken());
+        } catch (final AuthenticationException e) {
+            fail();
+        }
+
+        Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
+                Mockito.any(URL.class), Mockito.anyMap(), (byte[]) Mockito.any(), Mockito.anyString());
+
+        // verify token items
+        final String preferredCacheLocation = "https://preferred.cache/test.onmicrosoft.com";
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheLocation, resource, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheLocation, resource, clientId, TEST_IDTOKEN_UPN)));
+        clearCache(mockedCache);
+    }
+
+    private void updateAuthorityMetadataCache() {
+        final InstanceDiscoveryMetadata metadata = getInstanceDiscoveryMetadata();
+        for (final String alias : metadata.getAliases()) {
+            AuthorityValidationMetadataCache.updateInstanceDiscoveryMap(alias, metadata);
+        }
+    }
+
+    private InstanceDiscoveryMetadata getInstanceDiscoveryMetadata() {
+        final String preferredNetwork = "preferred.network";
+        final String preferredCacheLocation = "preferred.cache";
+
+        final List<String> aliases = new ArrayList<>();
+        aliases.add("preferred.network");
+        aliases.add("preferred.cache");
+        aliases.add("test.host");
+        aliases.add("test.alias");
+
+        return new InstanceDiscoveryMetadata(preferredNetwork, preferredCacheLocation, aliases);
+    }
+
     private void saveTokenIntoCache(final ITokenCacheStore mockedCache, final TokenCacheItem token) {
         if (!StringExtensions.isNullOrBlank(token.getResource())) {
-            mockedCache.setItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, token.getResource(), token.getClientId(),
+            mockedCache.setItem(CacheKey.createCacheKeyForRTEntry(token.getAuthority(), token.getResource(), token.getClientId(),
                     token.getUserInfo().getUserId()), token);
-            mockedCache.setItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, token.getResource(), token.getClientId(),
+            mockedCache.setItem(CacheKey.createCacheKeyForRTEntry(token.getAuthority(), token.getResource(), token.getClientId(),
                     token.getUserInfo().getDisplayableId()), token);
         } else if (StringExtensions.isNullOrBlank(token.getClientId())) {
-            mockedCache.setItem(CacheKey.createCacheKeyForFRT(VALID_AUTHORITY, token.getFamilyClientId(),
+            mockedCache.setItem(CacheKey.createCacheKeyForFRT(token.getAuthority(), token.getFamilyClientId(),
                     token.getUserInfo().getUserId()), token);
-            mockedCache.setItem(CacheKey.createCacheKeyForFRT(VALID_AUTHORITY, token.getFamilyClientId(),
+            mockedCache.setItem(CacheKey.createCacheKeyForFRT(token.getAuthority(), token.getFamilyClientId(),
                     token.getUserInfo().getDisplayableId()), token);
         } else {
-            mockedCache.setItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, token.getClientId(),
+            mockedCache.setItem(CacheKey.createCacheKeyForMRRT(token.getAuthority(), token.getClientId(),
                     token.getUserInfo().getUserId()), token);
-            mockedCache.setItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, token.getClientId(),
+            mockedCache.setItem(CacheKey.createCacheKeyForMRRT(token.getAuthority(), token.getClientId(),
                     token.getUserInfo().getDisplayableId()), token);
         }
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -27,6 +27,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
@@ -46,6 +47,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -59,10 +61,20 @@ import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import javax.crypto.NoSuchPaddingException;
@@ -71,6 +83,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import static android.R.attr.resource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -79,7 +92,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public final class AuthenticationContextTest {
@@ -390,6 +407,7 @@ public final class AuthenticationContextTest {
     @Test
     public void testAcquireTokenUserId() throws InterruptedException {
         FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
         final AuthenticationContext context = getAuthenticationContext(mockContext,
                 "https://login.windows.net/common", false, null);
 
@@ -1170,6 +1188,401 @@ public final class AuthenticationContextTest {
         clearCache(context);
     }
 
+    /**
+     * When an authority is invalid, but the validation is not required:
+     * a. ADAL still behaves correctly using developer provided authority
+     * b. Subsequent requests do not result in further authority validation network requests for the process lifetime.
+     */
+    @Test
+    public void testAuthorityValidationTurnedOffAndInstanceDiscoveryFailed() throws IOException, InterruptedException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final ITokenCacheStore mockedCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockedCache);
+        final Activity mockActivity = Mockito.mock(Activity.class);
+
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+
+        // The first network call would be doing instance discovery, the second one is refresh token request.
+        // mock another silent request will only do token refresh
+        Mockito.when(mockedConnection.getInputStream()).thenThrow(new IOException())
+                .thenReturn(Util.createInputStream(Util.getSuccessTokenResponse(true, true)),
+                Util.createInputStream(Util.getSuccessTokenResponse(true, false)));
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_OK);
+
+        // clear the authority validation map
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+        final CountDownLatch latch = new CountDownLatch(1);
+        context.acquireToken(mockActivity, "resource", "clientid", "redirectUri", TEST_IDTOKEN_UPN, new AuthenticationCallback<AuthenticationResult>() {
+            @Override
+            public void onSuccess(AuthenticationResult result) {
+                try {
+                    Assert.assertTrue(result.getAccessToken().equals("I am a new access token"));
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                Assert.fail();
+            }
+        });
+
+        latch.await();
+
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        Iterator<TokenCacheItem> items = context.getCache().getAll();
+        while (items.hasNext()) {
+            final TokenCacheItem item = items.next();
+            item.setExpiresOn(new Date());
+        }
+
+        context.acquireTokenSilentAsync("resource", "clientId", TEST_IDTOKEN_USERID, new AuthenticationCallback<AuthenticationResult>() {
+            @Override
+            public void onSuccess(AuthenticationResult result) {
+                try {
+                    Assert.assertTrue(result.getAccessToken().equals("I am a new access token"));
+                } finally {
+                    latch2.countDown();
+                }
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                Assert.fail();
+            }
+        });
+
+        latch2.await();
+
+        Mockito.verify(mockedConnection, times(3)).getInputStream();
+
+        // Clean up Authority validation cache
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+    }
+
+    /**
+     * When an authority is valid, but no metadata is returned:
+     * a.ADAL still behaves correctly using developer provided authority
+     * b.Subsequent requests do not result in further authority validation network requests for the process lifetime
+     */
+    @Test
+    public void testAuthorityValidationTurnedOnButNoMetadataReturned() throws IOException, InterruptedException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final ITokenCacheStore mockedCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, true, mockedCache);
+        final Activity mockActivity = Mockito.mock(Activity.class);
+
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+
+        // The first network call would be doing instance discovery, the second one is refresh token request.
+        // mock another silent request will only do token refresh
+        final String tenantDiscoveryResponse = "{\"tenant_discovery_endpoint\":\"valid endpoint\"}";
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(
+                Util.createInputStream(tenantDiscoveryResponse),
+                Util.createInputStream(Util.getSuccessTokenResponse(true, true)),
+                Util.createInputStream(Util.getSuccessTokenResponse(true, false)));
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        // clear the authority validation map
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+        final CountDownLatch latch = new CountDownLatch(1);
+        context.acquireToken(mockActivity, "resource", "clientid", "redirectUri", TEST_IDTOKEN_UPN, new AuthenticationCallback<AuthenticationResult>() {
+            @Override
+            public void onSuccess(AuthenticationResult result) {
+                try {
+                    Assert.assertTrue(result.getAccessToken().equals("I am a new access token"));
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                Assert.fail();
+            }
+        });
+
+        latch.await();
+
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        Iterator<TokenCacheItem> items = context.getCache().getAll();
+        while (items.hasNext()) {
+            final TokenCacheItem item = items.next();
+            item.setExpiresOn(new Date());
+        }
+
+        context.acquireTokenSilentAsync("resource", "clientId", TEST_IDTOKEN_USERID, new AuthenticationCallback<AuthenticationResult>() {
+            @Override
+            public void onSuccess(AuthenticationResult result) {
+                try {
+                    Assert.assertTrue(result.getAccessToken().equals("I am a new access token"));
+                } finally {
+                    latch2.countDown();
+                }
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                Assert.fail();
+            }
+        });
+
+        latch2.await();
+
+        Mockito.verify(mockedConnection, times(3)).getInputStream();
+    }
+
+    /**
+     *  If multiple simultaneous acquireToken calls with the same authority are made without any authority cache,
+     *  only one authority validation network request is ever made.
+     */
+    @Test
+    public void testMultipleATCallsInDifferentThreadsOnlyOneAuthorityValidation() throws IOException, InterruptedException, ExecutionException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final String accessToken = "some access token";
+        final String resource = "resource";
+        final String clientId = "clientId";
+        final ITokenCacheStore tokenCacheStore = getMockCache(30, accessToken, resource, clientId, TEST_IDTOKEN_UPN, true);
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, true, tokenCacheStore);
+        final Activity mockActivity = Mockito.mock(Activity.class);
+
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+
+        // there are valid access token in the cache.
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(DiscoveryTests.getDiscoveryResponse()));
+
+        // clear the authority validation map
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        final Callable<Void> task = new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                final CountDownLatch latch = new CountDownLatch(1);
+                context.acquireToken(mockActivity, "resource", "clientid", "redirectUri", TEST_IDTOKEN_UPN, new AuthenticationCallback<AuthenticationResult>() {
+                    @Override
+                    public void onSuccess(AuthenticationResult result) {
+                        try {
+                            Assert.assertTrue(result.getAccessToken().equals(accessToken));
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void onError(Exception exc) {
+                        Assert.fail();
+                    }
+                });
+
+                latch.await();
+                return null;
+            }
+        };
+
+        final List<Callable<Void>> tasks = Collections.nCopies(2, task);
+        final List<Future<Void>> results = executorService.invokeAll(tasks);
+        for (final Future<Void> result : results) {
+            result.get();
+        }
+
+        Mockito.verify(mockedConnection, times(1)).getInputStream();
+    }
+
+    /**
+     * When an authority is valid and metadata is returned:
+     * but differs from preferred_cache:
+     * new tokens are written to cache using solely the preferred_cache authority
+     */
+    @Test
+    public void testNewTokenOnlyWrittenToPreferredCacheLocation() throws InterruptedException, IOException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final ITokenCacheStore tokenCacheStore = new DefaultTokenCacheStore(mockContext);
+
+        final String resource = "resource";
+        final String authority = "https://sts.microsoft.com/test.onmicrosoft.com";
+        final AuthenticationContext context = getAuthenticationContext(mockContext, authority, true, tokenCacheStore);
+        context.getCache().removeAll();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Activity mockedActivity = Mockito.mock(Activity.class);
+        final AuthenticationCallback callback = new AuthenticationCallback() {
+            @Override
+            public void onSuccess(Object result) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                fail();
+            }
+        };
+
+        doAnswer(new Answer() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                final Intent intent = new Intent();
+                String state = String.format("a=%s&r=%s", authority, resource);
+                final String encodedState = Base64.encodeToString(state.getBytes("UTF-8"), Base64.NO_PADDING | Base64.URL_SAFE);
+                intent.putExtra(AuthenticationConstants.Browser.REQUEST_ID, callback.hashCode());
+                intent.putExtra(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, "https://login.windows.net/common?code=1234&state=" + encodedState);
+                context.onActivityResult(AuthenticationConstants.UIRequest.BROWSER_FLOW, AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, intent);
+                return null;
+            }
+        }).when(mockedActivity).startActivityForResult(Mockito.any(Intent.class), Mockito.anyInt());
+
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(DiscoveryTests.getDiscoveryResponse()),
+                Util.createInputStream(Util.getSuccessTokenResponse(true, true)));
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+        context.acquireToken(mockedActivity, "resource", "clientid",
+                "redirect", TEST_IDTOKEN_UPN, callback);
+
+        latch.await();
+
+        final ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
+        Mockito.verify(mockedActivity).startActivityForResult(intentArgumentCaptor.capture(), Mockito.anyInt());
+        final AuthenticationRequest requestMessage = (AuthenticationRequest) intentArgumentCaptor.getValue().getSerializableExtra(
+                AuthenticationConstants.Browser.REQUEST_MESSAGE);
+        assertTrue(requestMessage.getAuthority().contains("login.microsoftonline.com"));
+
+        final SharedPreferences sharedPreferences =  mockContext.getSharedPreferences("com.microsoft.aad.adal.cache", Activity.MODE_PRIVATE);
+        final Map<String, String> allTokens = (Map<String, String>) sharedPreferences.getAll();
+        Assert.assertTrue(allTokens.size() == 8);
+        // also verify all the key are using preferred_cache
+        final Set<String> keys = allTokens.keySet();
+        for (final String key : keys) {
+            assertTrue(key.contains("login.windows.net"));
+        }
+
+        assertTrue(HttpUrlConnectionFactory.getMockedConnectionOpenUrl().getHost().equals("login.microsoftonline.com"));
+    }
+
+    @Test
+    public void testCacheContainsPreferredCacheToken() throws InterruptedException, IOException {
+        final String resource = "resource";
+        final String clientId = "clientId";
+        final ITokenCacheStore tokenCacheStore = getMockCache(-20, "accessToken", resource, clientId, TEST_IDTOKEN_USERID, false);
+
+        final String authority = "https://sts.microsoft.com/test.onmicrosoft.com";
+        final String accessTokenForPassedInAuthority = "access token for passedInAuthority";
+        final TokenCacheItem itemForPassedInAuthority = getTokenCacheItem(authority, resource, clientId, TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        itemForPassedInAuthority.setAccessToken(accessTokenForPassedInAuthority);
+        tokenCacheStore.setItem(CacheKey.createCacheKeyForRTEntry(authority, resource, clientId, TEST_IDTOKEN_USERID), itemForPassedInAuthority);
+
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final AuthenticationContext authenticationContext = new AuthenticationContext(mockContext, authority, true, tokenCacheStore);
+
+        final HttpURLConnection connection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(connection);
+        when(connection.getInputStream()).thenReturn(Util.createInputStream(DiscoveryTests.getDiscoveryResponse()),
+                Util.createInputStream(Util.getSuccessTokenResponse(false, false)));
+        when(connection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+        when(connection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        authenticationContext.acquireTokenSilentAsync(resource, clientId, TEST_IDTOKEN_USERID, new AuthenticationCallback<AuthenticationResult>() {
+            @Override
+            public void onSuccess(AuthenticationResult result) {
+                assertNotNull(result.getAccessToken());
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                fail();
+            }
+        });
+
+        latch.await();
+
+        // verify cache
+        assertNotNull(tokenCacheStore.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_USERID)));
+        final TokenCacheItem item = tokenCacheStore.getItem(CacheKey.createCacheKeyForRTEntry(authority, resource, clientId, TEST_IDTOKEN_USERID));
+        assertNotNull(item);
+        assertTrue(item.getAccessToken().equals(accessTokenForPassedInAuthority));
+
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+    }
+
+    /**
+     * When an authority is valid and metadata is returned, but differs from the preferred_network,
+     * preferred_network host is used for all subsequent network requests.
+     */
+    @Test
+    public void testCacheContainsPassedInAuthority() throws IOException, InterruptedException {
+        final String resource = "resource";
+        final String clientId = "clientId";
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final ITokenCacheStore tokenCacheStore = new DefaultTokenCacheStore(mockContext);
+        tokenCacheStore.removeAll();
+
+        final String authority = "https://sts.microsoft.com/test.onmicrosoft.com";
+        final String accessTokenForPassedInAuthority = "access token for passedInAuthority";
+        final String refreshTokenForPassedInAuthority = "refresh token for passedInAuthority";
+        final TokenCacheItem itemForPassedInAuthority = getTokenCacheItem(authority, resource, clientId, TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        itemForPassedInAuthority.setAccessToken(accessTokenForPassedInAuthority);
+        itemForPassedInAuthority.setRefreshToken(refreshTokenForPassedInAuthority);
+        tokenCacheStore.setItem(CacheKey.createCacheKeyForRTEntry(authority, resource, clientId, TEST_IDTOKEN_USERID), itemForPassedInAuthority);
+
+        final String refreshTokenForPreferredNetwork = "refresh token for preferredNetwork";
+        final TokenCacheItem itemForPreferredNetwork = getTokenCacheItem("https://login.microsoftonline.com/test.onmicrosoft.com",
+                resource, clientId, TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        itemForPreferredNetwork.setRefreshToken(refreshTokenForPreferredNetwork);
+
+        final AuthenticationContext authenticationContext = new AuthenticationContext(mockContext, authority, true, tokenCacheStore);
+
+        final HttpURLConnection connection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(connection);
+        when(connection.getInputStream()).thenReturn(Util.createInputStream(DiscoveryTests.getDiscoveryResponse()),
+                Util.createInputStream(Util.getSuccessTokenResponse(false, false)));
+        when(connection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+        final OutputStream outputStream = Mockito.mock(OutputStream.class);
+        when(connection.getOutputStream()).thenReturn(outputStream);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        authenticationContext.acquireTokenSilentAsync(resource, clientId, TEST_IDTOKEN_USERID, new AuthenticationCallback<AuthenticationResult>() {
+            @Override
+            public void onSuccess(AuthenticationResult result) {
+                assertNotNull(result.getAccessToken());
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Exception exc) {
+                fail();
+            }
+        });
+
+        latch.await();
+
+        verify(outputStream).write(Util.getPoseMessage(refreshTokenForPassedInAuthority, clientId, resource));
+        assertTrue(HttpUrlConnectionFactory.getMockedConnectionOpenUrl().getHost().equals("login.microsoftonline.com"));
+
+        // verify cache
+        assertNotNull(tokenCacheStore.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_USERID)));
+        final TokenCacheItem item = tokenCacheStore.getItem(CacheKey.createCacheKeyForRTEntry(authority, resource, clientId, TEST_IDTOKEN_USERID));
+        assertNotNull(item);
+        assertTrue(item.getAccessToken().equals(accessTokenForPassedInAuthority));
+
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+    }
+
     private void verifyFamilyIdStoredInTokenCacheItem(final ITokenCacheStore cacheStore, final String cacheKey,
                                                       final String expectedFamilyClientId) {
 
@@ -1186,8 +1599,7 @@ public final class AuthenticationContextTest {
         intent.putExtra(AuthenticationConstants.Browser.REQUEST_ID, callback.hashCode());
         final AuthenticationRequest authRequest = new AuthenticationRequest(VALID_AUTHORITY,
                 resource, clientid, redirect, loginHint, false);
-        intent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
-                (Serializable) authRequest);
+        intent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO, authRequest);
         intent.putExtra(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, VALID_AUTHORITY
                 + "/oauth2/authorize?code=123&state=" + getState(VALID_AUTHORITY, resource));
         return intent;
@@ -2293,6 +2705,19 @@ public final class AuthenticationContextTest {
         return cache;
     }
 
+    private TokenCacheItem getTokenCacheItem(final String authority, final String resource, final String clientId,
+                                             final String userId, final String displayableId) {
+        final TokenCacheItem item = new TokenCacheItem();
+        item.setAuthority(authority);
+        item.setResource(resource);
+        item.setClientId(clientId);
+        item.setUserInfo(new UserInfo(userId, "givenName", "familyName", "idp", displayableId));
+        item.setAccessToken("accessToken");
+        item.setRefreshToken("refreshTOken");
+        item.setExpiresOn(new Date());
+
+        return item;
+    }
 
     private ITokenCacheStore getMockCache(int minutes, String token, String resource,
                                           String client, String user, boolean isMultiResource) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthorityValidationMetadataCacheTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthorityValidationMetadataCacheTest.java
@@ -47,6 +47,7 @@ public class AuthorityValidationMetadataCacheTest extends AndroidTestHelper {
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
     }
 
     @After

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
@@ -63,6 +63,7 @@ public class DiscoveryTests extends AndroidTestHelper {
 
     @Before
     public void setUp() throws Exception {
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
         super.setUp();
     }
 
@@ -282,8 +283,6 @@ public class DiscoveryTests extends AndroidTestHelper {
     // one hit network.
     @Test
     public void testMultiValidateAuthorityRequestsInDifferentThreads() throws IOException, InterruptedException, ExecutionException {
-        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
-
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
@@ -319,8 +318,6 @@ public class DiscoveryTests extends AndroidTestHelper {
      */
     @Test
     public void testAuthorityInAliasedList() throws IOException {
-        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
-
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/DiscoveryTests.java
@@ -311,6 +311,51 @@ public class DiscoveryTests extends AndroidTestHelper {
         Mockito.verify(mockedConnection, Mockito.times(1)).getInputStream();
     }
 
+    /**
+     * Verified scenario:
+     * When an authority is valid and metadata is returned:
+     * a. Subsequent requests for any aliases provided in the metadata do not result in further validation network requests
+     * being made for the process lifetime
+     */
+    @Test
+    public void testAuthorityInAliasedList() throws IOException {
+        AuthorityValidationMetadataCache.clearAuthorityValidationCache();
+
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(getDiscoveryResponse()));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        final String authorityUrl1 = "https://login.windows.net/sometenant.onmicrosoft.com";
+        try {
+            final Discovery discovery = new Discovery();
+            discovery.validateAuthority(new URL(authorityUrl1));
+        } catch (AuthenticationException e) {
+            fail();
+        }
+
+        // do authority validation for aliased authority
+        final String aliasedAuthorityUrl = "https://login.microsoftonline.com/sometenant.onmicrosoft.com";
+        try {
+            final Discovery discovery = new Discovery();
+            discovery.validateAuthority(new URL(aliasedAuthorityUrl));
+        } catch (AuthenticationException e) {
+            fail();
+        }
+
+        final String aliasedAuthorityUrl2 = "https://sts.microsoft.com/sometenant.onmicrosoft.com";
+        try {
+            final Discovery discovery = new Discovery();
+            discovery.validateAuthority(new URL(aliasedAuthorityUrl2));
+        } catch (AuthenticationException e) {
+            fail();
+        }
+
+        Mockito.verify(mockedConnection, Mockito.times(1)).getInputStream();
+    }
+
     static String getDiscoveryResponse() {
         final Map<String, String> discoveryResponse = AuthorityValidationMetadataCacheTest.getDiscoveryResponse();
         final JSONObject discoveryResponseJsonObject = new JSONObject(discoveryResponse);

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenInteractiveRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenInteractiveRequest.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.content.pm.ResolveInfo;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 
 /**
  * Internal class handling the detailed acquire token interactive logic. Will be responsible for showing the webview,
@@ -118,8 +119,12 @@ final class AcquireTokenInteractiveRequest {
 
         if (!StringExtensions.isNullOrBlank(result.getAccessToken()) && mTokenCacheAccessor != null) {
             // Developer may pass null for the acquireToken flow.
-            mTokenCacheAccessor.updateTokenCache(mAuthRequest.getResource(),
-                    mAuthRequest.getClientId(), result);
+            try {
+                mTokenCacheAccessor.updateTokenCache(mAuthRequest.getResource(),
+                        mAuthRequest.getClientId(), result);
+            } catch (MalformedURLException e) {
+                throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, e.getMessage(), e);
+            }
         }
 
         return result;

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -25,6 +25,7 @@ package com.microsoft.aad.adal;
 import android.content.Context;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 
 /**
  * Internal class handling the detailed acquiretoken silent logic, including cache lookup and also
@@ -169,8 +170,14 @@ class AcquireTokenSilentHandler {
      * Attempt to get new access token with regular RT. 
      */
     private AuthenticationResult tryRT() throws AuthenticationException {
-        final TokenCacheItem regularRTItem = mTokenCacheAccessor.getRegularRefreshTokenCacheItem(mAuthRequest.getResource(), 
-                mAuthRequest.getClientId(), mAuthRequest.getUserFromRequest());
+        final TokenCacheItem regularRTItem;
+
+        try {
+            regularRTItem = mTokenCacheAccessor.getRegularRefreshTokenCacheItem(mAuthRequest.getResource(),
+                    mAuthRequest.getClientId(), mAuthRequest.getUserFromRequest());
+        } catch (final MalformedURLException ex) {
+            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, ex.getMessage(), ex);
+        }
 
         if (regularRTItem == null) {
             Logger.v(TAG, "Regular token cache entry does not exist, try with MRRT.");
@@ -207,8 +214,13 @@ class AcquireTokenSilentHandler {
      */
     private AuthenticationResult tryMRRT() throws AuthenticationException {
         // Try to get it from cache
-        mMrrtTokenCacheItem = mTokenCacheAccessor.getMRRTItem(mAuthRequest.getClientId(), 
-                mAuthRequest.getUserFromRequest());
+        try {
+            mMrrtTokenCacheItem = mTokenCacheAccessor.getMRRTItem(mAuthRequest.getClientId(),
+                    mAuthRequest.getUserFromRequest());
+        } catch (final MalformedURLException ex) {
+            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, ex.getMessage(), ex);
+        }
+
         
         // MRRT does not exist, try with FRT.
         if (mMrrtTokenCacheItem == null) {
@@ -248,9 +260,15 @@ class AcquireTokenSilentHandler {
      */
     private AuthenticationResult tryFRT(final String familyClientId, final AuthenticationResult mrrtResult) 
             throws AuthenticationException {
-        final TokenCacheItem frtTokenCacheItem = mTokenCacheAccessor.getFRTItem(familyClientId, 
-                mAuthRequest.getUserFromRequest());
-        
+        final TokenCacheItem frtTokenCacheItem;
+
+        try {
+            frtTokenCacheItem = mTokenCacheAccessor.getFRTItem(familyClientId,
+                    mAuthRequest.getUserFromRequest());
+        } catch (final MalformedURLException ex) {
+            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, ex.getMessage(), ex);
+        }
+
         if (frtTokenCacheItem  == null) {
             // If we haven't tried with MRRT, use the MRRT. MRRT either exists or not, if it does not exist, we've 
             // already tried our best, null will be retured. If it eixsts, try with it. 
@@ -314,9 +332,16 @@ class AcquireTokenSilentHandler {
      * MRRT is when RT is not found or found RT is also MRRT. To support the old behavior, do a separate check on
      * the existence for MRRT token entry. 
      */
-    private boolean isMRRTEntryExisted() {
-        final TokenCacheItem mrrtItem = mTokenCacheAccessor.getMRRTItem(mAuthRequest.getClientId(), 
-                mAuthRequest.getUserFromRequest());
+    private boolean isMRRTEntryExisted() throws AuthenticationException {
+        final TokenCacheItem mrrtItem;
+
+        try {
+            mrrtItem = mTokenCacheAccessor.getMRRTItem(mAuthRequest.getClientId(),
+                    mAuthRequest.getUserFromRequest());
+        } catch (final MalformedURLException ex) {
+            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, ex.getMessage(), ex);
+        }
+
         return mrrtItem != null && !StringExtensions.isNullOrBlank(mrrtItem.getRefreshToken());
     }
     

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -73,6 +73,8 @@ class AuthenticationRequest implements Serializable {
 
     private String mClaimsChallenge;
 
+    private transient InstanceDiscoveryMetadata mInstanceDiscoveryMetadata;
+
     /**
      * Developer can use acquireToken(with loginhint) or acquireTokenSilent(with
      * userid), so this sets the type of the request.
@@ -310,5 +312,13 @@ class AuthenticationRequest implements Serializable {
 
     String getTelemetryRequestId() {
         return mTelemetryRequestId;
+    }
+
+    void setInstanceDiscoveryMetadata(final InstanceDiscoveryMetadata metadata) {
+        mInstanceDiscoveryMetadata = metadata;
+    }
+
+    InstanceDiscoveryMetadata getInstanceDiscoveryMetadata() {
+        return mInstanceDiscoveryMetadata;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/HttpUrlConnectionFactory.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HttpUrlConnectionFactory.java
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.aad.adal;
 
+import android.support.annotation.VisibleForTesting;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -35,6 +37,8 @@ final class HttpUrlConnectionFactory {
 
     private static HttpURLConnection sMockedConnection = null;
 
+    private static URL sMockedConnectionOpenUrl = null;
+
     /**
      * Private constructor to prevent the class from being initiated.
      */
@@ -46,13 +50,22 @@ final class HttpUrlConnectionFactory {
      */
     static void setMockedHttpUrlConnection(final HttpURLConnection mockedHttpUrlConnection) {
         sMockedConnection = mockedHttpUrlConnection;
+        if (mockedHttpUrlConnection == null) {
+            sMockedConnectionOpenUrl = null;
+        }
     }
     
     static HttpURLConnection createHttpUrlConnection(final URL url) throws IOException {
         if (sMockedConnection != null) {
+            sMockedConnectionOpenUrl = url;
             return sMockedConnection;
         }
         
         return (HttpURLConnection) url.openConnection();
+    }
+
+    @VisibleForTesting
+    static URL getMockedConnectionOpenUrl() {
+        return sMockedConnectionOpenUrl;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.aad.adal;
 
-import android.net.Uri;
-
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
 
 import java.io.UnsupportedEncodingException;
@@ -34,6 +32,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.microsoft.aad.adal.TokenEntryType.FRT_TOKEN_ENTRY;
+import static com.microsoft.aad.adal.TokenEntryType.MRRT_TOKEN_ENTRY;
+import static com.microsoft.aad.adal.TokenEntryType.REGULAR_TOKEN_ENTRY;
+
 /**
  * Internal class handling the interaction with {@link AcquireTokenSilentHandler} and {@link ITokenCacheStore}. 
  */
@@ -43,7 +45,6 @@ class TokenCacheAccessor {
     private final ITokenCacheStore mTokenCacheStore;
     private String mAuthority; // Remove final to update the authority when preferred cache location is not the same as passed in authority
     private final String mTelemetryRequestId;
-    private InstanceDiscoveryMetadata mInstanceDiscoveryMetadata;
     
     TokenCacheAccessor(final ITokenCacheStore tokenCacheStore, final String authority, final String telemetryRequestId) {
         if (tokenCacheStore == null) {
@@ -107,12 +108,13 @@ class TokenCacheAccessor {
     TokenCacheItem getRegularRefreshTokenCacheItem(final String resource, final String clientId, final String user) throws MalformedURLException {
         final CacheEvent cacheEvent = startCacheTelemetryRequest(EventStrings.TOKEN_TYPE_RT);
 
-        final String cacheKey = CacheKey.createCacheKeyForRTEntry(mAuthority, resource, clientId, user);
+        // try preferred cache location first
+        final String cacheKey = CacheKey.createCacheKeyForRTEntry(getAuthorityUrlWithPreferredCache(), resource, clientId, user);
 
         TokenCacheItem item =  mTokenCacheStore.getItem(cacheKey);
         // try all the alias
         if (item == null ) {
-           item = getTokenCacheItemFromAliasedHost(resource, clientId, null, user, TokenEntryType.REGULAR_TOKEN_ENTRY);
+           item = performAdditionalCacheLookup(resource, clientId, null, user, REGULAR_TOKEN_ENTRY);
         }
 
         if (item != null) {
@@ -128,16 +130,18 @@ class TokenCacheAccessor {
      */
     TokenCacheItem getMRRTItem(final String clientId, final String user) throws MalformedURLException {
         final CacheEvent cacheEvent = startCacheTelemetryRequest(EventStrings.TOKEN_TYPE_MRRT);
-        final String cacheKey = CacheKey.createCacheKeyForMRRT(mAuthority, clientId, user);
+        final String cacheKey = CacheKey.createCacheKeyForMRRT(getAuthorityUrlWithPreferredCache(), clientId, user);
 
         TokenCacheItem item = mTokenCacheStore.getItem(cacheKey);
         if (item == null) {
-            item = getTokenCacheItemFromAliasedHost(null, clientId, null, user, TokenEntryType.MRRT_TOKEN_ENTRY);
+            item = performAdditionalCacheLookup(null, clientId, null, user, MRRT_TOKEN_ENTRY);
         }
+
         if (item != null) {
             cacheEvent.setTokenTypeMRRT(true);
             cacheEvent.setTokenTypeFRT(item.isFamilyToken());
         }
+
         Telemetry.getInstance().stopEvent(mTelemetryRequestId, cacheEvent, EventStrings.TOKEN_CACHE_LOOKUP);
 
         return item;
@@ -153,11 +157,11 @@ class TokenCacheAccessor {
             return null;
         }
         
-        final String cacheKey = CacheKey.createCacheKeyForFRT(mAuthority, familyClientId, user);
+        final String cacheKey = CacheKey.createCacheKeyForFRT(getAuthorityUrlWithPreferredCache(), familyClientId, user);
 
         TokenCacheItem item = mTokenCacheStore.getItem(cacheKey);
         if (item == null) {
-            item = getTokenCacheItemFromAliasedHost(null, null, familyClientId, user, TokenEntryType.FRT_TOKEN_ENTRY);
+            item = performAdditionalCacheLookup(null, null, familyClientId, user, FRT_TOKEN_ENTRY);
         }
         if (item != null) {
             cacheEvent.setTokenTypeFRT(true);
@@ -209,8 +213,12 @@ class TokenCacheAccessor {
                 result.setIdToken(cachedItem.getRawIdToken());
                 result.setTenantId(cachedItem.getTenantId());
             }
-            
-            updateTokenCache(resource, clientId, result);
+
+            try {
+                updateTokenCache(resource, clientId, result);
+            } catch (MalformedURLException e) {
+                throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, e.getMessage(), e);
+            }
         } else if (AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(result.getErrorCode())) {
             // remove Item if oauth2_error is invalid_grant
             Logger.v(TAG, "Received INVALID_GRANT error code, remove existing cache entry.");
@@ -221,7 +229,7 @@ class TokenCacheAccessor {
     /**
      * Update token cache with returned auth result.
      */
-    void updateTokenCache(final String resource, final String clientId, final AuthenticationResult result) {
+    void updateTokenCache(final String resource, final String clientId, final AuthenticationResult result) throws MalformedURLException{
         if (result == null || StringExtensions.isNullOrBlank(result.getAccessToken())) {
             return;
         }
@@ -326,7 +334,7 @@ class TokenCacheAccessor {
      * on RT. 
      * If the token is FRT, store three separate entries. 
      */
-    private void setItemToCacheForUser(final String resource, final String clientId, final AuthenticationResult result, final String userId) {
+    private void setItemToCacheForUser(final String resource, final String clientId, final AuthenticationResult result, final String userId) throws MalformedURLException {
         logReturnedToken(result);
         Logger.v(TAG, "Save regular token into cache.");
 
@@ -334,14 +342,15 @@ class TokenCacheAccessor {
         cacheEvent.setRequestId(mTelemetryRequestId);
         Telemetry.getInstance().startEvent(mTelemetryRequestId, EventStrings.TOKEN_CACHE_WRITE);
 
-        mTokenCacheStore.setItem(CacheKey.createCacheKeyForRTEntry(mAuthority, resource, clientId, userId), 
-                TokenCacheItem.createRegularTokenCacheItem(mAuthority, resource, clientId, result));
+        // new tokens will only be saved into preferred cache location
+        mTokenCacheStore.setItem(CacheKey.createCacheKeyForRTEntry(getAuthorityUrlWithPreferredCache(), resource, clientId, userId),
+                TokenCacheItem.createRegularTokenCacheItem(getAuthorityUrlWithPreferredCache(), resource, clientId, result));
         cacheEvent.setTokenTypeRT(true);
         // Store separate entries for MRRT.  
         if (result.getIsMultiResourceRefreshToken()) {
             Logger.v(TAG, "Save Multi Resource Refresh token to cache");
-            mTokenCacheStore.setItem(CacheKey.createCacheKeyForMRRT(mAuthority, clientId, userId),
-                    TokenCacheItem.createMRRTTokenCacheItem(mAuthority, clientId, result));
+            mTokenCacheStore.setItem(CacheKey.createCacheKeyForMRRT(getAuthorityUrlWithPreferredCache(), clientId, userId),
+                    TokenCacheItem.createMRRTTokenCacheItem(getAuthorityUrlWithPreferredCache(), clientId, result));
             cacheEvent.setTokenTypeMRRT(true);
         }
         
@@ -349,7 +358,7 @@ class TokenCacheAccessor {
         if (!StringExtensions.isNullOrBlank(result.getFamilyClientId()) && !StringExtensions.isNullOrBlank(userId)) {
             Logger.v(TAG, "Save Family Refresh token into cache");
             final TokenCacheItem familyTokenCacheItem = TokenCacheItem.createFRRTTokenCacheItem(mAuthority, result);
-            mTokenCacheStore.setItem(CacheKey.createCacheKeyForFRT(mAuthority, result.getFamilyClientId(), userId), familyTokenCacheItem);
+            mTokenCacheStore.setItem(CacheKey.createCacheKeyForFRT(getAuthorityUrlWithPreferredCache(), result.getFamilyClientId(), userId), familyTokenCacheItem);
             cacheEvent.setTokenTypeFRT(true);
         }
         Telemetry.getInstance().stopEvent(mTelemetryRequestId, cacheEvent,
@@ -451,34 +460,46 @@ class TokenCacheAccessor {
         return cacheEvent;
     }
 
+    private TokenCacheItem performAdditionalCacheLookup(final String resource, final String clientid, final String familyClientId,
+                                                        final String user, final TokenEntryType type) throws MalformedURLException {
+        TokenCacheItem item = getTokenCacheItemFromPassedInAuthority(resource, clientid, familyClientId, user, type);
+
+        if (item == null) {
+            item = getTokenCacheItemFromAliasedHost(resource, clientid, familyClientId, user, type);
+        }
+
+        return item;
+    }
+
+    private TokenCacheItem getTokenCacheItemFromPassedInAuthority(final String resource, final String clientId, final String familyClientId,
+                                                                  final String user, final TokenEntryType type) throws MalformedURLException {
+        if (getAuthorityUrlWithPreferredCache().equalsIgnoreCase(mAuthority)) {
+            return null;
+        }
+
+        final String cacheKeyWithPassedInAuthority = getCacheKey(mAuthority, resource, clientId, user, familyClientId, type);
+        return mTokenCacheStore.getItem(cacheKeyWithPassedInAuthority);
+    }
+
     private TokenCacheItem getTokenCacheItemFromAliasedHost(final String resource, final String clientId, final String familyClientId,
                                                             final String user, final TokenEntryType type) throws MalformedURLException {
-        if (mInstanceDiscoveryMetadata == null) {
+
+        final InstanceDiscoveryMetadata instanceDiscoveryMetadata = getInstanceDiscoveryMetadata();
+        if (instanceDiscoveryMetadata == null) {
             return null;
         }
 
         TokenCacheItem tokenCacheItemForAliasedHost = null;
-        final List<String> aliasHosts = mInstanceDiscoveryMetadata.getAliases();
+        final List<String> aliasHosts = instanceDiscoveryMetadata.getAliases();
         for (final String aliasHost : aliasHosts) {
             final String authority = constructAuthorityUrl(aliasHost);
-            if (authority.equalsIgnoreCase(mAuthority)) {
+            // Already looked cache with preferred cache location and passed in authority, needs to look through other
+            // aliased host.
+            if (authority.equalsIgnoreCase(mAuthority) || authority.equalsIgnoreCase(getAuthorityUrlWithPreferredCache())) {
                 continue;
             }
 
-            final String cacheKeyForAliasedHost;
-            switch (type) {
-                case REGULAR_TOKEN_ENTRY:
-                    cacheKeyForAliasedHost = CacheKey.createCacheKeyForRTEntry(authority, resource, clientId, user);
-                    break;
-                case MRRT_TOKEN_ENTRY:
-                    cacheKeyForAliasedHost = CacheKey.createCacheKeyForMRRT(authority, clientId, user);
-                    break;
-                case FRT_TOKEN_ENTRY:
-                    cacheKeyForAliasedHost = CacheKey.createCacheKeyForFRT(authority, familyClientId, user);
-                    break;
-                default:
-                    return null;
-            }
+            final String cacheKeyForAliasedHost = getCacheKey(authority, resource, clientId, user, familyClientId, type);
 
             final TokenCacheItem item = mTokenCacheStore.getItem(cacheKeyForAliasedHost);
             if (item != null) {
@@ -490,19 +511,36 @@ class TokenCacheAccessor {
         return tokenCacheItemForAliasedHost;
     }
 
-    void setInstanceDiscoveryMetadata(final InstanceDiscoveryMetadata instanceDiscoveryMetadata) {
-        mInstanceDiscoveryMetadata = instanceDiscoveryMetadata;
-    }
-
-    void updatePreferredCacheLocation() throws MalformedURLException {
-        if (mInstanceDiscoveryMetadata == null || !mInstanceDiscoveryMetadata.isValidated()) {
-            return;
+    private String getCacheKey(final String authority, final String resource, final String clientId, final String user,
+                               final String familyClientId, final TokenEntryType type) {
+        final String cacheKey;
+        switch (type) {
+            case REGULAR_TOKEN_ENTRY:
+                cacheKey = CacheKey.createCacheKeyForRTEntry(authority, resource, clientId, user);
+                break;
+            case MRRT_TOKEN_ENTRY:
+                cacheKey = CacheKey.createCacheKeyForMRRT(authority, clientId, user);
+                break;
+            case FRT_TOKEN_ENTRY:
+                cacheKey = CacheKey.createCacheKeyForFRT(authority, familyClientId, user);
+                break;
+            default:
+                return null;
         }
 
-        final String preferredLocation = mInstanceDiscoveryMetadata.getPreferredCache();
+        return cacheKey;
+    }
+
+    String getAuthorityUrlWithPreferredCache() throws MalformedURLException {
+        final InstanceDiscoveryMetadata instanceDiscoveryMetadata = getInstanceDiscoveryMetadata();
+        if (instanceDiscoveryMetadata == null || !instanceDiscoveryMetadata.isValidated()) {
+            return mAuthority;
+        }
+
+        final String preferredLocation = instanceDiscoveryMetadata.getPreferredCache();
 
         // mAuthority can be updated to preferred location.
-        mAuthority = constructAuthorityUrl(preferredLocation);
+        return constructAuthorityUrl(preferredLocation);
     }
 
     private String constructAuthorityUrl(final String host) throws MalformedURLException {
@@ -511,7 +549,11 @@ class TokenCacheAccessor {
             return mAuthority;
         }
 
-        final Uri authorityUri = new Uri.Builder().authority(host).appendPath(passedInAuthority.getPath()).build();
-        return authorityUri.toString();
+        return Utility.constructAuthorityUrl(passedInAuthority, host).toString();
+    }
+
+    private InstanceDiscoveryMetadata getInstanceDiscoveryMetadata() throws MalformedURLException {
+        final URL passedInAuthority = new URL(mAuthority);
+        return AuthorityValidationMetadataCache.getCachedInstanceDiscoveryMetadata(passedInAuthority);
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/Utility.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Utility.java
@@ -22,6 +22,10 @@
 // THE SOFTWARE.
 package com.microsoft.aad.adal;
 
+import android.net.Uri;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Date;
 
 final class Utility {
@@ -45,5 +49,11 @@ final class Utility {
     static boolean isClaimsChallengePresent(final AuthenticationRequest request) {
         // if developer pass claims down through extra qp, we should also skip cache.
         return !StringExtensions.isNullOrBlank(request.getClaimsChallenge());
+    }
+
+    static URL constructAuthorityUrl(final URL originalAuthority, final String host) throws MalformedURLException {
+        final String path = originalAuthority.getPath().replaceFirst("/", "");
+        final Uri.Builder builder = new Uri.Builder().scheme(originalAuthority.getProtocol()).authority(host).appendPath(path);
+        return new URL(builder.build().toString());
     }
 }


### PR DESCRIPTION
Please make sure every Pull Request has the following information:

<ul>
  <li>#913</li>
  <li>Cache update for authority migration. New token will always be written into the preferred cache location; For read, try preferred_cache first, followed by provided authority and aliased authority. </li>
</ul>
