### PR TITLE
fix issue #1009, part 2, NPE in Discovery.java found in ADAL 1.13.2

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -248,7 +248,7 @@ class AcquireTokenRequest {
         }
 
         // replace the authority if host is not the same as the original one.
-        if (!authorityUrl.getHost().equalsIgnoreCase(metadata.getPreferredNetwork())) {
+        if (metadata.getPreferredNetwork() != null && !authorityUrl.getHost().equalsIgnoreCase(metadata.getPreferredNetwork())) {
             try {
                 final URL replacedAuthority = Utility.constructAuthorityUrl(authorityUrl, metadata.getPreferredNetwork());
                 request.setAuthority(replacedAuthority.toString());

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -253,7 +253,8 @@ class AcquireTokenRequest {
                 final URL replacedAuthority = Utility.constructAuthorityUrl(authorityUrl, metadata.getPreferredNetwork());
                 request.setAuthority(replacedAuthority.toString());
             } catch (final MalformedURLException ex) {
-                throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, ex.getMessage(), ex);
+                //Intentionally empty.
+                Logger.i(TAG, "preferred network is invalid", "use exactly the same authority url that is passed");
             }
         }
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -228,7 +229,10 @@ final class Discovery {
             final Map<String, String> discoveryResponse = sendRequest(queryUrl);
             AuthorityValidationMetadataCache.processInstanceDiscoveryMetadata(authorityUrl, discoveryResponse);
             if (!AuthorityValidationMetadataCache.containsAuthorityHost(authorityUrl)) {
-                AuthorityValidationMetadataCache.updateInstanceDiscoveryMap(authorityUrl.getHost(), new InstanceDiscoveryMetadata(true));
+                ArrayList<String> aliases = new ArrayList<String>();
+                aliases.add(authorityUrl.getHost());
+                AuthorityValidationMetadataCache.updateInstanceDiscoveryMap(authorityUrl.getHost(),
+                        new InstanceDiscoveryMetadata(authorityUrl.getHost(), authorityUrl.getHost(), aliases));
             }
             result = AuthorityValidationMetadataCache.isAuthorityValidated(authorityUrl);
         } catch (final IOException | JSONException e) {


### PR DESCRIPTION
1. add the preferred network and preferred cache
2. when the preferred network in invalid, use the authority url that is passed.