### PR TITLE
Add network checking when hitting the network in authority validation| Fix 985

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -63,7 +63,7 @@ class AcquireTokenRequest {
      * Instance validation related calls are serviced inside Discovery as a
      * module.
      */
-    private Discovery mDiscovery = new Discovery();
+    private Discovery mDiscovery;
 
     /**
      * Event Variable for the acquireToken API called. This will track whether the API succeeded or not.
@@ -76,6 +76,7 @@ class AcquireTokenRequest {
     AcquireTokenRequest(final Context appContext, final AuthenticationContext authContext, final APIEvent apiEvent) {
         mContext = appContext;
         mAuthContext = authContext;
+        mDiscovery = new Discovery(mContext);
 
         if (authContext.getCache() != null && apiEvent != null) {
             mTokenCacheAccessor = new TokenCacheAccessor(authContext.getCache(),
@@ -199,9 +200,17 @@ class AcquireTokenRequest {
                 validateAuthority(authorityUrl, authenticationRequest.getUpnSuffix(), authenticationRequest.isSilent(),
                         authenticationRequest.getCorrelationId());
                 apiEvent.setValidationStatus(EventStrings.AUTHORITY_VALIDATION_SUCCESS);
-            } catch (AuthenticationException ex) {
-                apiEvent.setValidationStatus(EventStrings.AUTHORITY_VALIDATION_FAILURE);
-                throw ex;
+            } catch (final AuthenticationException authenticationException) {
+                if (null != authenticationException.getCode()
+                        && (authenticationException.getCode().equals(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE)
+                        || authenticationException.getCode().equals(ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION))) {
+                    // The authority validation is not done because of network error.
+                    apiEvent.setValidationStatus(EventStrings.AUTHORITY_VALIDATION_NOT_DONE);
+                } else {
+                    apiEvent.setValidationStatus(EventStrings.AUTHORITY_VALIDATION_FAILURE);
+                }
+
+                throw authenticationException;
             } finally {
                 Telemetry.getInstance().stopEvent(authenticationRequest.getTelemetryRequestId(), apiEvent,
                         EventStrings.AUTHORITY_VALIDATION_EVENT);

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import android.content.Context;
 import android.net.Uri;
 
 import org.json.JSONException;
@@ -89,13 +90,16 @@ final class Discovery {
 
     private UUID mCorrelationId;
 
+    private Context mContext;
+
     /**
      * interface to use in testing.
      */
     private final IWebRequestHandler mWebrequestHandler;
 
-    public Discovery() {
+    public Discovery(final Context context) {
         initValidList();
+        mContext = context;
         mWebrequestHandler = new WebRequestHandler();
     }
 
@@ -211,6 +215,9 @@ final class Discovery {
         if (AuthorityValidationMetadataCache.containsAuthorityHost(authorityUrl)) {
             return;
         }
+
+        //Check if the network connection available
+        HttpWebRequest.throwIfNetworkNotAvailable(mContext);
 
         // It will query prod instance to verify the authority
         // construct query string for this instance
@@ -344,7 +351,7 @@ final class Discovery {
         return sInstanceDiscoveryNetworkRequestLock;
     }
 
-    Set<String> getValidHosts() {
+    static Set<String> getValidHosts() {
         return AAD_WHITELISTED_HOSTS;
     }
 }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/HttpEvent.java
@@ -61,8 +61,7 @@ final class HttpEvent extends DefaultEvent {
 
     void setHttpPath(final URL httpPath) {
         final String authority = httpPath.getAuthority();
-        final Discovery discovery = new Discovery();
-        if (!discovery.getValidHosts().contains(authority)) {
+        if (!Discovery.getValidHosts().contains(authority)) {
             return;
         }
 


### PR DESCRIPTION
Fix for #985 
As there is a network request happening during authority validation, we should check the network when calling performInstanceDiscovery(). If there is no network, it is expected to return DEVICE_INTERNET_IS_NOT_AVAILABLE or NO_NETWORK_CONNECTION_POWER_OPTIMIZATION if the device is in doze mode. 

In this PR,
1. Added property for Discovery class.
2. Added the network checking in performInstanceDiscovery().
3. Added the unit tests.
4. Fixed the related unit tests.