### PR TITLE
BrokerEvent no longer sends event_name

### DIFF
--- a/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
@@ -89,8 +89,10 @@ final class BrokerEvent extends DefaultEvent {
 
         dispatchMap.put(EventStrings.BROKER_APP_USED, Boolean.toString(true));
         for (Pair<String, String> eventPair : eventList) {
-
-            dispatchMap.put(eventPair.first, eventPair.second);
+            final String name = eventPair.first;
+            if (!name.equals(EventStrings.EVENT_NAME)) {
+                dispatchMap.put(eventPair.first, eventPair.second);
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #970 -- `BrokerEvent` now only adds data to the `dispatchMap` if the `eventPair.first` is `!=` `Microsoft.ADAL.event_name`