### PR TITLE
Sample app with Sovereign Cloud support

### DIFF
--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/AcquireTokenFragment.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/AcquireTokenFragment.java
@@ -33,16 +33,10 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.Switch;
-
-//import com.microsoft.identity.client.UIBehavior;
 
 import com.microsoft.aad.adal.PromptBehavior;
 
 import java.util.ArrayList;
-
-//import static com.microsoft.identity.client.sample.R.id.enablePII;
-
 
 /**
  * AcquireToken Fragment, contains the flow for acquireToken interactively, acquireTokenSilent, getUsers, removeUser.
@@ -50,6 +44,7 @@ import java.util.ArrayList;
 public class AcquireTokenFragment extends Fragment {
     private Spinner mAuthority;
     private EditText mLoginhint;
+    private EditText mExtraQp;
     private Spinner mResource;
     private Spinner mPromptBehavior;
     private Spinner mClientId;
@@ -76,6 +71,7 @@ public class AcquireTokenFragment extends Fragment {
 
         mPromptBehavior = (Spinner) view.findViewById(R.id.prompt_behavior);
 
+        mExtraQp = (EditText) view.findViewById(R.id.extraQP);
         mAcquireToken = (Button) view.findViewById(R.id.btn_acquiretoken);
         mAcquireTokenSilent = (Button) view.findViewById(R.id.btn_acquiretokensilent);
 
@@ -135,35 +131,39 @@ public class AcquireTokenFragment extends Fragment {
     RequestOptions getCurrentRequestOptions() {
         final Constants.AuthorityType authorityType = Constants.AuthorityType.valueOf(mAuthority.getSelectedItem().toString()) ;
         final String loginHint = mLoginhint.getText().toString();
+        final String extraQp = mExtraQp.getText().toString();
         final Constants.DataProfile resource = Constants.DataProfile.valueOf(mResource.getSelectedItem().toString());
         final PromptBehavior behavior = PromptBehavior.valueOf(mPromptBehavior.getSelectedItem().toString());
         final Constants.RedirectUri redirectUri = Constants.RedirectUri.valueOf(mRedirectUri.getSelectedItem().toString());
         final Constants.ClientId clientId = Constants.ClientId.valueOf(mClientId.getSelectedItem().toString());
-        return RequestOptions.create(authorityType, loginHint, resource, behavior, clientId, redirectUri);
+        return RequestOptions.create(authorityType, loginHint, extraQp, resource, behavior, clientId, redirectUri);
     }
 
     static class RequestOptions {
         final Constants.AuthorityType mAuthorityType;
         final String mLoginHint;
+        final String mExtraQp;
         final Constants.DataProfile mResource;
         final PromptBehavior mBehavior;
         final Constants.RedirectUri mRedirectUri;
         final Constants.ClientId mClientId;
 
         RequestOptions(final Constants.AuthorityType authorityType, final String loginHint,
-                       final Constants.DataProfile dataProfile, final PromptBehavior behavior,
-                       final Constants.ClientId clientId, final Constants.RedirectUri redirectUri) {
+                       final String extraQp, final Constants.DataProfile dataProfile,
+                       final PromptBehavior behavior, final Constants.ClientId clientId,
+                       final Constants.RedirectUri redirectUri) {
             mAuthorityType = authorityType;
             mLoginHint = loginHint;
+            mExtraQp = extraQp;
             mResource = dataProfile;
             mBehavior = behavior;
             mClientId = clientId;
             mRedirectUri = redirectUri;
         }
 
-        static RequestOptions create(final Constants.AuthorityType authority, final String loginHint,  final Constants.DataProfile dataProfile,
+        static RequestOptions create(final Constants.AuthorityType authority, final String loginHint, final String extraQp, final Constants.DataProfile dataProfile,
                                      final PromptBehavior behavior, final Constants.ClientId clientId, final Constants.RedirectUri redirectUri) {
-            return new RequestOptions(authority, loginHint, dataProfile, behavior, clientId, redirectUri);
+            return new RequestOptions(authority, loginHint, extraQp, dataProfile, behavior, clientId, redirectUri);
         }
 
         Constants.AuthorityType getAuthorityType() {
@@ -172,6 +172,10 @@ public class AcquireTokenFragment extends Fragment {
 
         String getLoginHint() {
             return mLoginHint;
+        }
+
+        String getExtraQp() {
+            return mExtraQp;
         }
 
         Constants.DataProfile getDataProfile() {

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
@@ -60,7 +60,8 @@ public class Constants {
     enum ClientId {
         MSDEVEX("b92e0ba5-f86e-4411-8e18-6b5f928d968a"),
         ONEDRIVE("af124e86-4e96-495a-b70a-90f90ab96707"),
-        OFFICE("d3590ed6-52b3-4102-aeff-aad2292ab01c");
+        OFFICE("d3590ed6-52b3-4102-aeff-aad2292ab01c"),
+        BLACKFOREST("f5d01c1c-abe6-4207-ae2d-5bc9af251724");
 
         private final String text;
         ClientId(String s) {

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -39,20 +39,16 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
-import android.widget.EditText;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
 
-import com.microsoft.aad.adal.ADALError;
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationContext;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.IDispatcher;
-import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.Telemetry;
-import com.microsoft.aad.adal.UserInfo;
 
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
@@ -88,8 +84,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     private RelativeLayout mContentMain;
 
-    private EditText mEditText;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -113,8 +107,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             // auto select the first item
             onNavigationItemSelected(navigationView.getMenu().getItem(0));
         }
-
-        mEditText = (EditText)findViewById(R.id.extraQP);
     }
 
     @Override
@@ -161,7 +153,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         prepareRequestParameters(requestOptions);
 
         callAcquireTokenWithResource(requestOptions.getDataProfile().getText(), requestOptions.getBehavior(),
-                requestOptions.getLoginHint(), requestOptions.getClientId().getText(), requestOptions.getRedirectUri().getText());
+                requestOptions.getLoginHint(), requestOptions.getClientId().getText(), requestOptions.getRedirectUri().getText(), requestOptions.getExtraQp());
     }
 
     @Override
@@ -261,9 +253,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     private void callAcquireTokenWithResource(final String resource, PromptBehavior prompt, final String loginHint,
-                                              final String clientId, final String redirectUri) {
+                                              final String clientId, final String redirectUri, final String extraQp) {
         mAuthContext.acquireToken(MainActivity.this, resource, clientId, redirectUri, loginHint,
-                prompt, "", new AuthenticationCallback<AuthenticationResult>() {
+                prompt, extraQp, new AuthenticationCallback<AuthenticationResult>() {
 
                     @Override
                     public void onSuccess(AuthenticationResult authenticationResult) {


### PR DESCRIPTION
This PR adds support to the sample app for sovereign cloud

Authority: `AAD_COMMON`
Login hint: **Must be blank** (AAD issue)
Resource: `SIMPLE`
Client id: `BLACKFOREST`
Extra qp: `instance_aware=true`