### PR TITLE
foci serialize API update for authority migration update

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -44,6 +44,7 @@ import android.support.test.InstrumentationRegistry;
 import android.util.Base64;
 import android.util.Log;
 
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -172,7 +173,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testFavorLocalCacheUseLocalRTFailsSwitchToBroker()
             throws PackageManager.NameNotFoundException, OperationCanceledException, IOException,
-            AuthenticatorException, InterruptedException {
+            AuthenticatorException, InterruptedException, JSONException {
         // Make sure AT is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), true, true, null);
 
@@ -231,7 +232,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testFavorLocalCacheUseLocalRTFailsWithInvalidGrantSwitchToBroker()
             throws PackageManager.NameNotFoundException, OperationCanceledException,
-            IOException, AuthenticatorException, InterruptedException {
+            IOException, AuthenticatorException, InterruptedException, JSONException {
 
         // Make sure AT is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), true, false, null);
@@ -291,7 +292,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testFavorLocalCacheUseLocalRTSucceeds()
             throws PackageManager.NameNotFoundException, OperationCanceledException,
-            IOException, AuthenticatorException, InterruptedException {
+            IOException, AuthenticatorException, InterruptedException, JSONException {
         // Make sure AT is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, null);
 
@@ -332,7 +333,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testBothLocalAndBrokerSilentAuthFailedSwitchedToBrokerForInteractive()
             throws OperationCanceledException, IOException, AuthenticatorException,
-            PackageManager.NameNotFoundException, InterruptedException {
+            PackageManager.NameNotFoundException, InterruptedException,JSONException {
 
         // Make sure AT is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, null);
@@ -384,7 +385,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testLocalSilentFailedBrokerSilentReturnErrorCannotTryWithInteractive()
             throws OperationCanceledException, IOException, AuthenticatorException,
-            PackageManager.NameNotFoundException, InterruptedException {
+            PackageManager.NameNotFoundException, InterruptedException, JSONException {
         // Make sure AT is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, null);
 
@@ -503,7 +504,8 @@ public final class AcquireTokenRequestTest {
         cacheStore.setItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, null), mrrtItem);
     }
 
-    public void testEmbeddedAuthCacheSkippedWhenClaimsSent() throws PackageManager.NameNotFoundException, IOException, InterruptedException {
+    public void testEmbeddedAuthCacheSkippedWhenClaimsSent() throws PackageManager.NameNotFoundException, IOException,
+            InterruptedException, JSONException {
         // Make sure AT is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(MINUS_MINUTE), false, false, null);
         final FileMockContext mockContext = createMockContext();
@@ -604,7 +606,7 @@ public final class AcquireTokenRequestTest {
     }
 
     public void testBrokerAuthCacheSkippedWhenClaimsSent() throws PackageManager.NameNotFoundException, IOException,
-            OperationCanceledException, AuthenticatorException, InterruptedException {
+            OperationCanceledException, AuthenticatorException, InterruptedException, JSONException {
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, null);
 
         final AccountManager mockedAccountManager = getMockedAccountManager();
@@ -803,7 +805,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testResiliencyTokenReturnExtendedLifetimeOnMinServerError() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(EXTEND_MINUS_MINUTE));
 
@@ -837,7 +839,7 @@ public final class AcquireTokenRequestTest {
 
     public void testResiliencyTokenReturnExtendedLifetimeOnMaxServerError() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(EXTEND_MINUS_MINUTE));
 
@@ -876,7 +878,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testResiliencyTokenReturnExtendedLifetimeOnwithRetryFail() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(EXTEND_MINUS_MINUTE));
 
@@ -916,7 +918,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testResiliencyTokenReturnExtendedLifetimeOnwithExpiredStaleAT() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(-1));
 
@@ -953,7 +955,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testResiliencyTokenReturnExtendedLifetimeOnwithValidRetry() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(EXTEND_MINUS_MINUTE));
 
@@ -991,7 +993,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testResiliencyTokenReturnExtendedLifetimeOff() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(EXTEND_MINUS_MINUTE));
 
@@ -1030,7 +1032,7 @@ public final class AcquireTokenRequestTest {
     @Test
     public void testResiliencyTokenReturnExtendedLifetimeOnwithoutRetry() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is not expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), false, false, getExpireDate(EXTEND_MINUS_MINUTE));
 
@@ -1064,7 +1066,7 @@ public final class AcquireTokenRequestTest {
 
     public void testResiliencyTokenReturnExtendedLifetimeOnwithNullAccessTokenCacheItem() throws PackageManager.NameNotFoundException,
             NoSuchAlgorithmException, OperationCanceledException, IOException, AuthenticatorException,
-            InterruptedException {
+            InterruptedException, JSONException {
         // make sure AT's expires_in is expired and ext_expires_in is expired
         final ITokenCacheStore cacheStore = getTokenCache(getExpireDate(-MINUS_MINUTE), true, true, getExpireDate(EXTEND_MINUS_MINUTE));
         cacheStore.removeItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId", TEST_USERID));
@@ -1327,7 +1329,7 @@ public final class AcquireTokenRequestTest {
         AuthenticationSettings.INSTANCE.setUseBroker(true);
     }
 
-    private void prepareSuccessHttpUrlConnection() throws IOException {
+    private void prepareSuccessHttpUrlConnection() throws IOException, JSONException {
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
@@ -1337,7 +1339,7 @@ public final class AcquireTokenRequestTest {
         Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
     }
 
-    private HttpURLConnection prepareFailedHttpUrlConnection(final String errorCode, final String ...errorCodes) throws IOException {
+    private HttpURLConnection prepareFailedHttpUrlConnection(final String errorCode, final String ...errorCodes) throws IOException, JSONException {
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -31,6 +31,7 @@ import android.test.suitebuilder.annotation.SmallTest;
 
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
 
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +41,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
@@ -196,7 +196,7 @@ public final class AcquireTokenSilentHandlerTest {
 
     // Verify if regular RT exists, if the RT is not MRRT, we only redeem token with the regular RT. 
     @Test
-    public void testRegularRT() throws IOException {
+    public void testRegularRT() throws IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         final String resource = "resource";
@@ -258,7 +258,7 @@ public final class AcquireTokenSilentHandlerTest {
 
     // Test the current cache that does not mark RT as MRRT even it's MRRT.
     @Test
-    public void testRegularRTExistsMRRTForSameClientIdExist() throws IOException {
+    public void testRegularRTExistsMRRTForSameClientIdExist() throws IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         final String resource = "resource";
@@ -322,7 +322,7 @@ public final class AcquireTokenSilentHandlerTest {
      * Test only when MRRT without FoCI in the cache.
      */
     @Test
-    public void testMRRTSuccessNoFoCI() throws IOException {
+    public void testMRRTSuccessNoFoCI() throws IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         final String resource = "resource";
@@ -378,7 +378,7 @@ public final class AcquireTokenSilentHandlerTest {
      * refresh token.
      */
     @Test
-    public void testFRTSuccess() throws IOException {
+    public void testFRTSuccess() throws IOException, JSONException {
 
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
@@ -432,7 +432,7 @@ public final class AcquireTokenSilentHandlerTest {
      * Also make sure only FRT token entry is deleted.
      */
     @Test
-    public void testFRTFailedWithInvalidGrant() throws IOException {
+    public void testFRTFailedWithInvalidGrant() throws IOException, JSONException {
 
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
@@ -478,7 +478,7 @@ public final class AcquireTokenSilentHandlerTest {
      * Test if FRT request failed, retry with MRRT if exists.
      */
     @Test
-    public void testFRTRequestFailedFallBackMRRTRequest() throws IOException {
+    public void testFRTRequestFailedFallBackMRRTRequest() throws IOException, JSONException {
 
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getContext());
@@ -546,7 +546,7 @@ public final class AcquireTokenSilentHandlerTest {
      * only FRT token cache entry is removed.
      */
     @Test
-    public void testFRTRequestFailFallBackToMRTMRTRequestFail() throws IOException {
+    public void testFRTRequestFailFallBackToMRTMRTRequestFail() throws IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getContext());
         mockCache.removeAll();
@@ -627,7 +627,7 @@ public final class AcquireTokenSilentHandlerTest {
      * Test if MRRT is not marked as FRT, if the MRRT request fails, we will try with FRT.
      */
     @Test
-    public void testMRRTRequestFailsTryFRT() throws UnsupportedEncodingException, IOException {
+    public void testMRRTRequestFailsTryFRT() throws JSONException, IOException {
         FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getContext());
         mockCache.removeAll();
@@ -712,7 +712,7 @@ public final class AcquireTokenSilentHandlerTest {
      * Test RT request returns errors, but error response doesn't contain error_code.
      */
     @Test
-    public void testRefreshTokenRequestNotReturnErrorCode() throws IOException {
+    public void testRefreshTokenRequestNotReturnErrorCode() throws IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -754,7 +754,7 @@ public final class AcquireTokenSilentHandlerTest {
      * Test RT request failed with interaction_required, cache will not be cleared.
      */
     @Test
-    public void testRefreshTokenWithInteractionRequiredCacheNotCleared() throws IOException {
+    public void testRefreshTokenWithInteractionRequiredCacheNotCleared() throws IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -888,7 +888,7 @@ public final class AcquireTokenSilentHandlerTest {
     }
 
     @Test
-    public void testRTExistedInPreferredCache() throws IOException {
+    public void testRTExistedInPreferredCache() throws IOException, JSONException {
         final FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         clearCache(mockedCache);
@@ -950,7 +950,7 @@ public final class AcquireTokenSilentHandlerTest {
     }
 
     @Test
-    public void testMRRTExistInPreferredLocation() throws IOException {
+    public void testMRRTExistInPreferredLocation() throws IOException, JSONException {
         final FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         clearCache(mockedCache);
@@ -1010,7 +1010,7 @@ public final class AcquireTokenSilentHandlerTest {
     }
 
     @Test
-    public void testFRTExistedInPreferredLocation() throws IOException {
+    public void testFRTExistedInPreferredLocation() throws IOException, JSONException {
         final FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         clearCache(mockedCache);
@@ -1077,7 +1077,7 @@ public final class AcquireTokenSilentHandlerTest {
      * the developer specified authority token is used.
      */
     @Test
-    public void testTokenPresentForPassedInAuthorityAndOtherAliasedHost() throws IOException {
+    public void testTokenPresentForPassedInAuthorityAndOtherAliasedHost() throws IOException, JSONException {
         final FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         clearCache(mockedCache);
@@ -1142,7 +1142,7 @@ public final class AcquireTokenSilentHandlerTest {
     }
 
     @Test
-    public void testTokenForAliasedAuthorityPresent() throws IOException {
+    public void testTokenForAliasedAuthorityPresent() throws IOException, JSONException {
         final FileMockContext mockContext = new FileMockContext(getContext());
         final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
         clearCache(mockedCache);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -44,6 +44,7 @@ import com.google.gson.Gson;
 
 import junit.framework.Assert;
 
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -654,7 +655,7 @@ public final class AuthenticationContextTest {
      * @throws IOException
      */
     @Test
-    public void testAcquireTokenByRefreshTokenPositive() throws IOException, InterruptedException {
+    public void testAcquireTokenByRefreshTokenPositive() throws IOException, InterruptedException, JSONException {
         FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -702,7 +703,7 @@ public final class AuthenticationContextTest {
     }
 
     @Test
-    public void testAcquireTokenByRefreshTokenNotReturningRefreshToken() throws IOException, InterruptedException {
+    public void testAcquireTokenByRefreshTokenNotReturningRefreshToken() throws IOException, InterruptedException, JSONException {
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
         final AuthenticationContext context = getAuthenticationContext(mockContext,
@@ -979,12 +980,13 @@ public final class AuthenticationContextTest {
     }
 
     @Test
-    public void testScenarioUserIdLoginHintUse() throws InterruptedException, AuthenticationException, IOException {
+    public void testScenarioUserIdLoginHintUse() throws InterruptedException, AuthenticationException, IOException, JSONException {
         scenarioUserIdLoginHint("test@user.com", "test@user.com", "test@user.com");
     }
 
     private void scenarioUserIdLoginHint(final String idTokenUpn, final String responseIntentHint,
-                                         final String acquireTokenHint) throws InterruptedException, AuthenticationException, IOException {
+                                         final String acquireTokenHint)
+            throws InterruptedException, AuthenticationException, IOException, JSONException {
 
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final AuthenticationContext context = new AuthenticationContext(mockContext,
@@ -1038,7 +1040,7 @@ public final class AuthenticationContextTest {
     }
 
     @Test
-    public void testScenarioNullUserIdToken() throws InterruptedException, AuthenticationException, IOException {
+    public void testScenarioNullUserIdToken() throws InterruptedException, AuthenticationException, IOException, JSONException {
         scenarioUserIdLoginHint("test@user.com", "", "");
     }
 
@@ -1098,7 +1100,7 @@ public final class AuthenticationContextTest {
     }
 
     @Test
-    public void testScenarioEmptyIdToken() throws InterruptedException, AuthenticationException, IOException {
+    public void testScenarioEmptyIdToken() throws InterruptedException, AuthenticationException, IOException, JSONException {
         FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final AuthenticationContext context = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false);
@@ -1144,7 +1146,7 @@ public final class AuthenticationContextTest {
      */
     @Test
     public void testFamilyClientIdCorrectlyStoredInCache() throws IOException, InterruptedException,
-            AuthenticationException {
+            AuthenticationException, JSONException {
 
         FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
@@ -1196,7 +1198,7 @@ public final class AuthenticationContextTest {
      * b. Subsequent requests do not result in further authority validation network requests for the process lifetime.
      */
     @Test
-    public void testAuthorityValidationTurnedOffAndInstanceDiscoveryFailed() throws IOException, InterruptedException {
+    public void testAuthorityValidationTurnedOffAndInstanceDiscoveryFailed() throws IOException, InterruptedException, JSONException {
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final ITokenCacheStore mockedCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -1273,7 +1275,7 @@ public final class AuthenticationContextTest {
      * b.Subsequent requests do not result in further authority validation network requests for the process lifetime
      */
     @Test
-    public void testAuthorityValidationTurnedOnButNoMetadataReturned() throws IOException, InterruptedException {
+    public void testAuthorityValidationTurnedOnButNoMetadataReturned() throws IOException, InterruptedException, JSONException {
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final ITokenCacheStore mockedCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -1407,7 +1409,7 @@ public final class AuthenticationContextTest {
      * new tokens are written to cache using solely the preferred_cache authority
      */
     @Test
-    public void testNewTokenOnlyWrittenToPreferredCacheLocation() throws InterruptedException, IOException {
+    public void testNewTokenOnlyWrittenToPreferredCacheLocation() throws InterruptedException, IOException, JSONException {
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final ITokenCacheStore tokenCacheStore = new DefaultTokenCacheStore(mockContext);
 
@@ -1484,7 +1486,7 @@ public final class AuthenticationContextTest {
     }
 
     @Test
-    public void testCacheContainsPreferredCacheToken() throws InterruptedException, IOException {
+    public void testCacheContainsPreferredCacheToken() throws InterruptedException, IOException, JSONException {
         final String resource = "resource";
         final String clientId = "clientId";
         final ITokenCacheStore tokenCacheStore = getMockCache(-20, "accessToken", resource, clientId, TEST_IDTOKEN_USERID, false);
@@ -1535,7 +1537,7 @@ public final class AuthenticationContextTest {
      * preferred_network host is used for all subsequent network requests.
      */
     @Test
-    public void testCacheContainsPassedInAuthority() throws IOException, InterruptedException {
+    public void testCacheContainsPassedInAuthority() throws IOException, InterruptedException, JSONException {
         final String resource = "resource";
         final String clientId = "clientId";
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
@@ -1690,7 +1692,7 @@ public final class AuthenticationContextTest {
 
     @Test
     public void testAcquireTokenSilentSyncNegative() throws InterruptedException, AuthenticationException,
-            IOException {
+            IOException, JSONException {
         AuthorityValidationMetadataCache.clearAuthorityValidationCache();
 
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
@@ -33,6 +33,7 @@ import com.microsoft.aad.adal.Logger.LogLevel;
 
 import junit.framework.Assert;
 
+import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -74,7 +75,7 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
     }
 
     @Test
-    public void testCreateFromResourceUrlInvalidFormat() throws IOException {
+    public void testCreateFromResourceUrlInvalidFormat() throws IOException, JSONException {
         Log.d(TAG, "test:" + getClass().getName() + "thread:" + android.os.Process.myTid());
 
         //mock http response

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -25,6 +25,8 @@ package com.microsoft.aad.adal;
 import android.util.Base64;
 import android.util.Log;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
@@ -92,52 +94,58 @@ final class Util {
         return tokenCacheItem;
     }
 
-    static String getSuccessTokenResponseWithFamilyClientId() {
-        final String tokenResponse = "{\"id_token\":\""
-                + TEST_IDTOKEN
-                + "\",\"access_token\":\"I am a new access token\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"I am a new refresh token\",\"scope\":\"*\"";
+    static String getSuccessTokenResponseWithFamilyClientId() throws JSONException {
+        final JSONObject responseJsonObject = getCommonSuccessResponseData();
 
-        final StringBuilder tokenResponseBuilder = new StringBuilder(tokenResponse);
-        tokenResponseBuilder.append(",\"resource\":\"resource\"");
-        tokenResponseBuilder.append(",\"foci\":\"1\"}");
+        responseJsonObject.put("refresh_token", "I am a new refresh token");
+        responseJsonObject.put("resource", "resource");
+        responseJsonObject.put("foci", "1");
 
-        return tokenResponseBuilder.toString();
+        return responseJsonObject.toString();
     }
 
-    static String getSuccessTokenResponse(final boolean isMrrt, final boolean withFociFlag) {
-        final String tokenResponse = "{\"id_token\":\""
-                + TEST_IDTOKEN
-                + "\",\"access_token\":\"I am a new access token\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"I am a new refresh token\",\"scope\":\"*\"";
-        
-        final StringBuilder tokenResponseBuilder = new StringBuilder(tokenResponse);
+    static String getSuccessTokenResponse(final boolean isMrrt, final boolean withFociFlag) throws JSONException {
+        final JSONObject responseJsonObject = getCommonSuccessResponseData();
+        responseJsonObject.put(AuthenticationConstants.OAuth2.REFRESH_TOKEN, "I am a new refresh token");
         if (isMrrt) {
-            tokenResponseBuilder.append(",\"resource\":\"resource\"");
+            responseJsonObject.put(AuthenticationConstants.AAD.RESOURCE, "resource");
         }
-        
-        if (withFociFlag) {
-            tokenResponseBuilder.append(",\"foci\":\"familyClientId\"");
-        } 
-            
-        tokenResponseBuilder.append("}");
 
-        return tokenResponseBuilder.toString();
-    }
-    
-    static String getSuccessResponseWithoutRefreshToken() {
-        final String tokenResponse = "{\"id_token\":\""
-                + TEST_IDTOKEN
-                + "\",\"access_token\":\"I am a new access token\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"scope\":\"*\"}";
-        return tokenResponse;
-    }
-    
-    static String getErrorResponseBody(final String errorCode) {
-        final String errorDescription = "\"error_description\":\"AADSTS70000: Authentication failed. Refresh Token is not valid.\r\nTrace ID: bb27293d-74e4-4390-882b-037a63429026\r\nCorrelation ID: b73106d5-419b-4163-8bc6-d2c18f1b1a13\r\nTimestamp: 2014-11-06 18:39:47Z\",\"error_codes\":[70000],\"timestamp\":\"2014-11-06 18:39:47Z\",\"trace_id\":\"bb27293d-74e4-4390-882b-037a63429026\",\"correlation_id\":\"b73106d5-419b-4163-8bc6-d2c18f1b1a13\",\"submit_url\":null,\"context\":null";
-        
-        if (errorCode != null) {
-            return "{\"error\":\"" + errorCode + "\"," + errorDescription + "}";
+        if (withFociFlag) {
+            responseJsonObject.put(AuthenticationConstants.OAuth2.ADAL_CLIENT_FAMILY_ID, "familyClientId");
         }
-        
-        return "{" + errorDescription + "}";
+
+        return responseJsonObject.toString();
+    }
+    
+    static String getSuccessResponseWithoutRefreshToken() throws JSONException {
+        return getCommonSuccessResponseData().toString();
+    }
+
+    private static JSONObject getCommonSuccessResponseData() throws JSONException {
+        final JSONObject responseJsonObject = new JSONObject();
+        responseJsonObject.put(AuthenticationConstants.OAuth2.ID_TOKEN, TEST_IDTOKEN);
+        responseJsonObject.put(AuthenticationConstants.OAuth2.ACCESS_TOKEN, "I am a new access token");
+        responseJsonObject.put(AuthenticationConstants.OAuth2.TOKEN_TYPE, "Bearer");
+        responseJsonObject.put(AuthenticationConstants.OAuth2.EXPIRES_IN, "10");
+        responseJsonObject.put("expires_on", "1368768616");
+        responseJsonObject.put(AuthenticationConstants.OAuth2.SCOPE, "*");
+
+        return responseJsonObject;
+    }
+    
+    static String getErrorResponseBody(final String errorCode) throws JSONException {
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put(AuthenticationConstants.OAuth2.ERROR, errorCode);
+        jsonObject.put(AuthenticationConstants.OAuth2.ERROR_DESCRIPTION, "AADSTS70000: Authentication failed. Refresh Token is not valid.\n" +
+                "Trace ID: bb27293d-74e4-4390-882b-037a63429026\n" +
+                "Correlation ID: b73106d5-419b-4163-8bc6-d2c18f1b1a13\n" +
+                "Timestamp: 2014-11-06 18:39:47Z");
+        jsonObject.put(AuthenticationConstants.OAuth2.ERROR_CODES, "[70000]");
+        jsonObject.put("timestamp", "2014-11-06 18:39:47Z");
+        jsonObject.put("trace_id", "bb27293d-74e4-4390-882b-037a63429026");
+        jsonObject.put(AuthenticationConstants.AAD.CORRELATION_ID, "b73106d5-419b-4163-8bc6-d2c18f1b1a13");
+        return jsonObject.toString();
     }
     
     static byte[] getPoseMessage(final String refreshToken, final String clientId, final String resource) 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -91,7 +91,19 @@ final class Util {
         
         return tokenCacheItem;
     }
-    
+
+    static String getSuccessTokenResponseWithFamilyClientId() {
+        final String tokenResponse = "{\"id_token\":\""
+                + TEST_IDTOKEN
+                + "\",\"access_token\":\"I am a new access token\",\"token_type\":\"Bearer\",\"expires_in\":\"10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"I am a new refresh token\",\"scope\":\"*\"";
+
+        final StringBuilder tokenResponseBuilder = new StringBuilder(tokenResponse);
+        tokenResponseBuilder.append(",\"resource\":\"resource\"");
+        tokenResponseBuilder.append(",\"foci\":\"1\"}");
+
+        return tokenResponseBuilder.toString();
+    }
+
     static String getSuccessTokenResponse(final boolean isMrrt, final boolean withFociFlag) {
         final String tokenResponse = "{\"id_token\":\""
                 + TEST_IDTOKEN

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -40,6 +40,7 @@ import android.util.SparseArray;
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -1222,9 +1223,17 @@ public class AuthenticationContext {
          * apps. So the client ID for the FoCI token cache item is hard coded
          * below.
          */
-        final String cacheKey = CacheKey.createCacheKeyForFRT(this.getAuthority(),
-                AuthenticationConstants.MS_FAMILY_ID, uniqueUserId);
-        final TokenCacheItem tokenItem = this.getCache().getItem(cacheKey);
+        final TokenCacheAccessor tokenCacheAccessor = new TokenCacheAccessor(mTokenCacheStore, this.getAuthority(),
+                Telemetry.registerNewRequest());
+        final TokenCacheItem tokenItem;
+        try {
+            // TokenCacheAccessor has all the logic for token cache fallback lookup. If the metadata cache is not cached yet,
+            // it basically means that there hasn't been any requests done with the authority, otherwise authority validation
+            // cache is already filled up.
+            tokenItem = tokenCacheAccessor.getFRTItem(AuthenticationConstants.MS_FAMILY_ID, uniqueUserId);
+        } catch (final MalformedURLException e) {
+            throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, e.getMessage(), e);
+        }
 
         if (tokenItem == null) {
             Logger.i(TAG, "Cannot find the family token cache item for this userID", "");
@@ -1260,6 +1269,13 @@ public class AuthenticationContext {
                     + "because broker is enabled.");
         }
 
+        // If the serialized blob is from an app which already integrates ADAL having authority migration support, the token cache
+        // item already has the authority updated with preferred cache location (login.windows.net is the preferred cache location);
+        // If the blob is from an old version of ADAL, the token cache item contains the passed in authority (Note: most of microsoft first
+        // party app uses Token Share Library today are using login.windows.net).
+        // If the app receives the blob has the version of adal supporting authority migration, lookup will always go to preferred location
+        // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
+        // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -358,7 +358,7 @@ class TokenCacheAccessor {
         // Store separate entries for FRT.
         if (!StringExtensions.isNullOrBlank(result.getFamilyClientId()) && !StringExtensions.isNullOrBlank(userId)) {
             Logger.v(TAG, "Save Family Refresh token into cache");
-            final TokenCacheItem familyTokenCacheItem = TokenCacheItem.createFRRTTokenCacheItem(mAuthority, result);
+            final TokenCacheItem familyTokenCacheItem = TokenCacheItem.createFRRTTokenCacheItem(getAuthorityUrlWithPreferredCache(), result);
             mTokenCacheStore.setItem(CacheKey.createCacheKeyForFRT(getAuthorityUrlWithPreferredCache(), result.getFamilyClientId(), userId), familyTokenCacheItem);
             cacheEvent.setTokenTypeFRT(true);
         }


### PR DESCRIPTION
Please make sure every Pull Request has the following information:

<ul>
  <li>#913</li>
  <li>update serialize api, use tokenCacheAccessor which contains the cache fallback logic</li>
</ul>
