### PR TITLE
[GDPR] artifacts. the log part.

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -41,7 +41,7 @@ import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
+import com.microsoft.aad.adal.Logger;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.Window;
@@ -158,7 +158,7 @@ public class AuthenticationActivity extends Activity {
         // Get the message from the intent
         mAuthRequest = getAuthenticationRequestFromIntent(getIntent());
         if (mAuthRequest == null) {
-            Log.d(TAG, "Intent for Authentication Activity doesn't have the request details, returning to caller");
+            Logger.d(TAG, "Intent for Authentication Activity doesn't have the request details, returning to caller");
             Intent resultIntent = new Intent();
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE,
                     AuthenticationConstants.Browser.WEBVIEW_INVALID_REQUEST);
@@ -205,7 +205,7 @@ public class AuthenticationActivity extends Activity {
         // Disable hardware acceleration in WebView if needed
         if (!AuthenticationSettings.INSTANCE.getDisableWebViewHardwareAcceleration()) {
             mWebView.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null);
-            Log.d(TAG, "Hardware acceleration is disabled in WebView");
+            Logger.d(TAG, "Hardware acceleration is disabled in WebView");
         }
         
         mStartUrl = "about:blank";
@@ -213,7 +213,7 @@ public class AuthenticationActivity extends Activity {
             Oauth2 oauth = new Oauth2(mAuthRequest);
             mStartUrl = oauth.getCodeRequestUrl();
         } catch (UnsupportedEncodingException e) {
-            Log.d(TAG, e.getMessage());
+            Logger.d(TAG, e.getMessage());
             Intent resultIntent = new Intent();
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
                     mAuthRequest);
@@ -429,7 +429,7 @@ public class AuthenticationActivity extends Activity {
      */
     private void returnError(ADALError errorCode, String argument) {
         // Set result back to account manager call
-        Log.w(TAG, "Argument error:" + argument);
+        Logger.w(TAG, "Argument error:" + argument);
         Intent resultIntent = new Intent();
         // TODO only send adalerror from activity side as int
         resultIntent
@@ -456,7 +456,7 @@ public class AuthenticationActivity extends Activity {
                 // This encoding issue will happen at the beginning of API call,
                 // if it is not supported on this device. ADAL uses one encoding
                 // type.
-                Log.e(TAG, "Encoding", e);
+                Logger.e(TAG, "Encoding", e);
             }
         }
         return loadUrl;
@@ -729,9 +729,9 @@ public class AuthenticationActivity extends Activity {
                         request.proceed(privateKey, certChain);
                         return;
                     } catch (KeyChainException e) {
-                        Log.e(TAG, "KeyChain exception", e);
+                        Logger.e(TAG, "KeyChain exception", e);
                     } catch (InterruptedException e) {
-                        Log.e(TAG, "InterruptedException exception", e);
+                        Logger.e(TAG, "InterruptedException exception", e);
                     }
 
                     request.cancel();

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -34,7 +34,7 @@ import android.os.Looper;
 import android.os.NetworkOnMainThreadException;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
+import com.microsoft.aad.adal.Logger;
 import android.util.SparseArray;
 
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
@@ -687,7 +687,7 @@ public class AuthenticationContext {
 
         final Looper currentLooper = Looper.myLooper();
         if (currentLooper != null && currentLooper == mContext.getMainLooper()) {
-            Log.e(TAG, "Sync network calls must not be invoked in main thread. "
+            Logger.e(TAG, "Sync network calls must not be invoked in main thread. "
                             + "This method will throw android.os.NetworkOnMainThreadException in next major release",
                     new NetworkOnMainThreadException());
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -30,7 +30,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Handler;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -114,7 +113,7 @@ class AuthenticationDialog {
                 // Disable hardware acceleration in WebView if needed
                 if (!AuthenticationSettings.INSTANCE.getDisableWebViewHardwareAcceleration()) {
                     mWebView.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null);
-                    Log.d(TAG, "Hardware acceleration is disabled in WebView");
+                    Logger.d(TAG, "Hardware acceleration is disabled in WebView");
                 }
 
                 mWebView.getSettings().setJavaScriptEnabled(true);

--- a/adal/src/main/java/com/microsoft/aad/adal/HashMapExtensions.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HashMapExtensions.java
@@ -24,7 +24,6 @@
 package com.microsoft.aad.adal;
 
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -77,7 +76,7 @@ final class HashMapExtensions {
                         key = StringExtensions.urlFormDecode(elements[0].trim());
                         value = StringExtensions.urlFormDecode(elements[1].trim());
                     } catch (UnsupportedEncodingException e) {
-                        Log.d(TAG, e.getMessage());
+                        Logger.d(TAG, e.getMessage());
                     }
 
                     if (!StringExtensions.isNullOrBlank(key)

--- a/adal/src/main/java/com/microsoft/aad/adal/Logger.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Logger.java
@@ -84,8 +84,8 @@ public class Logger {
      */
     private ILogger mExternalLogger = null;
 
-    // enabled by default
-    private boolean mAndroidLogEnabled = true;
+    // disabled by default
+    private boolean mAndroidLogEnabled = false;
 
     private static Logger sInstance = new Logger();
 
@@ -370,6 +370,10 @@ public class Logger {
         Logger.getInstance().warn(tag, message, additionalMessage, errorCode);
     }
 
+    public static void w(String tag, String msg) {
+        Logger.getInstance().warn(tag, msg, null, null);
+    }
+
     /**
      * Logs error message.
      * @param tag tag for the log message
@@ -391,6 +395,10 @@ public class Logger {
     public static void e(String tag, String message, String additionalMessage, ADALError errorCode,
             Throwable err) {
         Logger.getInstance().error(tag, message, additionalMessage, errorCode, err);
+    }
+
+    public static void e(String tag, String msg, Throwable tr) {
+        Logger.getInstance().error(tag, msg, null, null, tr);
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/PRNGFixes.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/PRNGFixes.java
@@ -34,7 +34,7 @@ package com.microsoft.aad.adal;
 
 import android.os.Build;
 import android.os.Process;
-import android.util.Log;
+import com.microsoft.aad.adal.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -227,7 +227,7 @@ final class PRNGFixes {
             } catch (IOException e) {
                 // On a small fraction of devices /dev/urandom is not writable.
                 // Log and ignore.
-                Log.w(PRNGFixes.class.getSimpleName(), "Failed to mix seed into " + URANDOM_FILE);
+                Logger.w(PRNGFixes.class.getSimpleName(), "Failed to mix seed into " + URANDOM_FILE);
             } finally {
                 mSeeded = true;
             }

--- a/adal/src/main/java/com/microsoft/aad/adal/PackageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/PackageHelper.java
@@ -32,7 +32,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.Signature;
 import android.util.Base64;
-import android.util.Log;
+import com.microsoft.aad.adal.Logger;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -125,7 +125,7 @@ class PackageHelper {
                 // This encoding issue will happen at the beginning of API call,
                 // if it is not supported on this device. ADAL uses one encoding
                 // type.
-                Log.e(TAG, "Encoding", e);
+                Logger.e(TAG, "Encoding", e);
             }
         }
         return "";


### PR DESCRIPTION
1. fully use com.microsoft.aad.adal.Logger as a wrapper to android.util.Log. There won't be any direct call to methods in android.util.Log except the test code.
2. add some methods into com.microsoft.aad.adal.Logger to be compatible with (taking the same parameter as) the methods in android.util.Log