### PR TITLE
Return different error code when communication with broker fails | Fix for issue 901

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -339,7 +339,7 @@ public final class AcquireTokenRequestTest {
 
         final AccountManager mockedAccountManager = getMockedAccountManager();
         mockAccountManagerGetAccountBehavior(mockedAccountManager);
-        mockGetAuthTokenCallWithThrow(mockedAccountManager);
+        mockGetAuthTokenCallWithNoAccountFound(mockedAccountManager);
         mockAddAccountCall(mockedAccountManager);
 
         final FileMockContext mockContext = createMockContext();
@@ -1252,10 +1252,10 @@ public final class AcquireTokenRequestTest {
                 .thenReturn(mockedResult);
     }
 
-    private void mockGetAuthTokenCallWithThrow(final AccountManager mockedAccountManager)
+    private void mockGetAuthTokenCallWithNoAccountFound(final AccountManager mockedAccountManager)
             throws OperationCanceledException, IOException, AuthenticatorException {
         final AccountManagerFuture<Bundle> mockedResult = Mockito.mock(AccountManagerFuture.class);
-        when(mockedResult.getResult()).thenThrow(mock(AuthenticatorException.class));
+        when(mockedResult.getResult()).thenReturn(null);
 
         when(mockedAccountManager.getAuthToken(Mockito.any(Account.class), Matchers.anyString(),
                 Matchers.any(Bundle.class), Matchers.eq(false), (AccountManagerCallback<Bundle>) Matchers.eq(null),

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -166,14 +166,14 @@ public final class BrokerAccountServiceTest {
     }
 
     @Test
-    public void testGetAuthTokenVerifyNoNetwork() throws InterruptedException, AuthenticatorException,OperationCanceledException, IOException {
+    public void testGetAuthTokenVerifyNoNetwork() throws InterruptedException, AuthenticatorException, OperationCanceledException, IOException {
         final CountDownLatch latch = new CountDownLatch(1);
         sThreadExecutor.execute(new Runnable() {
             @Override
             public void run() {
                 final Context mockContext = getMockContext();
                 Bundle requestBundle = new Bundle();
-                requestBundle.putString("isConnectionAvailable","false");
+                requestBundle.putString("isConnectionAvailable", "false");
 
                 try {
                     final Bundle bundle = BrokerAccountServiceHandler.getInstance().getAuthToken(mockContext, requestBundle, getBrokerEvent());
@@ -187,7 +187,30 @@ public final class BrokerAccountServiceTest {
             }
         });
         latch.await();
+    }
 
+    @Test
+    public void testGetAuthTokenVerifyThrowOperationCanceledException() throws InterruptedException, AuthenticatorException, OperationCanceledException, IOException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        sThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final Context mockContext = getMockContext();
+                Bundle requestBundle = new Bundle();
+                requestBundle.putString(OperationCanceledException.class.toString(), "true");
+
+                try {
+                    final Bundle bundle = BrokerAccountServiceHandler.getInstance().getAuthToken(mockContext, requestBundle, getBrokerEvent());
+                    Assert.assertTrue(bundle.getInt(AccountManager.KEY_ERROR_CODE) == AccountManager.ERROR_CODE_CANCELED);
+                    Assert.assertTrue(bundle.getString(AccountManager.KEY_ERROR_MESSAGE).equals(ADALError.AUTH_FAILED_CANCELLED.getDescription()));
+                } catch (final AuthenticationException e) {
+                    fail();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        latch.await();
     }
 
     @Test

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -150,8 +150,18 @@ final class BrokerAccountServiceHandler {
         }
 
         final Throwable throwable = exception.getAndSet(null);
+        //AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING will be thrown if there is any exception thrown during binding the service.
         if (throwable != null) {
-            throw new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, throwable.getMessage(), throwable);
+            if (throwable instanceof RemoteException) {
+                Logger.e(TAG, "Get error when trying to get token from broker: " + throwable.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
+            } else if (throwable instanceof InterruptedException) {
+                Logger.e(TAG, "The broker account service binding call is interrupted. "  + throwable.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_EXCEPTION, throwable);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
+            } else {
+                Logger.e(TAG, "Get error when trying to bind the broker account service." + throwable.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
+            }
         }
 
         return bundleResult.getAndSet(null);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -70,6 +70,8 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import static com.microsoft.aad.adal.AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT;
+
 /**
  * Handles interactions to authenticator inside the Account Manager.
  */
@@ -318,6 +320,7 @@ class BrokerProxy implements IBrokerProxy {
         } else {
             bundleResult = getAuthTokenFromAccountManager(request, requestBundle);
         }
+
         if (bundleResult == null) {
             Logger.v(TAG, "No bundle result returned from broker for silent request.");
             return null;
@@ -349,29 +352,44 @@ class BrokerProxy implements IBrokerProxy {
                 // Making blocking request here
                 Logger.v(TAG, "Received result from broker");
                 bundleResult = result.getResult();
-            } catch (OperationCanceledException e) {
+            } catch (final OperationCanceledException e) {
+                // Error code AUTH_FAILED_CANCELLED will be thrown if the request was canceled for any reason.
                 Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.AUTH_FAILED_CANCELLED, e);
-            } catch (AuthenticatorException e) {
-                Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
+                throw new AuthenticationException(ADALError.AUTH_FAILED_CANCELLED, e.getMessage(), e);
+            } catch (final AuthenticatorException e) {
+                // Error code BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN will be thrown if there was an error
+                // communicating with the authenticator or if the authenticator returned an invalid response.
+                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(INVALID_GRANT)){
+                    Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST,
+                            "Acquire token failed with 'invalid grant' error, cannot proceed with silent request.",
+                            ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
+                    throw new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, e.getMessage());
+                } else {
+                    Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN);
+                    throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN, e.getMessage());
+                }
+            } catch (final IOException e) {
+                //  Error code BROKER_AUTHENTICATOR_IO_EXCEPTION will be thrown
+                //  when Authenticator gets problem from webrequest or file read/write or network error
+                Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION);
+
                 if (e.getMessage() != null && e.getMessage().contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.getDescription())) {
                     throw new AuthenticationException(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE,
                             "Received error from broker, errorCode: " + e.getMessage());
                 } else if (e.getMessage() != null && e.getMessage().contains(ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION.getDescription())) {
                     throw new AuthenticationException(ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION,
                             "Received error from broker, errorCode: " + e.getMessage());
+                } else {
+                    throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION, e.getMessage(), e);
                 }
-            } catch (IOException e) {
-                // Authenticator gets problem from webrequest or file read/write
-                Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION);
             }
 
             Logger.v(TAG, "Returning result from broker");
             return bundleResult;
         } else {
             Logger.v(TAG, "Target account is not found");
+            return null;
         }
