### PR TITLE
Fix the bug when broker returns null for getIntentForInteractiveRequest

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -260,9 +260,14 @@ public final class BrokerAccountServiceTest {
                 brokerEvent.setRequestId("1234");
                 Telemetry.getInstance().startEvent(brokerEvent.getTelemetryRequestId(), EventStrings.BROKER_REQUEST_INTERACTIVE);
 
-                final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, brokerEvent);
-                assertTrue(Boolean.toString(true).equals(intent.getStringExtra(AuthenticationConstants.Broker.BROKER_SKIP_CACHE)));
-                assertTrue(claimsChallenge.equals(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_CLAIMS)));
+                try {
+                    final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, brokerEvent);
+                    assertTrue(Boolean.toString(true).equals(intent.getStringExtra(AuthenticationConstants.Broker.BROKER_SKIP_CACHE)));
+                    assertTrue(claimsChallenge.equals(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_CLAIMS)));
+
+                } catch (final AuthenticationException exc) {
+                    fail("Exception ia not expected.");
+                }
 
                 verifyBrokerEventList(brokerEvent);
                 latch.countDown();

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -266,7 +266,7 @@ public final class BrokerAccountServiceTest {
                     assertTrue(claimsChallenge.equals(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_CLAIMS)));
 
                 } catch (final AuthenticationException exc) {
-                    fail("Exception ia not expected.");
+                    fail("Exception is not expected.");
                 }
 
                 verifyBrokerEventList(brokerEvent);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -75,7 +75,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -909,7 +908,7 @@ public class BrokerProxyTests {
 
     @Test
     public void testGetIntentForBrokerActivityEmptyIntent() throws NameNotFoundException, OperationCanceledException,
-            IOException, AuthenticatorException {
+            IOException, AuthenticatorException, AuthenticationException {
         final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/test", "resource", "client",
                 "redirect", "loginhint", PromptBehavior.Auto, "", UUID.randomUUID(), false);
         final AccountManager mockAcctManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
@@ -924,18 +923,14 @@ public class BrokerProxyTests {
 
         // action
         final BrokerProxy brokerProxy = new BrokerProxy(context);
-        try {
-            final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
-            // assert
-            assertNull("Intent is null", intent);
-        } catch (final AuthenticationException exc) {
-            fail("Not expected.");
-        }
+        final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
+        // assert
+        assertNull("Intent is null", intent);
     }
 
     @Test
     public void testGetIntentForBrokerActivityHasIntent() throws NameNotFoundException, OperationCanceledException,
-            IOException, AuthenticatorException {
+            IOException, AuthenticatorException, AuthenticationException {
         final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", "loginhint", PromptBehavior.Auto, "", UUID.randomUUID(), false);
 
@@ -955,16 +950,12 @@ public class BrokerProxyTests {
 
         // action
         final BrokerProxy brokerProxy = new BrokerProxy(context);
-        try {
-            final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
+        final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
 
-            // assert
-            assertNotNull("intent is not null", intent);
-            assertEquals("intent is not null", AuthenticationConstants.Broker.BROKER_REQUEST,
-                    intent.getStringExtra(AuthenticationConstants.Broker.BROKER_REQUEST));
-        } catch (final AuthenticationException exc) {
-        fail("Not expected.");
-    }
+        // assert
+        assertNotNull("intent is not null", intent);
+        assertEquals("intent is not null", AuthenticationConstants.Broker.BROKER_REQUEST,
+                intent.getStringExtra(AuthenticationConstants.Broker.BROKER_REQUEST));
     }
     
     /**
@@ -972,7 +963,7 @@ public class BrokerProxyTests {
      * reset as always. 
      */
     @Test
-    public void testForcePromptFlagOldBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
+    public void testForcePromptFlagOldBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException, AuthenticationException {
         final Intent intent = new Intent();
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.FORCE_PROMPT);
         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT, authenticationRequest.getPrompt().name());
@@ -986,12 +977,8 @@ public class BrokerProxyTests {
         mockedContext.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
                 AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
-        try {
-            final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
-            assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
-        } catch (final AuthenticationException exc) {
-            fail("Not expected.");
-        }
+        final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
+        assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
     }
     
     /**
@@ -999,7 +986,7 @@ public class BrokerProxyTests {
      * as Force_Prompt. 
      */
     @Test
-    public void testForcePromptNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
+    public void testForcePromptNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException, AuthenticationException {
         final Intent intent = new Intent();
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.FORCE_PROMPT);
         intent.putExtra(AuthenticationConstants.Broker.BROKER_VERSION, AuthenticationConstants.Broker.BROKER_PROTOCOL_VERSION);
@@ -1016,12 +1003,8 @@ public class BrokerProxyTests {
                 AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
 
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
-        try {
-            final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
-            assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.FORCE_PROMPT.name()));
-        } catch (final AuthenticationException exc) {
-            fail("Not expected.");
-        }
+        final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
+        assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.FORCE_PROMPT.name()));
     }
     
     /**
@@ -1029,7 +1012,7 @@ public class BrokerProxyTests {
      * as always. 
      */
     @Test
