### PR TITLE
Host RC builds on VSTS for partner teams to integrate easily | User Story 280835

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -230,6 +230,28 @@ publishing {
     }
 
     // Repositories to which Gradle can publish artifacts
+    if (System.getenv("VSTS_ENV_ACCESS_TOKEN") != null || vstsMavenAccessToken != null) {
+        repositories {
+            maven {
+                name "vsts-maven-adal-android"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                credentials {
+                    username "VSTS"
+                    password System.getenv("VSTS_ENV_ACCESS_TOKEN") != null ? System.getenv("VSTS_ENV_ACCESS_TOKEN") : vstsMavenAccessToken
+                }
+            }
+        }
+    } else {
+        repositories {
+            maven {
+                url "\\\\adalbuildvm\\AndroidRelease\\repository"
+            }
+        }
+    }
+}
+
+// Repositories from which Gradle can fetch dependencies
+if (System.getenv("VSTS_ENV_ACCESS_TOKEN") != null || vstsMavenAccessToken != null) {
     repositories {
         maven {
             name "vsts-maven-adal-android"
@@ -238,18 +260,6 @@ publishing {
                 username "VSTS"
                 password System.getenv("VSTS_ENV_ACCESS_TOKEN") != null ? System.getenv("VSTS_ENV_ACCESS_TOKEN") : vstsMavenAccessToken
             }
-        }
-    }
-}
-
-// Repositories from which Gradle can fetch dependencies
-repositories {
-    maven {
-        name "vsts-maven-adal-android"
-        url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
-        credentials {
-            username "VSTS"
-            password System.getenv("VSTS_ENV_ACCESS_TOKEN") != null ? System.getenv("VSTS_ENV_ACCESS_TOKEN") : vstsMavenAccessToken
         }
     }
 }

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -229,9 +229,27 @@ publishing {
         }
     }
 
+    // Repositories to which Gradle can publish artifacts
     repositories {
         maven {
-            url "\\\\adalbuildvm\\AndroidRelease\\repository";
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username "VSTS"
+                password System.getenv("VSTS_ENV_ACCESS_TOKEN") != null ? System.getenv("VSTS_ENV_ACCESS_TOKEN") : vstsMavenAccessToken
+            }
+        }
+    }
+}
+
+// Repositories from which Gradle can fetch dependencies
+repositories {
+    maven {
+        name "vsts-maven-adal-android"
+        url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+        credentials {
+            username "VSTS"
+            password System.getenv("VSTS_ENV_ACCESS_TOKEN") != null ? System.getenv("VSTS_ENV_ACCESS_TOKEN") : vstsMavenAccessToken
         }
     }
 }


### PR DESCRIPTION
Task: [User Story 280835](https://identitydivision.visualstudio.com/DevEx/_workitems/edit/280835)
Description:
Host RC builds on VSTS for partner teams to integrate easily.
Usage:
To publish files to run [Artifactory](https://identitydivision.visualstudio.com/DevEx/_packaging?feed=AndroidADAL&_a=feed), you can build and publish script below
_gradle clean build publish_
