### PR TITLE
fix the case that 'bindService' returned false for issue #899

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
@@ -585,7 +585,12 @@ public enum ADALError {
     /**
      * The value of the x-ms-clitelem header contained malformed data.
      */
-    X_MS_CLITELEM_MALFORMED("Malformed x-ms-clitelem header");
+    X_MS_CLITELEM_MALFORMED("Malformed x-ms-clitelem header"),
+
+    /**
+     * Failed to bind the service in broker app.
+     */
+    BROKER_BIND_SERVICE_FAILED("Failed to bind the service in broker app");
 
     private String mDescription;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -327,6 +327,7 @@ final class BrokerAccountServiceHandler {
         if (!serviceBound) {
             connection.unBindService(context);
             callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
+            Logger.e(TAG, "Failed to bind service to broker app", "'bindService' returned false", ADALError.BROKER_BIND_SERVICE_FAILED);
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -326,8 +326,8 @@ final class BrokerAccountServiceHandler {
         }
         if (!serviceBound) {
             connection.unBindService(context);
-            callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
             Logger.e(TAG, "Failed to bind service to broker app", "'bindService' returned false", ADALError.BROKER_BIND_SERVICE_FAILED);
+            callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -324,6 +324,10 @@ final class BrokerAccountServiceHandler {
         if (brokerEvent != null) {
             brokerEvent.setBrokerAccountServiceBindingSucceed(serviceBound);
         }
+        if (!serviceBound) {
+            connection.unBindService(context);
+            callback.onError(new AuthenticationException(ADALError.BROKER_BIND_SERVICE_FAILED));
+        }
     }
 
     private class BrokerAccountServiceConnection implements android.content.ServiceConnection {


### PR DESCRIPTION
This is a part of fix to issue https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/899 .
 It will fix the case that "bindService" return false. In this case, this change will unbind the service according to Android doc to avoid memory leak on ServiceConnection.

