### PR TITLE
Add GDPR Compliant PII/OII Filtering to Telemetry

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/APIEventTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/APIEventTest.java
@@ -37,6 +37,7 @@ public final class APIEventTest {
 
     @Test
     public void testProcessEvent() throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        Telemetry.setAllowPii(true);
         final APIEvent event = new APIEvent(EventStrings.API_EVENT);
 
         event.setAPIId("123");
@@ -61,5 +62,6 @@ public final class APIEventTest {
 
         final String email = dispatchMap.get(EventStrings.LOGIN_HINT);
         assertTrue(email.equals(StringExtensions.createHash("pii@pii.com")));
+        Telemetry.setAllowPii(false);
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryPrivacyComplianceTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryPrivacyComplianceTests.java
@@ -1,0 +1,115 @@
+package com.microsoft.aad.adal;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(AndroidJUnit4.class)
+public final class TelemetryPrivacyComplianceTests {
+
+    @Test
+    public void testApiEventPrivacyCompliance() {
+        final APIEvent apiEvent = new APIEvent(EventStrings.API_EVENT);
+        populateWithPii(apiEvent);
+        verifyEmpty(apiEvent);
+    }
+
+    @Test
+    public void testBrokerEventPrivacyCompliance() {
+        final BrokerEvent brokerEvent = new BrokerEvent(EventStrings.BROKER_EVENT);
+        populateWithPii(brokerEvent);
+        verifyEmpty(brokerEvent);
+    }
+
+    @Test
+    public void testCacheEventPrivacyCompliance() {
+        final CacheEvent cacheEvent = new CacheEvent(EventStrings.CACHE_EVENT_COUNT);
+        populateWithPii(cacheEvent);
+        verifyEmpty(cacheEvent);
+    }
+
+    @Test
+    public void testDefaultEventPrivacyCompliance() {
+        final DefaultEvent defaultEvent = new DefaultEvent();
+        populateWithPii(defaultEvent);
+        verifyEmpty(defaultEvent);
+    }
+
+    @Test
+    public void testHttpEventPrivacyCompliance() {
+        final HttpEvent httpEvent = new HttpEvent(EventStrings.HTTP_EVENT);
+        populateWithPii(httpEvent);
+        verifyEmpty(httpEvent);
+    }
+
+    @Test
+    public void testUiEventPrivacyCompliance() {
+        final UIEvent uiEvent = new UIEvent(EventStrings.UI_EVENT);
+        populateWithPii(uiEvent);
+        verifyEmpty(uiEvent);
+    }
+
+    @Test
+    public void testApiEventPrivacyComplianceWithPiiPresent() {
+        Telemetry.setAllowPii(true);
+        final APIEvent apiEvent = new APIEvent(EventStrings.API_EVENT);
+        apiEvent.setLoginHint("sample_value");
+        apiEvent.setIdToken(AuthenticationContextTest.TEST_IDTOKEN);
+        verifyHashed(apiEvent);
+        Telemetry.setAllowPii(false);
+    }
+
+    private void populateWithPii(final DefaultEvent event) {
+        for (final String piiProperty : TelemetryUtils.GDPR_FILTERED_FIELDS) {
+            event.setProperty(piiProperty, "sample_value");
+        }
+    }
+
+    private void verifyEmpty(final DefaultEvent event) {
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        for (final String key : dispatchMap.keySet()) {
+            if (TelemetryUtils.GDPR_FILTERED_FIELDS.contains(key)) {
+                throw new AssertionError("Telemetry dispatch contained PII key: " + key);
+            }
+        }
+    }
+
+    private void verifyHashed(final DefaultEvent event) {
+        final Map<String, String> dispatchMap = new HashMap<>();
+        event.processEvent(dispatchMap);
+        for (final Map.Entry<String, String> entry : dispatchMap.entrySet()) {
+            final String key = entry.getKey();
+            boolean shouldThrow = false;
+            try {
+                if (key.equals(EventStrings.LOGIN_HINT)) {
+                    shouldThrow = !entry.getValue().equals(StringExtensions.createHash("sample_value"));
+                }
+
+                if (key.equals(EventStrings.USER_ID)) {
+                    shouldThrow = !entry.getValue().equals(StringExtensions.createHash("admin@aaltests.onmicrosoft.com"));
+                }
+
+                if (key.equals(EventStrings.TENANT_ID)) {
+                    shouldThrow = !entry.getValue().equals(StringExtensions.createHash("30baa666-8df8-48e7-97e6-77cfd0995963"));
+                }
+
+                if (shouldThrow) {
+                    throw new AssertionError("Event contained PII key/pair: "
+                            + key
+                            + "/"
+                            + entry.getValue()
+                    );
+                }
+            } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+                throw new AssertionError("Could not validate PII compliance/hashing");
+            }
+        }
+    }
+}

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryPrivacyComplianceTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryPrivacyComplianceTests.java
@@ -1,3 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package com.microsoft.aad.adal;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryTest.java
@@ -166,7 +166,8 @@ class AggregatedTelemetryTestClass implements IDispatcher {
 
     boolean checkNoPIIPresent(final String piiKey, final String piiValue) {
         try {
-            return mEventData.get(piiKey).equals(StringExtensions.createHash(piiValue));
+            final String value = mEventData.get(piiKey);
+            return null == value || value.equals(StringExtensions.createHash(piiValue));
         } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
             return false;
         }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/DefaultEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/DefaultEvent.java
@@ -77,7 +77,7 @@ class DefaultEvent implements IEvents {
             throw new IllegalArgumentException("Telemetry setProperty on null name");
         }
 
-        if (value == null) {
+        if (value == null || !isPrivacyCompliant(name)) {
             return;
         }
 
@@ -95,19 +95,19 @@ class DefaultEvent implements IEvents {
      */
     @Override
     public void processEvent(final Map<String, String> dispatchMap) {
-        if (sApplicationName != null) {
+        if (sApplicationName != null && isPrivacyCompliant(EventStrings.APPLICATION_NAME)) {
             dispatchMap.put(EventStrings.APPLICATION_NAME, sApplicationName);
         }
 
-        if (sApplicationVersion != null) {
+        if (sApplicationVersion != null && isPrivacyCompliant(EventStrings.APPLICATION_VERSION)) {
             dispatchMap.put(EventStrings.APPLICATION_VERSION, sApplicationVersion);
         }
 
-        if (sClientId != null) {
+        if (sClientId != null && isPrivacyCompliant(EventStrings.CLIENT_ID)) {
             dispatchMap.put(EventStrings.CLIENT_ID, sClientId);
         }
 
-        if (sDeviceId != null) {
+        if (sDeviceId != null && isPrivacyCompliant(EventStrings.DEVICE_ID)) {
             dispatchMap.put(EventStrings.DEVICE_ID, sDeviceId);
         }
     }
@@ -155,5 +155,14 @@ class DefaultEvent implements IEvents {
 
     String getTelemetryRequestId() {
         return mRequestId;
+    }
+
+    /**
+     * Tests supplied EventStrings for privacy compliance.
+     * @param fieldName The EventString to evaluate.
+     * @return True, if the field can be reported. False otherwise.
+     */
+    static boolean isPrivacyCompliant(final String fieldName) {
+        return Telemetry.getAllowPii() || !TelemetryUtils.GDPR_FILTERED_FIELDS.contains(fieldName);
     }
 }

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/Telemetry.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/Telemetry.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class Telemetry {
     private static final String TAG = Telemetry.class.getSimpleName();
     private DefaultDispatcher mDispatcher = null;
+    private static boolean mAllowPii = false;
     private final Map<Pair<String, String>, String> mEventTracking = new ConcurrentHashMap<Pair<String, String>, String>();
     private static final Telemetry INSTANCE = new Telemetry();
 
@@ -41,6 +42,25 @@ public final class Telemetry {
      */
     public static synchronized Telemetry getInstance() {
         return INSTANCE;
+    }
+
+    /**
+     * Sets the PII/OII allow flag. If set to true, PII/OII fields will not be explicitly blocked
+     * in Telemetry data.
+     *
+     * @param allowFlag true, if PII/OII should be allowed in Telemetry data. False otherwise.
+     */
+    public static void setAllowPii(final boolean allowFlag) {
+        mAllowPii = allowFlag;
+    }
+
+    /**
+     * Gets the state of the PII/OII allow flag.
+     *
+     * @return the flag state.
+     */
+    public static boolean getAllowPii() {
+        return mAllowPii;
     }
 
     /**

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
@@ -29,7 +29,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import static com.microsoft.aad.adal.EventStrings.*;
+
+import static com.microsoft.aad.adal.EventStrings.LOGIN_HINT;
+import static com.microsoft.aad.adal.EventStrings.TENANT_ID;
+import static com.microsoft.aad.adal.EventStrings.USER_ID;
 
 final class TelemetryUtils {
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
@@ -24,16 +24,36 @@
 package com.microsoft.aad.adal;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import static com.microsoft.aad.adal.EventStrings.*;
 
 final class TelemetryUtils {
+
+    final static Set<String> GDPR_FILTERED_FIELDS = new HashSet<>();
+
+    private static final String TAG = TelemetryUtils.class.getSimpleName();
+
+    static {
+        initializeGdprFilteredFields();
+    }
 
     private TelemetryUtils() {
         // Intentionally left blank.
     }
 
-    private static final String TAG = TelemetryUtils.class.getSimpleName();
+    private static void initializeGdprFilteredFields() {
+        GDPR_FILTERED_FIELDS.addAll(
+                Arrays.asList(
+                        LOGIN_HINT,
+                        USER_ID,
+                        TENANT_ID
+                )
+        );
+    }
 
     static class CliTelemInfo implements Serializable {
 


### PR DESCRIPTION
These changes close #1019 - modified `setProperty(String, String)` to omit telemetry fields declared as excluded by `TelemetryUtils#GDPR_FILTERED_FIELDS`.

A switch is also added to override this exclusion: `Telemetry#setAllowPii(boolean)`