### PR TITLE
[EXPERIMENTAL] Revert "BrokerEvent no longer sends event_name"

### DIFF
--- a/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
@@ -89,10 +89,8 @@ final class BrokerEvent extends DefaultEvent {
 
         dispatchMap.put(EventStrings.BROKER_APP_USED, Boolean.toString(true));
         for (Pair<String, String> eventPair : eventList) {
-            final String name = eventPair.first;
-            if (!name.equals(EventStrings.EVENT_NAME)) {
-                dispatchMap.put(eventPair.first, eventPair.second);
-            }
+
+            dispatchMap.put(eventPair.first, eventPair.second);
         }
     }
 }


### PR DESCRIPTION
Reverts AzureAD/azure-activedirectory-library-for-android#981