### PR TITLE
Adds a method to turn AuthenticationResults into TokenResponses

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -23,8 +23,6 @@
 
 package com.microsoft.aad.adal;
 
-import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryTokenResponse;
-
 import java.io.Serializable;
 import java.util.Date;
 
@@ -387,18 +385,4 @@ public class AuthenticationResult implements Serializable {
         mCliTelemInfo = cliTelemInfo;
     }
 
-    /**
-     * Gets this AuthenticationResult as a {@link AzureActiveDirectoryTokenResponse}.
-     *
-     * @return The {@link AzureActiveDirectoryTokenResponse} representing this object.
-     */
-    public AzureActiveDirectoryTokenResponse asAADTokenResponse() {
-        final AzureActiveDirectoryTokenResponse adTokenResponse = new AzureActiveDirectoryTokenResponse();
-        adTokenResponse.setAccessToken(getAccessToken());
-        adTokenResponse.setTokenType(getAccessTokenType());
-        adTokenResponse.setRefreshToken(getRefreshToken());
-        adTokenResponse.setExpiresOn(String.valueOf(getExpiresOn().getTime()));
-        adTokenResponse.setIdToken(getIdToken());
-        return adTokenResponse;
-    }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -23,6 +23,8 @@
 
 package com.microsoft.aad.adal;
 
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryTokenResponse;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -383,5 +385,20 @@ public class AuthenticationResult implements Serializable {
 
     final void setCliTelemInfo(final CliTelemInfo cliTelemInfo) {
         mCliTelemInfo = cliTelemInfo;
+    }
+
+    /**
+     * Gets this AuthenticationResult as a {@link AzureActiveDirectoryTokenResponse}.
+     *
+     * @return The {@link AzureActiveDirectoryTokenResponse} representing this object.
+     */
+    public AzureActiveDirectoryTokenResponse asAADTokenResponse() {
+        final AzureActiveDirectoryTokenResponse adTokenResponse = new AzureActiveDirectoryTokenResponse();
+        adTokenResponse.setAccessToken(getAccessToken());
+        adTokenResponse.setTokenType(getAccessTokenType());
+        adTokenResponse.setRefreshToken(getRefreshToken());
+        adTokenResponse.setExpiresOn(String.valueOf(getExpiresOn().getTime()));
+        adTokenResponse.setIdToken(getIdToken());
+        return adTokenResponse;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -384,5 +384,4 @@ public class AuthenticationResult implements Serializable {
     final void setCliTelemInfo(final CliTelemInfo cliTelemInfo) {
         mCliTelemInfo = cliTelemInfo;
     }
-
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -22,6 +22,7 @@ final class CoreAdapter {
         adTokenResponse.setTokenType(result.getAccessTokenType());
         adTokenResponse.setRefreshToken(result.getRefreshToken());
         adTokenResponse.setExpiresOn(String.valueOf(result.getExpiresOn().getTime()));
+        adTokenResponse.setExtExpiresIn(String.valueOf(result.getExtendedExpiresOn().getTime()));
         adTokenResponse.setIdToken(result.getIdToken());
         // TODO populate other missing fields...
         return adTokenResponse;

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -1,5 +1,7 @@
 package com.microsoft.aad.adal;
 
+import com.microsoft.identity.common.Account;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryAccount;
 import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryTokenResponse;
 
 /**
@@ -12,11 +14,44 @@ final class CoreAdapter {
     }
 
     /**
-     * Gets the supplied AuthenticationResult as a {@link AzureActiveDirectoryTokenResponse}.
+     * Gets the supplied {@link UserInfo} as an {@link Account}.
      *
-     * @return The newly created {@link AzureActiveDirectoryTokenResponse}.
+     * @param userInfo The UserInfo to transform.
+     * @return The newly created Account.
      */
-    public static AzureActiveDirectoryTokenResponse asAADTokenResponse(final AuthenticationResult result) {
+    public static AzureActiveDirectoryAccount asAadAccount(final UserInfo userInfo) {
+        final AzureActiveDirectoryAccount account = new AzureActiveDirectoryAccount();
+        account.setDisplayableId(userInfo.getDisplayableId());
+        account.setName(userInfo.getGivenName());
+        account.setIdentityProvider(account.getIdentityProvider());
+        account.setUid(userInfo.getUserId());
+        // TODO Need to get the UTID attribute.
+        return account;
+    }
+
+    /**
+     * Gets the supplied {@link Account} as a {@link UserInfo}.
+     *
+     * @param account The Account to transform.
+     * @return The newly created UserInfo.
+     */
+    public static UserInfo asUserInfo(final AzureActiveDirectoryAccount account) {
+        return new UserInfo(
+                account.getUserIdentifier(),
+                account.getName(),
+                null, // TODO Need to get the 'family name' attribute
+                account.getIdentityProvider(),
+                account.getDisplayableId()
+        );
+    }
+
+    /**
+     * Gets the supplied {@link AuthenticationResult} as a {@link AzureActiveDirectoryTokenResponse}.
+     *
+     * @param result The AuthenticationResult to transform.
+     * @return The newly created AzureActiveDirectoryTokenResponse.
+     */
+    public static AzureActiveDirectoryTokenResponse asAadTokenResponse(final AuthenticationResult result) {
         final AzureActiveDirectoryTokenResponse adTokenResponse = new AzureActiveDirectoryTokenResponse();
         adTokenResponse.setAccessToken(result.getAccessToken());
         adTokenResponse.setTokenType(result.getAccessTokenType());

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -1,0 +1,30 @@
+package com.microsoft.aad.adal;
+
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryTokenResponse;
+
+/**
+ * Utility class for object transformations between :common and :adal.
+ */
+final class CoreAdapter {
+
+    private CoreAdapter() {
+        // Util class. No reason to instantiate.
+    }
+
+    /**
+     * Gets the supplied AuthenticationResult as a {@link AzureActiveDirectoryTokenResponse}.
+     *
+     * @return The newly created {@link AzureActiveDirectoryTokenResponse}.
+     */
+    public static AzureActiveDirectoryTokenResponse asAADTokenResponse(final AuthenticationResult result) {
+        final AzureActiveDirectoryTokenResponse adTokenResponse = new AzureActiveDirectoryTokenResponse();
+        adTokenResponse.setAccessToken(result.getAccessToken());
+        adTokenResponse.setTokenType(result.getAccessTokenType());
+        adTokenResponse.setRefreshToken(result.getRefreshToken());
+        adTokenResponse.setExpiresOn(String.valueOf(result.getExpiresOn().getTime()));
+        adTokenResponse.setIdToken(result.getIdToken());
+        // TODO populate other missing fields...
+        return adTokenResponse;
+    }
+
+}


### PR DESCRIPTION
This change is a counterpart to [`common/#25`](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/25) -- many fields are still missing, as there's no direct 1:1 mapping for these objects.

@shoatman We can sync on this tomorrow prior to a merge