### PR TITLE
Corrects telemetry field for Authority type AAD

### DIFF
--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -152,7 +152,7 @@ final class EventStrings {
 
     // Parameter values
     static final String AUTHORITY_TYPE_ADFS = "adfs";
-    static final String AUTHORITY_TYPE_AAD = EVENT_PREFIX + "aad";
+    static final String AUTHORITY_TYPE_AAD = "aad";
 
     static final String AUTHORITY_VALIDATION_SUCCESS = EVENT_PREFIX + "authority_validation_status_success";
     static final String AUTHORITY_VALIDATION_FAILURE = EVENT_PREFIX + "authority_validation_status_failure";

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -154,8 +154,8 @@ final class EventStrings {
     static final String AUTHORITY_TYPE_ADFS = "adfs";
     static final String AUTHORITY_TYPE_AAD = "aad";
 
-    static final String AUTHORITY_VALIDATION_SUCCESS = "authority_validation_status_success";
-    static final String AUTHORITY_VALIDATION_FAILURE = "authority_validation_status_failure";
+    static final String AUTHORITY_VALIDATION_SUCCESS = "yes";
+    static final String AUTHORITY_VALIDATION_FAILURE = "no";
     static final String AUTHORITY_VALIDATION_NOT_DONE = "authority_validation_status_not_done";
 
     // Broker account service related events

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -154,9 +154,9 @@ final class EventStrings {
     static final String AUTHORITY_TYPE_ADFS = "adfs";
     static final String AUTHORITY_TYPE_AAD = "aad";
 
-    static final String AUTHORITY_VALIDATION_SUCCESS = EVENT_PREFIX + "authority_validation_status_success";
-    static final String AUTHORITY_VALIDATION_FAILURE = EVENT_PREFIX + "authority_validation_status_failure";
-    static final String AUTHORITY_VALIDATION_NOT_DONE = EVENT_PREFIX + "authority_validation_status_not_done";
+    static final String AUTHORITY_VALIDATION_SUCCESS = "authority_validation_status_success";
+    static final String AUTHORITY_VALIDATION_FAILURE = "authority_validation_status_failure";
+    static final String AUTHORITY_VALIDATION_NOT_DONE = "authority_validation_status_not_done";
 
     // Broker account service related events
     static final String BROKER_ACCOUNT_SERVICE_STARTS_BINDING = EVENT_PREFIX + "broker_account_service_starts_binding";

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -156,7 +156,7 @@ final class EventStrings {
 
     static final String AUTHORITY_VALIDATION_SUCCESS = "yes";
     static final String AUTHORITY_VALIDATION_FAILURE = "no";
-    static final String AUTHORITY_VALIDATION_NOT_DONE = "authority_validation_status_not_done";
+    static final String AUTHORITY_VALIDATION_NOT_DONE = "not_done";
 
     // Broker account service related events
     static final String BROKER_ACCOUNT_SERVICE_STARTS_BINDING = EVENT_PREFIX + "broker_account_service_starts_binding";


### PR DESCRIPTION
Corrects mismatch with iOS telemetry implementation. See [here](https://github.com/AzureAD/azure-activedirectory-library-for-objc/blob/dev/ADAL/src/telemetry/ADTelemetryEventStrings.m#L117) & #982 