-    public void testPromptAlwaysNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
+    public void testPromptAlwaysNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException, AuthenticationException {
         final Intent intent = new Intent();
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.Always);
         intent.putExtra(AuthenticationConstants.Broker.BROKER_VERSION, AuthenticationConstants.Broker.BROKER_PROTOCOL_VERSION);
@@ -1046,12 +1029,8 @@ public class BrokerProxyTests {
                 AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
 
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
-        try {
-            final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
-            assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
-        } catch (final AuthenticationException exc) {
-            fail("Not expected.");
-        }
+        final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
+        assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
     }
     
     private FileMockContext getMockedContext(final AccountManager mockedAccountManager) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -75,6 +75,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -923,10 +924,13 @@ public class BrokerProxyTests {
 
         // action
         final BrokerProxy brokerProxy = new BrokerProxy(context);
-        final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
-
-        // assert
-        assertNull("Intent is null", intent);
+        try {
+            final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
+            // assert
+            assertNull("Intent is null", intent);
+        } catch (final AuthenticationException exc) {
+            fail("Not expected.");
+        }
     }
 
     @Test
@@ -951,12 +955,16 @@ public class BrokerProxyTests {
 
         // action
         final BrokerProxy brokerProxy = new BrokerProxy(context);
-        final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
+        try {
+            final Intent intent = brokerProxy.getIntentForBrokerActivity(authRequest, null);
 
-        // assert
-        assertNotNull("intent is not null", intent);
-        assertEquals("intent is not null", AuthenticationConstants.Broker.BROKER_REQUEST,
-                intent.getStringExtra(AuthenticationConstants.Broker.BROKER_REQUEST));
+            // assert
+            assertNotNull("intent is not null", intent);
+            assertEquals("intent is not null", AuthenticationConstants.Broker.BROKER_REQUEST,
+                    intent.getStringExtra(AuthenticationConstants.Broker.BROKER_REQUEST));
+        } catch (final AuthenticationException exc) {
+        fail("Not expected.");
+    }
     }
     
     /**
@@ -978,8 +986,12 @@ public class BrokerProxyTests {
         mockedContext.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
                 AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
-        final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
-        assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
+        try {
+            final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
+            assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
+        } catch (final AuthenticationException exc) {
+            fail("Not expected.");
+        }
     }
     
     /**
@@ -1004,8 +1016,12 @@ public class BrokerProxyTests {
                 AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
 
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
-        final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
-        assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.FORCE_PROMPT.name()));
+        try {
+            final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
+            assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.FORCE_PROMPT.name()));
+        } catch (final AuthenticationException exc) {
+            fail("Not expected.");
+        }
     }
     
     /**
@@ -1030,9 +1046,12 @@ public class BrokerProxyTests {
                 AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, true));
 
         final BrokerProxy brokerProxy = new BrokerProxy(mockedContext);
-        final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
-
-        assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
+        try {
+            final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
+            assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
+        } catch (final AuthenticationException exc) {
+            fail("Not expected.");
+        }
     }
     
     private FileMockContext getMockedContext(final AccountManager mockedAccountManager) {

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -227,12 +227,7 @@ final class BrokerAccountServiceHandler {
             }
         }
 
-        if (bundleResult.get() == null) {
-            Logger.e(TAG, "Get null intent from broker.", "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
-            throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Get null intent from broker.");
-        } else {
-            return bundleResult.getAndSet(null);
-        }
+        return bundleResult.getAndSet(null);
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -172,7 +172,7 @@ final class BrokerAccountServiceHandler {
      * @param context The application {@link Context}.
      * @return The {@link Intent} to launch the interactive request.
      */
