### PR TITLE
Adds support for broker, spe ring info + server_error, server_suberror, and rt_age

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -610,13 +610,36 @@ class AcquireTokenRequest {
                     final String tenantId = data.getStringExtra(
                             AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID);
                     final UserInfo userinfo = UserInfo.getUserInfoFromBrokerResult(data.getExtras());
+
+                    // grab the fields tracked by x-ms-clitelem
+                    final String serverErrorCode = data.getStringExtra(AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR);
+                    final String serverSubErrorCode = data.getStringExtra(AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR);
+                    final String refreshTokenAge = data.getStringExtra(AuthenticationConstants.Broker.CliTelemInfo.RT_AGE);
+                    final String speRingInfo = data.getStringExtra(AuthenticationConstants.Broker.CliTelemInfo.SPE_RING);
+
+                    // create the broker AuthenticationResult
                     final AuthenticationResult brokerResult = new AuthenticationResult(accessToken, null,
                             expire, false, userinfo, tenantId, idtoken, null);
+
+                    // set the x-ms-clitelem fields on the result from the Broker
+                    brokerResult.setServerErrorCode(serverErrorCode);
+                    brokerResult.setServerSubErrorCode(serverSubErrorCode);
+                    brokerResult.setRefreshTokenAge(refreshTokenAge);
+                    brokerResult.setSpeRing(speRingInfo);
+
                     if (brokerResult.getAccessToken() != null) {
                         waitingRequest.getAPIEvent().setWasApiCallSuccessful(true, null);
                         waitingRequest.getAPIEvent().setCorrelationId(
                                 waitingRequest.getRequest().getCorrelationId().toString());
                         waitingRequest.getAPIEvent().setIdToken(brokerResult.getIdToken());
+
+                        // add the x-ms-clitelem info to the ApiEvent
+                        waitingRequest.getAPIEvent().setServerErrorCode(brokerResult.getServerErrorCode());
+                        waitingRequest.getAPIEvent().setServerSubErrorCode(brokerResult.getServerSubErrorCode());
+                        waitingRequest.getAPIEvent().setRefreshTokenAge(brokerResult.getRefreshTokenAge());
+                        waitingRequest.getAPIEvent().setSpeRing(brokerResult.getSpeRing());
+
+                        // stop the event
                         waitingRequest.getAPIEvent().stopTelemetryAndFlush();
 
                         waitingRequest.getDelegate().onSuccess(brokerResult);

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -622,10 +622,12 @@ class AcquireTokenRequest {
                             expire, false, userinfo, tenantId, idtoken, null);
 
                     // set the x-ms-clitelem fields on the result from the Broker
-                    brokerResult.setServerErrorCode(serverErrorCode);
-                    brokerResult.setServerSubErrorCode(serverSubErrorCode);
-                    brokerResult.setRefreshTokenAge(refreshTokenAge);
-                    brokerResult.setSpeRing(speRingInfo);
+                    final TelemetryUtils.CliTelemInfo cliTelemInfo = new TelemetryUtils.CliTelemInfo();
+                    cliTelemInfo.setServerErrorCode(serverErrorCode);
+                    cliTelemInfo.setServerSubErrorCode(serverSubErrorCode);
+                    cliTelemInfo.setRefreshTokenAge(refreshTokenAge);
+                    cliTelemInfo.setSpeRing(speRingInfo);
+                    brokerResult.setCliTelemInfo(cliTelemInfo);
 
                     if (brokerResult.getAccessToken() != null) {
                         waitingRequest.getAPIEvent().setWasApiCallSuccessful(true, null);
@@ -634,10 +636,10 @@ class AcquireTokenRequest {
                         waitingRequest.getAPIEvent().setIdToken(brokerResult.getIdToken());
 
                         // add the x-ms-clitelem info to the ApiEvent
-                        waitingRequest.getAPIEvent().setServerErrorCode(brokerResult.getServerErrorCode());
-                        waitingRequest.getAPIEvent().setServerSubErrorCode(brokerResult.getServerSubErrorCode());
-                        waitingRequest.getAPIEvent().setRefreshTokenAge(brokerResult.getRefreshTokenAge());
-                        waitingRequest.getAPIEvent().setSpeRing(brokerResult.getSpeRing());
+                        waitingRequest.getAPIEvent().setServerErrorCode(cliTelemInfo.getServerErrorCode());
+                        waitingRequest.getAPIEvent().setServerSubErrorCode(cliTelemInfo.getServerSubErrorCode());
+                        waitingRequest.getAPIEvent().setRefreshTokenAge(cliTelemInfo.getRefreshTokenAge());
+                        waitingRequest.getAPIEvent().setSpeRing(cliTelemInfo.getSpeRing());
 
                         // stop the event
                         waitingRequest.getAPIEvent().stopTelemetryAndFlush();

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
@@ -65,9 +65,6 @@ final class AcquireTokenWithBrokerRequest {
             Logger.v(TAG, "User is specified for background(silent) token request, trying to acquire token silently.");
             authenticationResult = mBrokerProxy.getAuthTokenInBackground(mAuthRequest, brokerEvent);
             if (null != authenticationResult) {
-                brokerEvent.setServerErrorCode(authenticationResult.getServerErrorCode());
-                brokerEvent.setServerSubErrorCode(authenticationResult.getServerSubErrorCode());
-                brokerEvent.setRefreshTokenAge(authenticationResult.getRefreshTokenAge());
                 brokerEvent.setSpeRing(authenticationResult.getSpeRing());
             }
         } else {

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
@@ -64,8 +64,8 @@ final class AcquireTokenWithBrokerRequest {
                 .isNullOrBlank(mAuthRequest.getUserId())) {
             Logger.v(TAG, "User is specified for background(silent) token request, trying to acquire token silently.");
             authenticationResult = mBrokerProxy.getAuthTokenInBackground(mAuthRequest, brokerEvent);
-            if (null != authenticationResult) {
-                brokerEvent.setSpeRing(authenticationResult.getSpeRing());
+            if (null != authenticationResult && null != authenticationResult.getCliTelemInfo()) {
+                brokerEvent.setSpeRing(authenticationResult.getCliTelemInfo().getSpeRing());
             }
         } else {
             Logger.v(TAG, "User is not specified, skipping background(silent) token request");

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
@@ -64,6 +64,10 @@ final class AcquireTokenWithBrokerRequest {
                 .isNullOrBlank(mAuthRequest.getUserId())) {
             Logger.v(TAG, "User is specified for background(silent) token request, trying to acquire token silently.");
             authenticationResult = mBrokerProxy.getAuthTokenInBackground(mAuthRequest, brokerEvent);
+            brokerEvent.setServerErrorCode(authenticationResult.getServerErrorCode());
+            brokerEvent.setServerSubErrorCode(authenticationResult.getServerSubErrorCode());
+            brokerEvent.setRefreshTokenAge(authenticationResult.getRefreshTokenAge());
+            brokerEvent.setSpeRing(authenticationResult.getSpeRing());
         } else {
             Logger.v(TAG, "User is not specified, skipping background(silent) token request");
             authenticationResult = null;

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
@@ -64,10 +64,12 @@ final class AcquireTokenWithBrokerRequest {
                 .isNullOrBlank(mAuthRequest.getUserId())) {
             Logger.v(TAG, "User is specified for background(silent) token request, trying to acquire token silently.");
             authenticationResult = mBrokerProxy.getAuthTokenInBackground(mAuthRequest, brokerEvent);
-            brokerEvent.setServerErrorCode(authenticationResult.getServerErrorCode());
-            brokerEvent.setServerSubErrorCode(authenticationResult.getServerSubErrorCode());
-            brokerEvent.setRefreshTokenAge(authenticationResult.getRefreshTokenAge());
-            brokerEvent.setSpeRing(authenticationResult.getSpeRing());
+            if (null != authenticationResult) {
+                brokerEvent.setServerErrorCode(authenticationResult.getServerErrorCode());
+                brokerEvent.setServerSubErrorCode(authenticationResult.getServerSubErrorCode());
+                brokerEvent.setRefreshTokenAge(authenticationResult.getRefreshTokenAge());
+                brokerEvent.setSpeRing(authenticationResult.getSpeRing());
+            }
         } else {
             Logger.v(TAG, "User is not specified, skipping background(silent) token request");
             authenticationResult = null;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -489,6 +489,19 @@ public final class AuthenticationConstants {
 
         /** String for ssl prefix. */
         public static final String REDIRECT_SSL_PREFIX = "https://";
+
+        public static final class CliTelemInfo {
+
+            private static final String sPrefix = "cliteleminfo.";
+
+            public static final String SERVER_ERROR = sPrefix + "server_error";
+
+            public static final String SERVER_SUBERROR = sPrefix + "server_suberror";
+
+            public static final String RT_AGE = sPrefix + "rt_age";
+
+            public static final String SPE_RING = sPrefix + "spe_ring";
+        }
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -381,7 +381,7 @@ public class AuthenticationResult implements Serializable {
         mFamilyClientId = familyClientId;
     }
 
-    public final String getServerErrorCode() {
+    final String getServerErrorCode() {
         return mServerErrorCode;
     }
 
@@ -389,7 +389,7 @@ public class AuthenticationResult implements Serializable {
         mServerErrorCode = serverErrorCode;
     }
 
-    public final String getServerSubErrorCode() {
+    final String getServerSubErrorCode() {
         return mServerSubErrorCode;
     }
 
@@ -397,7 +397,7 @@ public class AuthenticationResult implements Serializable {
         mServerSubErrorCode = serverSubErrorCode;
     }
 
-    public final String getRefreshTokenAge() {
+    final String getRefreshTokenAge() {
         return mRefreshTokenAge;
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -89,6 +89,12 @@ public class AuthenticationResult implements Serializable {
 
     private Date mExtendedExpiresOn;
 
+    private String mServerErrorCode;
+
+    private String mServerSubErrorCode;
+
+    private String mRefreshTokenAge;
+
     private String mSpeRing;
 
     AuthenticationResult() {
@@ -373,6 +379,30 @@ public class AuthenticationResult implements Serializable {
     
     final void setFamilyClientId(final String familyClientId) {
         mFamilyClientId = familyClientId;
+    }
+
+    public final String getServerErrorCode() {
+        return mServerErrorCode;
+    }
+
+    final void setServerErrorCode(final String serverErrorCode) {
+        mServerErrorCode = serverErrorCode;
+    }
+
+    public final String getServerSubErrorCode() {
+        return mServerSubErrorCode;
+    }
+
+    final void setServerSubErrorCode(final String serverSubErrorCode) {
+        mServerSubErrorCode = serverSubErrorCode;
+    }
+
+    public final String getRefreshTokenAge() {
+        return mRefreshTokenAge;
+    }
+
+    final void setRefreshTokenAge(final String refreshTokenAge) {
+        mRefreshTokenAge = refreshTokenAge;
     }
 
     final String getSpeRing() {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -26,6 +26,8 @@ package com.microsoft.aad.adal;
 import java.io.Serializable;
 import java.util.Date;
 
+import static com.microsoft.aad.adal.TelemetryUtils.CliTelemInfo;
+
 /**
  * Result class to keep code, token and other info Serializable properties Mark
  * temp properties as Transient if you dont want to keep them in serialization.
@@ -89,13 +91,7 @@ public class AuthenticationResult implements Serializable {
 
     private Date mExtendedExpiresOn;
 
-    private String mServerErrorCode;
-
-    private String mServerSubErrorCode;
-
-    private String mRefreshTokenAge;
-
-    private String mSpeRing;
+    private CliTelemInfo mCliTelemInfo;
 
     AuthenticationResult() {
         mCode = null;
@@ -381,35 +377,11 @@ public class AuthenticationResult implements Serializable {
         mFamilyClientId = familyClientId;
     }
 
-    final String getServerErrorCode() {
-        return mServerErrorCode;
+    final CliTelemInfo getCliTelemInfo() {
+        return mCliTelemInfo;
     }
 
-    final void setServerErrorCode(final String serverErrorCode) {
-        mServerErrorCode = serverErrorCode;
-    }
-
-    final String getServerSubErrorCode() {
-        return mServerSubErrorCode;
-    }
-
-    final void setServerSubErrorCode(final String serverSubErrorCode) {
-        mServerSubErrorCode = serverSubErrorCode;
-    }
-
-    final String getRefreshTokenAge() {
-        return mRefreshTokenAge;
-    }
-
-    final void setRefreshTokenAge(final String refreshTokenAge) {
-        mRefreshTokenAge = refreshTokenAge;
-    }
-
-    final String getSpeRing() {
-        return mSpeRing;
-    }
-
-    final void setSpeRing(final String speRing) {
-        mSpeRing = speRing;
+    final void setCliTelemInfo(final CliTelemInfo cliTelemInfo) {
+        mCliTelemInfo = cliTelemInfo;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -481,10 +481,10 @@ class BrokerProxy implements IBrokerProxy {
                     "", expires, false, userinfo, tenantId, "", null);
 
             // set the x-ms-clitelem data
-            result.setServerErrorCode(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR));
-            result.setServerSubErrorCode(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR));
-            result.setRefreshTokenAge(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.RT_AGE));
-            result.setSpeRing(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SPE_RING));
+            result.setServerErrorCode(bundleResult.getString(SERVER_ERROR));
+            result.setServerSubErrorCode(bundleResult.getString(SERVER_SUBERROR));
+            result.setRefreshTokenAge(bundleResult.getString(RT_AGE));
+            result.setSpeRing(bundleResult.getString(SPE_RING));
 
             return result;
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -70,6 +70,11 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.RT_AGE;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.SPE_RING;
+
 /**
  * Handles interactions to authenticator inside the Account Manager.
  */
@@ -472,8 +477,16 @@ class BrokerProxy implements IBrokerProxy {
                 expires = new Date(bundleResult.getLong(AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE));
             }
 
-            return new AuthenticationResult(bundleResult.getString(AccountManager.KEY_AUTHTOKEN),
+            final AuthenticationResult result = new AuthenticationResult(bundleResult.getString(AccountManager.KEY_AUTHTOKEN),
                     "", expires, false, userinfo, tenantId, "", null);
+
+            // set the x-ms-clitelem data
+            result.setServerErrorCode(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR));
+            result.setServerSubErrorCode(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR));
+            result.setRefreshTokenAge(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.RT_AGE));
+            result.setSpeRing(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SPE_RING));
+
+            return result;
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -481,10 +481,12 @@ class BrokerProxy implements IBrokerProxy {
                     "", expires, false, userinfo, tenantId, "", null);
 
             // set the x-ms-clitelem data
-            result.setServerErrorCode(bundleResult.getString(SERVER_ERROR));
-            result.setServerSubErrorCode(bundleResult.getString(SERVER_SUBERROR));
-            result.setRefreshTokenAge(bundleResult.getString(RT_AGE));
-            result.setSpeRing(bundleResult.getString(SPE_RING));
+            final TelemetryUtils.CliTelemInfo cliTelemInfo = new TelemetryUtils.CliTelemInfo();
+            cliTelemInfo.setServerErrorCode(bundleResult.getString(SERVER_ERROR));
+            cliTelemInfo.setServerSubErrorCode(bundleResult.getString(SERVER_SUBERROR));
+            cliTelemInfo.setRefreshTokenAge(bundleResult.getString(RT_AGE));
+            cliTelemInfo.setSpeRing(bundleResult.getString(SPE_RING));
+            result.setCliTelemInfo(cliTelemInfo);
 
             return result;
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -663,7 +663,9 @@ class Oauth2 {
             try {
                 result = parseJsonResponse(webResponse.getBody());
                 if (result != null) {
-                    result.setSpeRing(speRing);
+                    final CliTelemInfo cliTelemInfo = new CliTelemInfo();
+                    cliTelemInfo.setSpeRing(speRing);
+                    result.setCliTelemInfo(cliTelemInfo);
                     httpEvent.setOauthErrorCode(result.getErrorCode());
                 }
             } catch (final JSONException jsonException) {

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheItem.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheItem.java
@@ -115,7 +115,9 @@ public class TokenCacheItem implements Serializable {
         mRefreshtoken = authenticationResult.getRefreshToken();
         mFamilyClientId = authenticationResult.getFamilyClientId();
         mExtendedExpiresOn = authenticationResult.getExtendedExpiresOn();
-        mSpeRing = authenticationResult.getSpeRing();
+        if (null != authenticationResult.getCliTelemInfo()) {
+            mSpeRing = authenticationResult.getCliTelemInfo().getSpeRing();
+        }
     }
 
     /**

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/APIEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/APIEvent.java
@@ -144,6 +144,32 @@ final class APIEvent extends DefaultEvent {
         }
     }
 
+    void setServerErrorCode(final String errorCode) {
+        if (null != errorCode && !errorCode.equals("0")) {
+            setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
+        }
+    }
+
+    void setServerSubErrorCode(final String subErrorCode) {
+        if (null != subErrorCode && !subErrorCode.equals("0")) {
+            setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
+
+        }
+    }
+
+    void setRefreshTokenAge(final String tokenAge) {
+        if (!StringExtensions.isNullOrBlank(tokenAge)) {
+            setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
+
+        }
+    }
+
+    void setSpeRing(final String speRing) {
+        if (!StringExtensions.isNullOrBlank(speRing)) {
+            setProperty(EventStrings.SPE_INFO, speRing.trim());
+        }
+    }
+
     /**
      * Each event chooses which of its members get picked on aggregation.
      * @param dispatchMap the Map that is filled with the aggregated event properties
@@ -165,7 +191,9 @@ final class APIEvent extends DefaultEvent {
                     || name.equals(EventStrings.USER_ID) || name.equals(EventStrings.LOGIN_HINT)
                     || name.equals(EventStrings.RESPONSE_TIME) || name.equals(EventStrings.CORRELATION_ID)
                     || name.equals(EventStrings.REQUEST_ID) || name.equals(EventStrings.API_ID)
-                    || name.equals(EventStrings.API_ERROR_CODE)) {
+                    || name.equals(EventStrings.API_ERROR_CODE) || name.equals(EventStrings.SERVER_ERROR_CODE)
+                    || name.equals(EventStrings.SERVER_SUBERROR_CODE) || name.equals(EventStrings.TOKEN_AGE)
+                    || name.equals(EventStrings.SPE_INFO)) {
                 dispatchMap.put(name, eventPair.second);
             }
         }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
@@ -58,13 +58,13 @@ final class BrokerEvent extends DefaultEvent {
     }
 
     void setServerErrorCode(final String errorCode) {
-        if (null != errorCode && !errorCode.equals("0")) {
+        if (!StringExtensions.isNullOrBlank(errorCode) && !errorCode.equals("0")) {
             setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
         }
     }
 
     void setServerSubErrorCode(final String subErrorCode) {
-        if (null != subErrorCode && !subErrorCode.equals("0")) {
+        if (!StringExtensions.isNullOrBlank(subErrorCode) && !subErrorCode.equals("0")) {
             setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
 
         }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
@@ -57,6 +57,32 @@ final class BrokerEvent extends DefaultEvent {
         setProperty(EventStrings.BROKER_ACCOUNT_SERVICE_CONNECTED, Boolean.toString(true));
     }
 
+    void setServerErrorCode(final String errorCode) {
+        if (null != errorCode && !errorCode.equals("0")) {
+            setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
+        }
+    }
+
+    void setServerSubErrorCode(final String subErrorCode) {
+        if (null != subErrorCode && !subErrorCode.equals("0")) {
+            setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
+
+        }
+    }
+
+    void setRefreshTokenAge(final String tokenAge) {
+        if (!StringExtensions.isNullOrBlank(tokenAge)) {
+            setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
+
+        }
+    }
+
+    void setSpeRing(final String speRing) {
+        if (!StringExtensions.isNullOrBlank(speRing)) {
+            setProperty(EventStrings.SPE_INFO, speRing.trim());
+        }
+    }
+
     @Override
     public void processEvent(final Map<String, String> dispatchMap) {
         final List<Pair<String, String>> eventList = getEventList();

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
@@ -86,6 +86,10 @@ final class CacheEvent extends DefaultEvent {
         dispatchMap.put(EventStrings.TOKEN_TYPE_IS_MRRT, "");
         dispatchMap.put(EventStrings.TOKEN_TYPE_IS_RT, "");
 
+        if (dispatchMap.containsKey(EventStrings.SPE_INFO)) {
+            dispatchMap.remove(EventStrings.SPE_INFO);
+        }
+
         for (Pair<String, String> eventPair : eventList) {
             final String name = eventPair.first;
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/CacheEvent.java
@@ -37,7 +37,7 @@ final class CacheEvent extends DefaultEvent {
     }
 
     void setSpeRing(final String speRing) {
-        if (null != speRing) {
+        if (!StringExtensions.isNullOrBlank(speRing)) {
             setProperty(EventStrings.SPE_INFO, speRing.trim());
         }
     }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -97,47 +97,34 @@ final class HttpEvent extends DefaultEvent {
             return;
         }
 
-        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getServerErrorCode())
-                && !cliTelemInfo.getServerErrorCode().equals("0")) {
-            setServerErrorCode(cliTelemInfo.getServerErrorCode());
-        }
-
-        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getServerSubErrorCode())
-                && !cliTelemInfo.getServerSubErrorCode().equals("0")) {
-            setServerSubErrorCode(cliTelemInfo.getServerSubErrorCode());
-        }
-
-        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getRefreshTokenAge())) {
-            setRefreshTokenAge(cliTelemInfo.getRefreshTokenAge());
-        }
-
-        if (!StringExtensions.isNullOrBlank(cliTelemInfo.getSpeRing())) {
-            setSpeRing(cliTelemInfo.getSpeRing());
-        }
+        setServerErrorCode(cliTelemInfo.getServerErrorCode());
+        setServerSubErrorCode(cliTelemInfo.getServerSubErrorCode());
+        setRefreshTokenAge(cliTelemInfo.getRefreshTokenAge());
+        setSpeRing(cliTelemInfo.getSpeRing());
     }
 
     void setServerErrorCode(final String errorCode) {
-        if (null != errorCode) {
+        if (!StringExtensions.isNullOrBlank(errorCode) && !errorCode.equals("0")) {
             setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());
         }
     }
 
     void setServerSubErrorCode(final String subErrorCode) {
-        if (null != subErrorCode) {
+        if (!StringExtensions.isNullOrBlank(subErrorCode) && !subErrorCode.equals("0")) {
             setProperty(EventStrings.SERVER_SUBERROR_CODE, subErrorCode.trim());
 
         }
     }
 
     void setRefreshTokenAge(final String tokenAge) {
-        if (null != tokenAge) {
+        if (!StringExtensions.isNullOrBlank(tokenAge)) {
             setProperty(EventStrings.TOKEN_AGE, tokenAge.trim());
 
         }
     }
 
     void setSpeRing(final String speRing) {
-        if (null != speRing) {
+        if (!StringExtensions.isNullOrBlank(speRing)) {
             setProperty(EventStrings.SPE_INFO, speRing.trim());
         }
     }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,7 +35,7 @@ final class TelemetryUtils {
 
     private static final String TAG = TelemetryUtils.class.getSimpleName();
 
-    static class CliTelemInfo {
+    static class CliTelemInfo implements Serializable {
 
         private String mVersion;
         private String mServerErrorCode;

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
@@ -72,7 +72,7 @@ public class Constants {
     }
 
     enum RedirectUri {
-        Regular("msauth://example.adal.aad.microsoft.com.userappwithbroker/IcB5PxIyvbLkbFVtBI%2FitkW%2Fejk%3D"),
+        Regular("msauth://com.microsoft.aad.adal.userappwithbroker/IcB5PxIyvbLkbFVtBI%2FitkW%2Fejk%3D"),
         Broker("urn:ietf:wg:oauth:2.0:oob");
 
         private final String text;


### PR DESCRIPTION
This a 3-part change to add support to the broker for tracking `x-ms-clitelem` metadata from `/token` requests.