-
-        return null;
     }
 
     private boolean isBrokerAccountServiceSupported() {
@@ -424,25 +442,31 @@ class BrokerProxy implements IBrokerProxy {
         if (!StringExtensions.isNullOrBlank(msg)) {
             final ADALError adalErrorCode;
             switch (errCode) {
-            case AccountManager.ERROR_CODE_BAD_ARGUMENTS:
-                adalErrorCode = ADALError.BROKER_AUTHENTICATOR_BAD_ARGUMENTS;
-                break;
-            case ACCOUNT_MANAGER_ERROR_CODE_BAD_AUTHENTICATION:
-                adalErrorCode = ADALError.BROKER_AUTHENTICATOR_BAD_AUTHENTICATION;
-                break;
-            case AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION:
-                adalErrorCode = ADALError.BROKER_AUTHENTICATOR_UNSUPPORTED_OPERATION;
-                break;
-            case AccountManager.ERROR_CODE_NETWORK_ERROR:
-                if (msg.contains(ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION.getDescription())) {
-                    adalErrorCode = ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION;
+                case AccountManager.ERROR_CODE_BAD_ARGUMENTS:
+                    adalErrorCode = ADALError.BROKER_AUTHENTICATOR_BAD_ARGUMENTS;
                     break;
-                } else {
-                    adalErrorCode = ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE;
+                case ACCOUNT_MANAGER_ERROR_CODE_BAD_AUTHENTICATION:
+                    adalErrorCode = ADALError.BROKER_AUTHENTICATOR_BAD_AUTHENTICATION;
                     break;
-                }
-            default:
-                adalErrorCode = ADALError.BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN;
+                case AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION:
+                    adalErrorCode = ADALError.BROKER_AUTHENTICATOR_UNSUPPORTED_OPERATION;
+                    break;
+                case AccountManager.ERROR_CODE_CANCELED:
+                    adalErrorCode = ADALError.AUTH_FAILED_CANCELLED;
+                    break;
+                case AccountManager.ERROR_CODE_NETWORK_ERROR:
+                    if (msg.contains(ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION.getDescription())) {
+                        adalErrorCode = ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION;
+                        break;
+                    } else if (msg.contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.getDescription())){
+                        adalErrorCode = ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE;
+                        break;
+                    } else {
+                        adalErrorCode = ADALError.BROKER_AUTHENTICATOR_IO_EXCEPTION;
+                        break;
+                    }
+                default:
+                    adalErrorCode = ADALError.BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN;
             }
 
             throw new AuthenticationException(adalErrorCode, msg);


### PR DESCRIPTION
When silent auth with broker fails, throw correct AuthenticationException with corresponding error code. AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED is only returned when broker did not found token when doing the silent auth. And in this case, an interactive auth is needed to get new tokens.

| ADALError  | When | Note |
| ------------- | ------------- | ------------- |
| BROKER_AUTHENTICATOR_NOT_RESPONDING  | error occurs when trying to get token from broker  | this is a retry-able error  |
| AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED  | 1) no account found in broker 2) the token in broker is invalid  | UI prompt is needed to get new tokens  |
| BROKER_AUTHENTICATOR_BAD_ARGUMENTS  | get ERROR_CODE_BAD_ARGUMENTS from AccountManager  |   |
| BROKER_AUTHENTICATOR_UNSUPPORTED_OPERATION | get ERROR_CODE_UNSUPPORTED_OPERATION from AccountManager |   |
| AUTH_FAILED_CANCELLED | get ERROR_CODE_CANCELED from AccountManager  |   |
| BROKER_AUTHENTICATOR_IO_EXCEPTION | when there is I/O error occurs during broker auth  |   |
| BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN | other error from broker auths  |   |
| BROKER_AUTHENTICATOR_BAD_AUTHENTICATION | get ERROR_CODE_BAD_AUTHENTICATION from AccountManager |   |