### PR TITLE
Changes the thrown Exception for AuthenticationContext#serialize when FRT is missing

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1254,7 +1254,7 @@ public class AuthenticationContext {
         if (!StringExtensions.isNullOrBlank(tokenItem.getFamilyClientId())) {
             return SSOStateSerializer.serialize(tokenItem);
         } else {
-            throw new IllegalArgumentException("tokenItem does not contain family refresh token");
+            throw new UsageAuthenticationException(ADALError.FAIL_TO_EXPORT, "tokenItem does not contain family refresh token");
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1251,11 +1251,11 @@ public class AuthenticationContext {
                     "Failed to export the FID because no family token cache item is found.");
         }
 
-        if (!StringExtensions.isNullOrBlank(tokenItem.getFamilyClientId())) {
-            return SSOStateSerializer.serialize(tokenItem);
-        } else {
+        if (StringExtensions.isNullOrBlank(tokenItem.getFamilyClientId())) {
             throw new UsageAuthenticationException(ADALError.FAIL_TO_EXPORT, "tokenItem does not contain family refresh token");
         }
+
+        return SSOStateSerializer.serialize(tokenItem);
     }
 
     /**


### PR DESCRIPTION
See #1063, #1049 -- This change modifies the thrown Exception to be an instance of `UsageAuthenticationException` (a checked Exception), rather than an `IllegalArgumentException`