### PR TITLE
Adds a shared component submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "microsoft-authentication-library-common-for-android"]
-	path = microsoft-authentication-library-common-for-android
+	path = common
 	url = https://github.com/AzureAD/microsoft-authentication-library-common-for-android.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "microsoft-authentication-library-common-for-android"]
+	path = microsoft-authentication-library-common-for-android
+	url = https://github.com/AzureAD/microsoft-authentication-library-common-for-android.git

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     compile "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     compile "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
+    compile project(":common")
 
     // Android Instrumental Test Dependencies
     androidTestCompile "com.android.support.test:runner:$rootProject.ext.runnerVersion"
@@ -133,44 +134,6 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
             "jacoco/testDebugUnitTest.exec",
             "outputs/code-coverage/connected/*coverage.ec"
     ])
-}
-
-task createPom  {
-    pom {
-        project {
-            groupId 'com.microsoft.aad'
-            artifactId 'adal'
-            version = project.version
-            packaging 'aar'
-            name 'adal'
-
-            description 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-            url 'https://github.com/MSOpenTech/azure-activedirectory-library-for-android'
-
-            developers {
-                developer {
-                    id 'microsoft'
-                    name 'Microsoft'
-                }
-            }
-
-            licenses {
-                license {
-                    name 'MIT License'
-                }
-            }
-            inceptionYear '2014'
-
-            properties {
-                branch 'master'
-                adalVersion = project.version
-            }
-
-            scm {
-                url "https://github.com/MSOpenTech/azure-activedirectory-library-for-android/tree/master"
-            }
-        }
-    }.writeTo("${archivesBaseName}-${version}.pom")
 }
 
 task sourcesJar(type: Jar) {
@@ -327,6 +290,6 @@ task checkstyle(type: Checkstyle) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
-        task.dependsOn 'checkstyle', 'pmd', 'findbugs', 'lint', 'createPom'
+        task.dependsOn 'checkstyle', 'pmd', 'findbugs', 'lint'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 }
 
 allprojects {
+    buildDir = "C:/temp/${rootProject.name}/${project.name}"
     repositories {
         jcenter()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,11 @@ buildscript {
 }
 
 allprojects {
-    buildDir = "C:/temp/${rootProject.name}/${project.name}"
+    // Windows has a maximum path length of 260 characters - to avoid hitting this ceiling
+    // stage the builds close to the root of C://
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+        buildDir = "C:/temp/${rootProject.name}/${project.name}"
+    }
     repositories {
         jcenter()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
-include ':adal',':userappwithbroker', ":automationtestapp"
+include ':adal', ':userappwithbroker', ":automationtestapp", ':common'
+project(':common').projectDir = new File('microsoft-authentication-library-common-for-android/common')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include ':adal', ':userappwithbroker', ":automationtestapp", ':common'
-project(':common').projectDir = new File('microsoft-authentication-library-common-for-android/common')
+project(':common').projectDir = new File('common/common')


### PR DESCRIPTION
> :rotating_light: **Repo access to `microsoft-authentication-library-common-for-android` is required to use this branch.**
---

This PR adds `microsoft-authentication-library-common-for-android` as a sibling `git submodule` to `adal`

The `:common` submodule is added as a `compile project` dependency and, due to issues with POM creation, the `gradle task createPom` has been removed from `adal/build.gradle`

Additionally, due to Windows' 260 character path limit, the `allproject.buildDir` is relocated to `"C:/temp/${rootProject.name}/${project.name}"`

Once merged, you can clone/checkout this branch using:
```
git clone -b unified/dev --recursive https://github.com/AzureAD/azure-activedirectory-library-for-android.git
```

To clone/checkout the unmerged fork `HEAD`, use:
```
git clone -b iambmelt/1_shared_component --recursive https://github.com/iambmelt/azure-activedirectory-library-for-android.git
```