### PR TITLE
fix NPE in Discovery.java found in ADAL 1.13.2

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -219,10 +219,8 @@ final class Discovery {
         try {
             queryUrl = buildQueryString(trustedHost, getAuthorizationCommonEndpoint(authorityUrl));
             final Map<String, String> discoveryResponse = sendRequest(queryUrl);
-
             AuthorityValidationMetadataCache.processInstanceDiscoveryMetadata(authorityUrl, discoveryResponse);
-
-            result = AuthorityValidationMetadataCache.getCachedInstanceDiscoveryMetadata(authorityUrl).isValidated();
+            result = AuthorityValidationMetadataCache.isAuthorityValidated(authorityUrl);
         } catch (final IOException | JSONException e) {
             Logger.e(TAG, "Error when validating authority", "", ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, e);
             throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_INSTANCE, e.getMessage(), e);


### PR DESCRIPTION
fix https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1009
previsouly, it's calling like "AuthorityValidationMetadataCache.getCachedInstanceDiscoveryMetadata(authorityUrl).isValidated();" directly without checking if the key 'authorityUrl' is in the key set. After my fix, it's calling 'AuthorityValidationMetadataCache.isAuthorityValidated(authorityUrl)' which has already checked if the key exists in key set.