-    public Intent getIntentForInteractiveRequest(final Context context, final BrokerEvent brokerEvent) {
+    public Intent getIntentForInteractiveRequest(final Context context, final BrokerEvent brokerEvent) throws AuthenticationException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         final AtomicReference<Intent> bundleResult = new AtomicReference<>(null);
         final AtomicReference<Throwable> exception = new AtomicReference<>(null);
@@ -204,11 +204,35 @@ final class BrokerAccountServiceHandler {
         }
 
         final Throwable throwable = exception.getAndSet(null);
+        //AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING will be thrown if there is any exception thrown during binding the service.
         if (throwable != null) {
-            Logger.e(TAG, "Didn't receive the activity to launch from broker: " + throwable.getMessage(), "", null, throwable);
+            if (throwable instanceof RemoteException) {
+                Logger.e(TAG, "Get error when trying to get token from broker. ",
+                        throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING,
+                        throwable.getMessage(),
+                        throwable);
+            } else if (throwable instanceof InterruptedException) {
+                Logger.e(TAG, "The broker account service binding call is interrupted. ",
+                        throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_EXCEPTION, throwable);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING,
+                        throwable.getMessage(),
+                        throwable);
+            } else {
+                Logger.e(TAG, "Didn't receive the activity to launch from broker. ",
+                        throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING,
+                        "Didn't receive the activity to launch from broker: " + throwable.getMessage(),
+                        throwable);
+            }
         }
 
-        return bundleResult.getAndSet(null);
+        if (bundleResult.get() == null) {
+            Logger.e(TAG, "Get null intent from broker.", "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
+            throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Get null intent from broker.");
+        } else {
+            return bundleResult.getAndSet(null);
+        }
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -595,8 +595,8 @@ class BrokerProxy implements IBrokerProxy {
         if (isBrokerAccountServiceSupported()) {
             intent = BrokerAccountServiceHandler.getInstance().getIntentForInteractiveRequest(mContext, brokerEvent);
             if (intent == null) {
-                Logger.e(TAG, "Get null intent for interactive request from broker.", null, ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
-                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Get null intent from broker.");
+                Logger.e(TAG, "Received null intent from broker interactive request.", null, ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Received null intent from broker interactive request.");
             } else {
                 intent.putExtras(requestBundle);
             }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -363,7 +363,7 @@ class BrokerProxy implements IBrokerProxy {
             } catch (final AuthenticatorException e) {
                 // Error code BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN will be thrown if there was an error
                 // communicating with the authenticator or if the authenticator returned an invalid response.
-                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(INVALID_GRANT)){
+                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(INVALID_GRANT)) {
                     Logger.e(TAG, AUTHENTICATOR_CANCELS_REQUEST,
                             "Acquire token failed with 'invalid grant' error, cannot proceed with silent request.",
                             ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
@@ -462,7 +462,7 @@ class BrokerProxy implements IBrokerProxy {
                     if (msg.contains(ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION.getDescription())) {
                         adalErrorCode = ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION;
                         break;
-                    } else if (msg.contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.getDescription())){
+                    } else if (msg.contains(ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.getDescription())) {
                         adalErrorCode = ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE;
                         break;
                     } else {
@@ -594,7 +594,12 @@ class BrokerProxy implements IBrokerProxy {
         final Intent intent;
         if (isBrokerAccountServiceSupported()) {
             intent = BrokerAccountServiceHandler.getInstance().getIntentForInteractiveRequest(mContext, brokerEvent);
-            intent.putExtras(requestBundle);
+            if (intent == null) {
+                Logger.e(TAG, "Get null intent for interactive request from broker.", null, ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
+                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Get null intent from broker.");
+            } else {
+                intent.putExtras(requestBundle);
+            }
         } else {
             intent = getIntentForBrokerActivityFromAccountManager(requestBundle);
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -588,7 +588,8 @@ class BrokerProxy implements IBrokerProxy {
      * from calling app's activity to control the lifetime of the activity.
      */
     @Override
-    public Intent getIntentForBrokerActivity(final AuthenticationRequest request, final BrokerEvent brokerEvent) {
+    public Intent getIntentForBrokerActivity(final AuthenticationRequest request, final BrokerEvent brokerEvent)
+            throws AuthenticationException {
         final Bundle requestBundle = getBrokerOptions(request);
         final Intent intent;
         if (isBrokerAccountServiceSupported()) {

--- a/adal/src/main/java/com/microsoft/aad/adal/IBrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IBrokerProxy.java
@@ -69,7 +69,8 @@ interface IBrokerProxy {
      * @param request AuthenticationRequest
      * @return Intent
      */
-    Intent getIntentForBrokerActivity(final AuthenticationRequest request, final BrokerEvent brokerEvent);
+    Intent getIntentForBrokerActivity(final AuthenticationRequest request, final BrokerEvent brokerEvent)
+            throws AuthenticationException;
 
     /*
      * Gets user info from broker.


### PR DESCRIPTION
Fix for issue #1031 

Add the null check in getIntentForInteractiveRequest, throw AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING if getting a null intent from broker.

Fix the bug that getIntentForInteractiveRequest returning null when getting any exception during the call of getIntentForInteractiveRequest., intead adal will throw the AuthenticationException when there is an exception happen.

Fix the relates unit tests.
