### PR TITLE
Handling HTTP Error Response | Part 1

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -422,6 +422,24 @@ public class OauthTests {
     }
 
     @Test
+    public void testRefreshTokenWebResponseRetryAfterStatus() {
+        final int RetryAfter = 429;
+        MockWebRequestHandler webRequest = new MockWebRequestHandler();
+        webRequest.setReturnResponse(new HttpWebResponse(RetryAfter,
+                "responseBody", new HashMap<String, List<String>>()));
+
+        // send request
+        MockAuthenticationCallback testResult = refreshToken(getValidAuthenticationRequest(),
+                webRequest, "test");
+
+        // Verify that callback can receive this error
+        assertNull("AuthenticationResult is null", testResult.getAuthenticationResult());
+        assertNotNull("Exception is not null", testResult.getException());
+        assertTrue(testResult.getException() instanceof AuthenticationServiceException);
+        assertEquals("responseBody", ((AuthenticationServiceException)testResult.getException()).getBody());
+    }
+
+    @Test
     public void testRefreshTokenWebResponsePositive() {
         MockWebRequestHandler webrequest = new MockWebRequestHandler();
         String json = "{\"access_token\":\"sometokenhere\",\"token_type\":\"Bearer\","

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationServiceException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationServiceException.java
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ADAL exception for STS error handling.
+ */
+public class AuthenticationServiceException extends AuthenticationException {
+    static final long serialVersionUID = 1;
+
+    private HttpWebResponse mResponse;
+
+    /**
+     * Constructor for {@link AuthenticationServiceException}.
+     * @param httpWebResponse
+     */
+    public AuthenticationServiceException(final HttpWebResponse httpWebResponse) {
+        super(ADALError.SERVER_ERROR, getResponseInfo(httpWebResponse));
+        mResponse = httpWebResponse;
+    }
+
+    private static String getResponseInfo(final HttpWebResponse response) {
+        if (null == response) {
+            throw new IllegalArgumentException("HttpWebResponse could not be NULL.");
+        } else {
+            return "Unexpected server response " + response.getStatusCode() + " " + response.getBody();
+        }
+    }
+
+    /**
+     * Get http web response status code.
+     * @return int status code
+     */
+    public int getStatusCode() {
+        if (mResponse != null) {
+            return mResponse.getStatusCode();
+        } else {
+            throw new IllegalArgumentException("HttpWebResponse could not be NULL.");
+        }
+    }
+
+    /**
+     * Get http web response body.
+     * @return String The response body for the network call.
+     */
+    public String getBody() {
+        if (mResponse != null) {
+            return mResponse.getBody();
+        } else {
+            throw new IllegalArgumentException("HttpWebResponse could not be NULL.");
+        }
+    }
+
+    /**
+     * Get the http web response headers.
+     * @return The response headers for the network call.
+     */
+    public Map<String, List<String>> getHeaders() {
+        if (null == mResponse || null == mResponse.getResponseHeaders()) {
+            throw new IllegalArgumentException("Illegal httpWebResponse.");
+        } else {
+            return mResponse.getResponseHeaders();
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for #1046 

- Add AuthenticationServiceException for STS error handling

1. If status code == 200, 400, 401, AuthenticationResult with error_code and error_description will be return
2. If status code == 5XX, ServerRespondingWithRetryableException will be thrown and will retry once if getIsExtendedLifetimeEnabled is true.
3. If status code is not expected as before, AuthenticationServiceException  will be thrown which contains httpWebResponse headers info. 
The client app get get these the status code by calling AuthenticationServiceException.getStatusCode() and get the responseBody by calling AuthenticationServiceException.getBody() and get the headers by calling AuthenticationServiceException.getHeaders().