### PR TITLE
fix issue #899, OnePlus bindService issue.

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
@@ -585,7 +585,12 @@ public enum ADALError {
     /**
      * The value of the x-ms-clitelem header contained malformed data.
      */
-    X_MS_CLITELEM_MALFORMED("Malformed x-ms-clitelem header");
+    X_MS_CLITELEM_MALFORMED("Malformed x-ms-clitelem header"),
+
+    /**
+     * Failed to bind the service in broker app.
+     */
+    BROKER_BIND_SERVICE_FAILED("Failed to bind the service in broker app");
 
     private String mDescription;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -324,6 +324,10 @@ final class BrokerAccountServiceHandler {
         if (brokerEvent != null) {
             brokerEvent.setBrokerAccountServiceBindingSucceed(serviceBound);
         }
+        if (!serviceBound) {
+            context.unbindService(connection);
+            callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
+        }
     }
 
     private class BrokerAccountServiceConnection implements android.content.ServiceConnection {

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -327,7 +327,7 @@ final class BrokerAccountServiceHandler {
             brokerEvent.setBrokerAccountServiceBindingSucceed(serviceBound);
         }
         if (!serviceBound) {
-            context.unbindService(connection);
+            connection.unBindService(context);
             callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
         } else {
             // make sure it's bound to the service with success in a period not longer than the TIMEOUT
@@ -336,7 +336,7 @@ final class BrokerAccountServiceHandler {
                 @Override
                 public void run() {
                     if (!connection.isBound()) {
-                        context.unbindService(connection);
+                        connection.unBindService(context);
                         callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
                     }
                 }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -316,7 +316,7 @@ final class BrokerAccountServiceHandler {
         final Intent brokerAccountServiceToBind = getIntentForBrokerAccountService(context);
 
         final BrokerAccountServiceConnection connection = new BrokerAccountServiceConnection();
-        BindServiceTimeoutRunnable timeoutRunnable = new BindServiceTimeoutRunnable(context, connection, callback);
+        final BindServiceTimeoutRunnable timeoutRunnable = new BindServiceTimeoutRunnable(context, connection, callback);
         connection.setBindServiceTimeoutCallback(timeoutRunnable);
 
         if (brokerEvent != null) {
@@ -332,7 +332,7 @@ final class BrokerAccountServiceHandler {
         }
         if (!serviceBound) {
             connection.unBindService(context);
-            callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
+            callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED, "'bindService' returned 'false'"));
         } else {
             // make sure it's bound to the service with success in a period not longer than the TIMEOUT
             mUiHandler.postDelayed(timeoutRunnable, BIND_SERVICE_TIMEOUT_THRESHOLD);
@@ -354,7 +354,7 @@ final class BrokerAccountServiceHandler {
         public void run() {
             if (!mServiceConnection.isBound()) {
                 mServiceConnection.unBindService(mContext);
-                mCallback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
+                mCallback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED, "'bindService' timeout."));
             }
         }
     }


### PR DESCRIPTION
resolve https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/899

Previously, we didn't check the return value of 'bindService'. It seems 'bindService' returned false quite often on OnePlus and some other devices, then we need to call 'unbindService' in this case to avoid any leak of ServiceConnection.