### PR TITLE
Adds cloud discovery metadata parsing, population to :common

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -100,7 +100,9 @@ dependencies {
     compile "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     compile "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
     compile "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
-    compile project(":common")
+    compile(project(":common")){
+        exclude group: 'com.google.code.gson', module: 'gson'
+    }
 
     // Android Instrumented Test Dependencies
     androidTestCompile "com.android.support.test:runner:$rootProject.ext.runnerVersion"

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -35,6 +35,7 @@ import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.HashMapExtensions;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectory;
 
 import org.json.JSONException;
 
@@ -243,6 +244,13 @@ final class Discovery {
         try {
             queryUrl = buildQueryString(trustedHost, getAuthorizationCommonEndpoint(authorityUrl));
             final Map<String, String> discoveryResponse = sendRequest(queryUrl);
+
+            // Set the Cloud instance discovery metadata on the AAD IdentityProvider
+            AzureActiveDirectory.initializeCloudMetadata(
+                    authorityUrl.getHost().toLowerCase(Locale.US),
+                    discoveryResponse
+            );
+
             AuthorityValidationMetadataCache.processInstanceDiscoveryMetadata(authorityUrl, discoveryResponse);
             if (!AuthorityValidationMetadataCache.containsAuthorityHost(authorityUrl)) {
                 ArrayList<String> aliases = new ArrayList<String>();


### PR DESCRIPTION
Populates the new cloud discovery metadata cache in `:common`

See changes in `:common` [here](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/37).