### PR TITLE
Shoatman/unified/dev/1057

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -48,6 +48,8 @@ import com.microsoft.identity.common.adal.error.ADALError;
 import com.microsoft.identity.common.adal.error.AuthenticationException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryCloud;
 
 import org.json.JSONException;
 import org.junit.After;
@@ -128,7 +130,10 @@ public final class AcquireTokenRequestTest {
         }
 
         final InstanceDiscoveryMetadata metadata = new InstanceDiscoveryMetadata("login.microsoftonline.com", "login.windows.net");
+        final AzureActiveDirectoryCloud cloud = CoreAdapter.asAadCloud(metadata);
+
         AuthorityValidationMetadataCache.updateInstanceDiscoveryMap("login.windows.net", metadata);
+        AzureActiveDirectory.putCloud("login.windows.net", cloud);
     }
 
     @After

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -556,17 +556,17 @@ public final class AcquireTokenRequestTest {
         final CountDownLatch latch = new CountDownLatch(1);
         authContext.acquireToken(Mockito.mock(Activity.class), "resource", "clientid", authContext.getRedirectUriForBroker(), TEST_UPN,
                 PromptBehavior.Auto, "claims=testclaims123", null, new AuthenticationCallback<AuthenticationResult>() {
-            @Override
-            public void onSuccess(AuthenticationResult result) {
-                assertNotNull(result.getAccessToken());
-                latch.countDown();
-            }
+                    @Override
+                    public void onSuccess(AuthenticationResult result) {
+                        assertNotNull(result.getAccessToken());
+                        latch.countDown();
+                    }
 
-            @Override
-            public void onError(Exception exc) {
-                fail();
-            }
-        });
+                    @Override
+                    public void onError(Exception exc) {
+                        fail();
+                    }
+                });
         latch.await();
     }
 
@@ -595,7 +595,8 @@ public final class AcquireTokenRequestTest {
 
         final IWindowComponent fragment = new IWindowComponent() {
             @Override
-            public void startActivityForResult(Intent intent, int requestCode) { }
+            public void startActivityForResult(Intent intent, int requestCode) {
+            }
         };
 
         try {
@@ -663,16 +664,16 @@ public final class AcquireTokenRequestTest {
         final String idToken = "I am an id token";
         final String resource = "resource";
         final String clientId = "clientid";
-        
+
         final AuthenticationResult result;
         if (extendedExpiresOn == null) {
-            result = new AuthenticationResult(accessToken, refreshToken, expiresOn, storeMRRT, 
+            result = new AuthenticationResult(accessToken, refreshToken, expiresOn, storeMRRT,
                     userInfo, "", idToken, null);
         } else {
-            result = new AuthenticationResult(accessToken, refreshToken, expiresOn, storeMRRT, 
+            result = new AuthenticationResult(accessToken, refreshToken, expiresOn, storeMRRT,
                     userInfo, "", idToken, extendedExpiresOn);
         }
-        
+
         final ITokenCacheStore cacheStore = new DefaultTokenCacheStore(InstrumentationRegistry.getContext());
         cacheStore.removeAll();
         final TokenCacheItem regularRTItem = TokenCacheItem.createRegularTokenCacheItem(VALID_AUTHORITY,
@@ -882,7 +883,7 @@ public final class AcquireTokenRequestTest {
     }
 
     /**
-     * Test for throwing exception when the request is rejected by server through there is a valid 
+     * Test for throwing exception when the request is rejected by server through there is a valid
      * stale AT in the cache and the ExtendedLifetime is on.
      */
     @Test
@@ -936,7 +937,7 @@ public final class AcquireTokenRequestTest {
         final AuthenticationContext authContext = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false, cacheStore);
         authContext.setExtendedLifetimeEnabled(true);
-        
+
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
@@ -1036,7 +1037,7 @@ public final class AcquireTokenRequestTest {
     }
 
     /**
-     * Test for throwing exception when the request is rejected by server through there is a valid 
+     * Test for throwing exception when the request is rejected by server through there is a valid
      * stale AT in the cache and the ExtendedLifetime is on.
      */
     @Test
@@ -1083,12 +1084,12 @@ public final class AcquireTokenRequestTest {
         cacheStore.removeItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId", TEST_UPN));
         cacheStore.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, "clientId", TEST_USERID)).setFamilyClientId(AuthenticationConstants.MS_FAMILY_ID);
         cacheStore.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, "clientId", TEST_UPN)).setFamilyClientId(AuthenticationConstants.MS_FAMILY_ID);
-        
+
         final FileMockContext mockContext = createMockContext();
         final AuthenticationContext authContext = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false, cacheStore);
         authContext.setExtendedLifetimeEnabled(true);
-        
+
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
@@ -1110,7 +1111,7 @@ public final class AcquireTokenRequestTest {
             cacheStore.removeAll();
         }
     }
-    
+
     @Test
     public void testVerifyManifestPermissionMissingGetAccountsPermission() throws InterruptedException, PackageManager.NameNotFoundException {
         final FileMockContext mockContext = createMockContext();
@@ -1120,7 +1121,7 @@ public final class AcquireTokenRequestTest {
 
         final AuthenticationContext authContext = new AuthenticationContext(mockContext,
                 VALID_AUTHORITY, false);
-        
+
         final TestAuthCallback callback = new TestAuthCallback();
         authContext.acquireToken(Mockito.mock(Activity.class), "resource", "clientid", authContext.getRedirectUriForBroker(),
                 "loginHint", callback);
@@ -1239,7 +1240,7 @@ public final class AcquireTokenRequestTest {
                 AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, 0, 0, 0, 0);
         final AuthenticatorDescription mockedAuthenticator = Mockito.spy(authenticatorDescription);
         final AuthenticatorDescription[] mockedAuthenticatorTypes
-                = new AuthenticatorDescription[] {mockedAuthenticator};
+                = new AuthenticatorDescription[]{mockedAuthenticator};
         Mockito.when(mockedAccountManager.getAuthenticatorTypes()).thenReturn(mockedAuthenticatorTypes);
 
         return mockedAccountManager;
@@ -1249,7 +1250,7 @@ public final class AcquireTokenRequestTest {
             throws OperationCanceledException, IOException, AuthenticatorException {
         final Account account = new Account(TEST_UPN, AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
         when(mockedAccountManger.getAccountsByType(Matchers.refEq(
-                AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE))).thenReturn(new Account[] {account});
+                AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE))).thenReturn(new Account[]{account});
 
         final Bundle bundle = new Bundle();
         bundle.putString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID, TEST_USERID);
@@ -1313,7 +1314,7 @@ public final class AcquireTokenRequestTest {
                 Util.ENCODED_SIGNATURE, Base64.NO_WRAP));
 
         final PackageInfo mockedPackageInfo = Mockito.mock(PackageInfo.class);
-        mockedPackageInfo.signatures = new Signature[] {mockedSignature};
+        mockedPackageInfo.signatures = new Signature[]{mockedSignature};
 
         final PackageManager mockedPackageManager = Mockito.mock(PackageManager.class);
         when(mockedPackageManager.getPackageInfo(Mockito.anyString(), Mockito.anyInt())).thenReturn(mockedPackageInfo);
@@ -1349,7 +1350,7 @@ public final class AcquireTokenRequestTest {
         Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
     }
 
-    private HttpURLConnection prepareFailedHttpUrlConnection(final String errorCode, final String ...errorCodes) throws IOException, JSONException {
+    private HttpURLConnection prepareFailedHttpUrlConnection(final String errorCode, final String... errorCodes) throws IOException, JSONException {
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
@@ -1369,7 +1370,7 @@ public final class AcquireTokenRequestTest {
         final byte[] testingSignature = md.digest();
         return Base64.encodeToString(testingSignature, Base64.NO_WRAP);
     }
-    
+
     private Date getExpireDate(int expireTime) {
         final Calendar expiredTime = new GregorianCalendar();
         expiredTime.add(Calendar.MINUTE, expireTime);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -438,7 +438,7 @@ public final class AcquireTokenSilentHandlerTest {
         clearCache(mockCache);
     }
 
-    private void addAzureADCloudForValidAuthority(){
+    private void addAzureADCloudForValidAuthority() {
         List<String> aliases = new ArrayList<String>();
         aliases.add("login.windows.net");
         aliases.add("login.microsoftonline.com");

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -1299,6 +1299,6 @@ public final class AcquireTokenSilentHandlerTest {
     private AcquireTokenSilentHandler getAcquireTokenHandler(final Context context, final AuthenticationRequest authRequest,
                                                              final ITokenCacheStore mockCache) {
         return new AcquireTokenSilentHandler(context, authRequest,
-                new TokenCacheAccessor(mockCache, authRequest.getAuthority(), authRequest.getTelemetryRequestId()));
+                new TokenCacheAccessor(context.getApplicationContext(), mockCache, authRequest.getAuthority(), authRequest.getTelemetryRequestId()));
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -396,6 +396,8 @@ public final class AcquireTokenSilentHandlerTest {
         final TokenCacheItem frTokenCacheItem = getTokenCacheItemWithFoCI(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN, AuthenticationConstants.MS_FAMILY_ID);
         saveTokenIntoCache(mockCache, frTokenCacheItem);
 
+        addAzureADCloudForValidAuthority();
+
         final String resource = "resource";
         final String clientId = "clientId";
         final AuthenticationRequest authenticationRequest = getAuthenticationRequest(VALID_AUTHORITY, resource, clientId, false);
@@ -434,6 +436,15 @@ public final class AcquireTokenSilentHandlerTest {
         assertNotNull(mockCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_UPN)));
 
         clearCache(mockCache);
+    }
+
+    private void addAzureADCloudForValidAuthority(){
+        List<String> aliases = new ArrayList<String>();
+        aliases.add("login.windows.net");
+        aliases.add("login.microsoftonline.com");
+        AzureActiveDirectoryCloud cloud = new AzureActiveDirectoryCloud("login.microsoftonline.com", "login.windows.net", aliases);
+
+        AzureActiveDirectory.putCloud("login.windows.net", cloud);
     }
 
     /**

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -37,6 +37,8 @@ import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryCloud;
 
 import org.json.JSONException;
 import org.junit.After;
@@ -1212,8 +1214,10 @@ public final class AcquireTokenSilentHandlerTest {
 
     private void updateAuthorityMetadataCache() {
         final InstanceDiscoveryMetadata metadata = getInstanceDiscoveryMetadata();
+        final AzureActiveDirectoryCloud cloud = CoreAdapter.asAadCloud(metadata);
         for (final String alias : metadata.getAliases()) {
             AuthorityValidationMetadataCache.updateInstanceDiscoveryMap(alias, metadata);
+            AzureActiveDirectory.putCloud(alias, cloud);
         }
     }
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -83,7 +83,7 @@ public class AndroidTestHelper {
     }
 
     public void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
-            final ThrowableRunnable testCode) {
+                                      final ThrowableRunnable testCode) {
         try {
             testCode.run();
             Assert.fail("This is expecting an exception, but it was not thrown.");
@@ -100,7 +100,7 @@ public class AndroidTestHelper {
     }
 
     public void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
-            final Runnable testCode) {
+                                      final Runnable testCode) {
         try {
             testCode.run();
             Assert.fail("This is expecting an exception, but it was not thrown.");
@@ -117,7 +117,7 @@ public class AndroidTestHelper {
 
     /**
      * just run tests and wait until finished
-     * 
+     *
      * @param signal
      * @param testCode
      * @param runOnUI

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AssertUtils.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AssertUtils.java
@@ -34,9 +34,9 @@ public class AssertUtils extends Assert {
 
     private static final String TAG = "AssertUtils";
     protected static final int REQUEST_TIME_OUT = 20000; // milliseconds
-    
+
     public static void assertThrowsException(final Class<? extends Exception> expected, String hasMessage,
-            final Runnable testCode) {
+                                             final Runnable testCode) {
         try {
             testCode.run();
             Assert.fail("This is expecting an exception, but it was not thrown.");
@@ -51,13 +51,13 @@ public class AssertUtils extends Assert {
             }
         }
     }
-    
+
     public static void assertAsync(final CountDownLatch signal, final Runnable testCode) {
 
         Log.d(TAG, "Thread:" + android.os.Process.myTid());
 
-        try {             
-                testCode.run();
+        try {
+            testCode.run();
         } catch (Throwable ex) {
             Log.e(TAG, ex.getMessage());
             Assert.fail("not expected:" + ex.getMessage());

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationActivityUnitTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationActivityUnitTest.java
@@ -371,7 +371,7 @@ public class AuthenticationActivityUnitTest {
                 Class.forName("com.microsoft.aad.adal.AuthenticationActivity$TokenTaskResult"));
         AccountManager mockAct = mock(AccountManager.class);
         when(mockAct.getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE))
-                .thenReturn(new Account[] {});
+                .thenReturn(new Account[]{});
         ReflectionUtils.setFieldValue(tokenTask, "mRequest", authRequest);
         ReflectionUtils.setFieldValue(tokenTask, "mPackageName", "testpackagename");
         ReflectionUtils.setFieldValue(tokenTask, "mAccountManager", mockAct);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -33,6 +33,7 @@ import android.content.pm.Signature;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.Suppress;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.UiThreadTest;
 import android.util.Base64;
@@ -44,6 +45,8 @@ import com.microsoft.identity.common.adal.error.AuthenticationException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryCloud;
 
 import junit.framework.Assert;
 
@@ -65,6 +68,7 @@ import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -935,7 +939,8 @@ public final class AuthenticationContextTest {
      * token response must match to result and cache.
      */
     @Test
-    public void testRefreshTokenPositive() throws IOException, InterruptedException, AuthenticationException {
+    public void
+    testRefreshTokenPositive() throws IOException, InterruptedException, AuthenticationException {
 
         FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
@@ -1191,6 +1196,14 @@ public final class AuthenticationContextTest {
         verifyFamilyIdStoredInTokenCacheItem(mockCache, CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId",
                 TEST_IDTOKEN_UPN), "familyClientId");
         clearCache(context);
+    }
+
+    private void addAzureADCloudForValidAuthority(){
+        List<String> aliases = new ArrayList<String>();
+        aliases.add("login.windows.net");
+        aliases.add("login.microsoftonline.com");
+        AzureActiveDirectoryCloud cloud = new AzureActiveDirectoryCloud("login.microsoftonline.com", "login.windows.net", aliases);
+        AzureActiveDirectory.putCloud("login.windows.net", cloud);
     }
 
     /**
@@ -1664,6 +1677,7 @@ public final class AuthenticationContextTest {
      * @throws AuthenticationException
      */
     @Test
+    @Suppress
     public void testAcquireTokenSilentSyncPositive() throws IOException, AuthenticationException,
             InterruptedException {
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -114,7 +114,7 @@ public final class AuthenticationContextTest {
      */
     private static final String VALID_AUTHORITY = "https://login.windows.net/test.onmicrosoft.com";
 
-    protected static final int CONTEXT_REQUEST_TIME_OUT = 20000;
+    protected static final int CONTEXT_REQUEST_TIME_OUT = 20000; //20000
 
     protected static final int ACTIVITY_TIME_OUT = 1000;
 
@@ -153,6 +153,13 @@ public final class AuthenticationContextTest {
             SecretKey secretKey = new SecretKeySpec(tempkey.getEncoded(), "AES");
             AuthenticationSettings.INSTANCE.setSecretKey(secretKey.getEncoded());
         }
+
+        final InstanceDiscoveryMetadata metadata = new InstanceDiscoveryMetadata("login.microsoftonline.com", "login.windows.net");
+        final AzureActiveDirectoryCloud cloud = CoreAdapter.asAadCloud(metadata);
+
+        AuthorityValidationMetadataCache.updateInstanceDiscoveryMap("login.windows.net", metadata);
+        AzureActiveDirectory.putCloud("login.windows.net", cloud);
+
         AuthenticationSettings.INSTANCE.setUseBroker(false);
         // ADAL is set to this signature for now
         PackageInfo info = InstrumentationRegistry.getContext().getPackageManager()
@@ -1677,7 +1684,6 @@ public final class AuthenticationContextTest {
      * @throws AuthenticationException
      */
     @Test
-    @Suppress
     public void testAcquireTokenSilentSyncPositive() throws IOException, AuthenticationException,
             InterruptedException {
 
@@ -1689,7 +1695,10 @@ public final class AuthenticationContextTest {
         final MockActivity testActivity = new MockActivity();
         final CountDownLatch signal = new CountDownLatch(1);
         testActivity.mSignal = signal;
-        final String response = "{\"access_token\":\"TokenFortestRefreshTokenPositive\",\"token_type\":\"Bearer\","
+
+        final String response = "{\"id_token\":\""
+                + TEST_IDTOKEN
+                + "\",\"access_token\":\"TokenFortestRefreshTokenPositive\",\"token_type\":\"Bearer\","
                 + "\"expires_in\":\"28799\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\","
                 + "\"scope\":\"*\"}";
 
@@ -1797,11 +1806,6 @@ public final class AuthenticationContextTest {
                                             AuthenticationResult result) {
         assertNull("Error is null", resultException);
         assertEquals("Token is same", "TokenFortestRefreshTokenPositive", result.getAccessToken());
-        assertNotNull("Cache is NOT empty for this userid for regular token",
-                mockCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId",
-                        TEST_IDTOKEN_USERID)));
-        assertNull("Cache is empty for multiresource token", mockCache.getItem(
-                CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, "clientId", TEST_IDTOKEN_USERID)));
         assertNotNull("Cache is NOT empty for this userid for regular token",
                 mockCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId",
                         TEST_IDTOKEN_USERID)));

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -33,7 +33,6 @@ import android.content.pm.Signature;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.Suppress;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.UiThreadTest;
 import android.util.Base64;
@@ -114,7 +113,11 @@ public final class AuthenticationContextTest {
      */
     private static final String VALID_AUTHORITY = "https://login.windows.net/test.onmicrosoft.com";
 
-    protected static final int CONTEXT_REQUEST_TIME_OUT = 20000; //20000
+    /**
+     * This value Controls the timeout for CloudDownLatches used in various tests
+     * You may want to increase this value when debugging a test
+     */
+    protected static final int CONTEXT_REQUEST_TIME_OUT = 20000;
 
     protected static final int ACTIVITY_TIME_OUT = 1000;
 
@@ -1205,7 +1208,7 @@ public final class AuthenticationContextTest {
         clearCache(context);
     }
 
-    private void addAzureADCloudForValidAuthority(){
+    private void addAzureADCloudForValidAuthority() {
         List<String> aliases = new ArrayList<String>();
         aliases.add("login.windows.net");
         aliases.add("login.microsoftonline.com");

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BaseTokenStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BaseTokenStoreTests.java
@@ -151,7 +151,7 @@ public abstract class BaseTokenStoreTests extends AndroidTestHelper {
         assertNotNull("Token cache item is expected to be NOT null", item);
         assertEquals("same item", mTestItem.getTenantId(), item.getTenantId());
         assertEquals("same item", mTestItem.getAccessToken(), item.getAccessToken());
-        
+
         item = store.getItem(CacheKey.createCacheKey("", "", "", true, "", null));
         assertNull("Token cache item is expected to be null", item);
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -315,7 +315,7 @@ public class BrokerProxyTests {
         bundle.putBoolean("com.microsoft.workaccount.user.info", true);
         when(mockedAccountManager.updateCredentials(eq(accounts[0]), eq(AuthenticationConstants.Broker.AUTHTOKEN_TYPE),
                 any(Bundle.class), (Activity) eq(null), (AccountManagerCallback) eq(null), (Handler) eq(null)))
-                        .thenReturn(mockResult);
+                .thenReturn(mockResult);
 
         final FileMockContext context = new FileMockContext(InstrumentationRegistry.getContext());
         context.setMockedAccountManager(mockedAccountManager);
@@ -370,7 +370,7 @@ public class BrokerProxyTests {
         AuthenticatorDescription[] descriptions = getAuthenticator(authenticatorType, brokerPackage);
         Context mockContext = getMockContext(signature, brokerPackage, brokerPackage, true);
         when(mockAcctManager.getAuthenticatorTypes()).thenReturn(descriptions);
-        when(mockAcctManager.getAccountsByType(Matchers.refEq(authenticatorType))).thenReturn(new Account[] {});
+        when(mockAcctManager.getAccountsByType(Matchers.refEq(authenticatorType))).thenReturn(new Account[]{});
         when(mockContext.getPackageName()).thenReturn(brokerPackage);
         ReflectionUtils.setFieldValue(brokerProxy, "mContext", mockContext);
         ReflectionUtils.setFieldValue(brokerProxy, "mAcctManager", mockAcctManager);
@@ -731,7 +731,7 @@ public class BrokerProxyTests {
 
     @Test
     public void testGetAuthTokenInBackgroundVerifyErrorNoNetworkConnection() throws NameNotFoundException,
-    OperationCanceledException, IOException, AuthenticatorException {
+            OperationCanceledException, IOException, AuthenticatorException {
         final String acctName = "testAcct123";
         final AuthenticationRequest authRequest = createAuthenticationRequest("https://login.windows.net/omercantest", "resource", "client",
                 "redirect", acctName.toLowerCase(Locale.US), PromptBehavior.Auto, "", UUID.randomUUID(), false);
@@ -962,10 +962,10 @@ public class BrokerProxyTests {
         assertEquals("intent is not null", AuthenticationConstants.Broker.BROKER_REQUEST,
                 intent.getStringExtra(AuthenticationConstants.Broker.BROKER_REQUEST));
     }
-    
+
     /**
      * Test verifying if always is set when speaking to new broker, intent for doing auth via broker will have prompt behavior
-     * reset as always. 
+     * reset as always.
      */
     @Test
     public void testForcePromptFlagOldBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
@@ -976,7 +976,7 @@ public class BrokerProxyTests {
         final AccountManager mockedAccoutManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
                 AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
         mockAddAccountResponse(mockedAccoutManager, getMockedAccountManagerFuture(intent));
-        
+
         final FileMockContext mockedContext = new FileMockContext(InstrumentationRegistry.getContext());
         mockedContext.setMockedAccountManager(mockedAccoutManager);
         mockedContext.setMockedPackageManager(getMockedPackageManagerWithBrokerAccountServiceDisabled(mock(Signature.class),
@@ -985,10 +985,10 @@ public class BrokerProxyTests {
         final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
         assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
     }
-    
+
     /**
      * Test verifying if force_prmopt is set when speaking to new broker, intent for doing auth via broker will have prompt behavior
-     * as Force_Prompt. 
+     * as Force_Prompt.
      */
     @Test
     public void testForcePromptNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
@@ -996,7 +996,7 @@ public class BrokerProxyTests {
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.FORCE_PROMPT);
         intent.putExtra(AuthenticationConstants.Broker.BROKER_VERSION, AuthenticationConstants.Broker.BROKER_PROTOCOL_VERSION);
         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT, authenticationRequest.getPrompt().name());
-        
+
         // mock account manager
         final AccountManager mockedAccoutManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
                 AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
@@ -1011,10 +1011,10 @@ public class BrokerProxyTests {
         final Intent returnedIntent = brokerProxy.getIntentForBrokerActivity(authenticationRequest, null);
         assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.FORCE_PROMPT.name()));
     }
-    
+
     /**
      * Test verifying if always is set when speaking to new broker, intent for doing auth via broker will have prompt behavior
-     * as always. 
+     * as always.
      */
     @Test
     public void testPromptAlwaysNewBroker() throws OperationCanceledException, IOException, AuthenticatorException, NameNotFoundException {
@@ -1022,7 +1022,7 @@ public class BrokerProxyTests {
         final AuthenticationRequest authenticationRequest = getAuthRequest(PromptBehavior.Always);
         intent.putExtra(AuthenticationConstants.Broker.BROKER_VERSION, AuthenticationConstants.Broker.BROKER_PROTOCOL_VERSION);
         intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT, authenticationRequest.getPrompt().name());
-        
+
         // mock account manager
         final AccountManager mockedAccoutManager = getMockedAccountManager(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
                 AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
@@ -1038,38 +1038,38 @@ public class BrokerProxyTests {
 
         assertTrue(returnedIntent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT).equalsIgnoreCase(PromptBehavior.Always.name()));
     }
-    
+
     private FileMockContext getMockedContext(final AccountManager mockedAccountManager) {
         final FileMockContext mockedContext = new FileMockContext(InstrumentationRegistry.getContext());
         mockedContext.setMockedAccountManager(mockedAccountManager);
-        
+
         return mockedContext;
     }
-    
+
     private AuthenticationRequest getAuthRequest(final PromptBehavior promptBehavior) {
         final AuthenticationRequest authenticationRequest = new AuthenticationRequest();
         authenticationRequest.setPrompt(promptBehavior);
-        
+
         return authenticationRequest;
     }
-    
+
     private AccountManagerFuture<Bundle> getMockedAccountManagerFuture(final Intent intent)
             throws OperationCanceledException, IOException, AuthenticatorException {
         final Bundle bundle = new Bundle();
         bundle.putParcelable(AccountManager.KEY_INTENT, intent);
-        
+
         final AccountManagerFuture<Bundle> mockedAccountManagerFuture = Mockito.mock(AccountManagerFuture.class);
         Mockito.when(mockedAccountManagerFuture.getResult()).thenReturn(bundle);
-        
+
         return mockedAccountManagerFuture;
     }
-    
+
     private AccountManager getMockedAccountManager(final AccountManagerFuture<Bundle> mockedAccountManagerFuture) {
         final AccountManager mockedAccoutManager = Mockito.mock(AccountManager.class);
-        Mockito.when(mockedAccoutManager.addAccount(Matchers.anyString(), Mockito.anyString(), Matchers.any(String[].class), 
-                Matchers.any(Bundle.class), Matchers.any(Activity.class), Matchers.any(AccountManagerCallback.class), 
+        Mockito.when(mockedAccoutManager.addAccount(Matchers.anyString(), Mockito.anyString(), Matchers.any(String[].class),
+                Matchers.any(Bundle.class), Matchers.any(Activity.class), Matchers.any(AccountManagerCallback.class),
                 Mockito.any(Handler.class))).thenReturn(mockedAccountManagerFuture);
-        
+
         return mockedAccoutManager;
     }
 
@@ -1096,7 +1096,7 @@ public class BrokerProxyTests {
         when(mockFuture.getResult()).thenReturn(expected);
         when(mockAcctManager.addAccount(anyString(), anyString(), (String[]) eq(null), any(Bundle.class),
                 (Activity) eq(null), (AccountManagerCallback<Bundle>) eq(null), any(Handler.class)))
-                        .thenReturn(mockFuture);
+                .thenReturn(mockFuture);
         when(mockAcctManager.getAccountsByType(anyString()))
                 .thenReturn(getAccountList("test", AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE));
     }
@@ -1115,7 +1115,7 @@ public class BrokerProxyTests {
                 brokerPackage, 0, 0, 0, 0);
         final AuthenticatorDescription mockedAuthenticator = Mockito.spy(authenticatorDescription);
         final AuthenticatorDescription[] mockedAuthenticatorTypes
-                = new AuthenticatorDescription[] {mockedAuthenticator};
+                = new AuthenticatorDescription[]{mockedAuthenticator};
 
         Mockito.when(mockAcctManager.getAuthenticatorTypes()).thenReturn(mockedAuthenticatorTypes);
 
@@ -1123,7 +1123,7 @@ public class BrokerProxyTests {
     }
 
     private Context getMockContext(final Signature signature, final String brokerPackageName,
-            final String contextPackageName, boolean permissionStatus) throws NameNotFoundException {
+                                   final String contextPackageName, boolean permissionStatus) throws NameNotFoundException {
         Context mockContext = mock(Context.class);
         // insert packagemanager mocks
         PackageManager mockPackageManager = getPackageManager(signature, brokerPackageName, permissionStatus);
@@ -1137,7 +1137,7 @@ public class BrokerProxyTests {
 
     @SuppressLint("PackageManagerGetSignatures")
     private PackageManager getPackageManager(final Signature signature, final String packageName,
-            boolean permissionStatus) throws NameNotFoundException {
+                                             boolean permissionStatus) throws NameNotFoundException {
         PackageManager mockPackage = mock(PackageManager.class);
         PackageInfo info = new PackageInfo();
         Signature[] signatures = new Signature[1];

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/CacheKeyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/CacheKeyTests.java
@@ -67,7 +67,7 @@ public class CacheKeyTests {
                 "ClientId123", false, "user123", null);
         assertEquals("expected key", "authority123endsslash$Resource123$clientid123$n$user123",
                 testKeySlash);
-        
+
         final String testKeyWithFamilyClientId = CacheKey.createCacheKey("authority", null, null, true, "user123", "family123");
         assertEquals("authority$null$null$y$user123$foci-family123", testKeyWithFamilyClientId);
     }
@@ -121,7 +121,7 @@ public class CacheKeyTests {
             assertEquals("contains resource", "resource",
                     ((IllegalArgumentException) exc).getMessage());
         }
-        
+
         // Test resource is null but the cache key is for MRRT. 
         try {
             final String cacheKey = CacheKey.createCacheKey("authority", null, "clientid", true, "user123", null);
@@ -143,7 +143,7 @@ public class CacheKeyTests {
             assertEquals("contains clientId", "both clientId and familyClientId are null",
                     ((IllegalArgumentException) exc).getMessage());
         }
-        
+
         // Test client id is null but family client id is not null
         try {
             final String key = CacheKey.createCacheKey("authority", null, null, true, "user123", "family123");

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/FileMockContext.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/FileMockContext.java
@@ -67,9 +67,9 @@ class FileMockContext extends MockContext {
     private int mFileWriteMode;
 
     private Map<String, Integer> mPermissionMap = new HashMap<String, Integer>();
-    
+
     private boolean mIsConnectionAvailable = true;
-    
+
     private AccountManager mMockedAccountManager = null;
 
     private PackageManager mMockedPackageManager = null;
@@ -119,7 +119,7 @@ class FileMockContext extends MockContext {
             if (mMockedAccountManager == null) {
                 return mock(AccountManager.class);
             }
-            
+
             return mMockedAccountManager;
         } else if (name.equalsIgnoreCase("connectivity")) {
             final ConnectivityManager mockedConnectivityManager = mock(ConnectivityManager.class);
@@ -173,7 +173,7 @@ class FileMockContext extends MockContext {
     public void addPermission(String permissionName) {
         mPermissionMap.put(permissionName, PackageManager.PERMISSION_GRANTED);
     }
-    
+
     public void removePermission(String permissionName) {
         mPermissionMap.remove(permissionName);
     }
@@ -246,7 +246,7 @@ class FileMockContext extends MockContext {
             if (mPermissionMap.containsKey(permName)) {
                 return PackageManager.PERMISSION_GRANTED;
             }
-            
+
             return PackageManager.PERMISSION_DENIED;
         }
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/FileTokenCacheStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/FileTokenCacheStoreTests.java
@@ -226,22 +226,23 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
         ITokenCacheStore store = new FileTokenCacheStore(mTargetContex, file);
 
         final Iterator<TokenCacheItem> allItems = store.getAll();
-        
+
         assertTrue(allItems.hasNext());
         final TokenCacheItem tokenCacheItem1 = allItems.next();
         assertNotNull(tokenCacheItem1);
-        
+
         assertTrue(allItems.hasNext());
         final TokenCacheItem tokenCacheItem2 = allItems.next();
         assertNotNull(tokenCacheItem2);
-        
+
         assertFalse(allItems.hasNext());
     }
 
     /**
      * test the usage of cache from different threads. It is expected to work
      * with multiThreads
-     * @throws AuthenticationException 
+     *
+     * @throws AuthenticationException
      */
     @Test
     public void testSharedCacheGetItem() throws AuthenticationException {
@@ -283,7 +284,8 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
 
     /**
      * memory cache is shared between context
-     * @throws AuthenticationException 
+     *
+     * @throws AuthenticationException
      */
     @Test
     public void testMemoryCacheMultipleContext() throws AuthenticationException {
@@ -321,7 +323,7 @@ public class FileTokenCacheStoreTests extends AndroidTestHelper {
 
         @Override
         public void Log(String tag, String message, String additionalMessage, LogLevel level,
-                ADALError errorCode) {
+                        ADALError errorCode) {
             mLogMessage = message;
             mLogErrorCode = errorCode;
         }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MemoryTokenCacheStoreTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MemoryTokenCacheStoreTests.java
@@ -68,10 +68,10 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
     /**
      * test the usage of cache from different threads. It is expected to work
      * with multiThreads
-     * 
+     *
      * @throws NoSuchPaddingException
      * @throws NoSuchAlgorithmException
-     * @throws AuthenticationException 
+     * @throws AuthenticationException
      */
     @Test
     public void testSharedCacheGetItem() throws NoSuchAlgorithmException, NoSuchPaddingException, AuthenticationException {
@@ -146,10 +146,10 @@ public class MemoryTokenCacheStoreTests extends BaseTokenStoreTests {
 
     /**
      * memory cache is shared between context
-     * 
+     *
      * @throws NoSuchPaddingException
      * @throws NoSuchAlgorithmException
-     * @throws AuthenticationException 
+     * @throws AuthenticationException
      */
     @Test
     public void testMemoryCacheMultipleContext() throws NoSuchAlgorithmException,

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockWebRequestHandler.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockWebRequestHandler.java
@@ -63,7 +63,7 @@ class MockWebRequestHandler implements IWebRequestHandler {
 
     @Override
     public HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
-            String contentType) throws IOException {
+                                    String contentType) throws IOException {
         mRequestUrl = url;
         mRequestHeaders = headers;
         if (content != null) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -27,11 +27,11 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AAD;
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
 import com.microsoft.identity.common.adal.error.ADALError;
 import com.microsoft.identity.common.adal.error.AuthenticationException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AAD;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
@@ -79,6 +79,7 @@ public class OauthTests {
     private static final String TEST_RETURNED_EXCEPTION = "test-returned-exception";
 
     private static final String TEST_AUTHORITY = "https://login.windows.net/common";
+
     @Before
     public void setUp() throws Exception {
         System.setProperty("dexmaker.dexcache", InstrumentationRegistry.getContext().getCacheDir().getPath());
@@ -527,7 +528,7 @@ public class OauthTests {
     }
 
     @Test
-    public void testprocessTokenResponse() throws  IOException {
+    public void testprocessTokenResponse() throws IOException {
 
         final AuthenticationRequest request = createAuthenticationRequest(TEST_AUTHORITY,
                 "resource", "client", "redirect", "loginhint", null, null, UUID.randomUUID(), false);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ReflectionUtils.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ReflectionUtils.java
@@ -34,7 +34,7 @@ public final class ReflectionUtils {
 
     /**
      * get non public method from class
-     * 
+     *
      * @param object
      * @param methodName
      * @return
@@ -53,7 +53,7 @@ public final class ReflectionUtils {
         m.setAccessible(true);
         return m;
     }
-    
+
     public static Method getStaticTestMethod(Class<?> c, final String methodName, Class<?>... paramtypes)
             throws IllegalArgumentException, ClassNotFoundException, NoSuchMethodException,
             InstantiationException, IllegalAccessException, InvocationTargetException {
@@ -64,7 +64,7 @@ public final class ReflectionUtils {
 
     /**
      * get non public instance default constructor for testing
-     * 
+     *
      * @param name
      * @return
      * @throws ClassNotFoundException
@@ -147,7 +147,7 @@ public final class ReflectionUtils {
             paramTypes = new Class<?>[params.length];
             for (int i = 0; i < params.length; i++) {
                 //paramTypes[i] = params[i].getClass();
-                if (params[i].getClass().getSimpleName().equals("Boolean")) {                    
+                if (params[i].getClass().getSimpleName().equals("Boolean")) {
                     paramTypes[i] = boolean.class;
                 } else {
                     paramTypes[i] = params[i].getClass();

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryPrivacyComplianceTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryPrivacyComplianceTests.java
@@ -23,9 +23,9 @@
 
 package com.microsoft.aad.adal;
 
-import com.microsoft.identity.common.adal.internal.util.StringExtensions;
-
 import android.support.test.runner.AndroidJUnit4;
+
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryTest.java
@@ -23,8 +23,6 @@
 
 package com.microsoft.aad.adal;
 
-import com.microsoft.identity.common.adal.internal.util.StringExtensions;
-
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -34,6 +32,8 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 import android.util.Log;
+
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -109,7 +109,7 @@ public class TelemetryTest {
                 Util.ENCODED_SIGNATURE, Base64.NO_WRAP));
 
         final PackageInfo mockedPackageInfo = Mockito.mock(PackageInfo.class);
-        mockedPackageInfo.signatures = new Signature[] {mockedSignature};
+        mockedPackageInfo.signatures = new Signature[]{mockedSignature};
 
         final PackageManager mockedPackageManager = Mockito.mock(PackageManager.class);
         when(mockedPackageManager.getPackageInfo(Mockito.anyString(), anyInt())).thenReturn(mockedPackageInfo);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TestLogResponse.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TestLogResponse.java
@@ -54,7 +54,7 @@ public class TestLogResponse {
 
             @Override
             public void Log(String tag, String message, String additionalMessage, LogLevel level,
-                    ADALError errorCode) {
+                            ADALError errorCode) {
 
                 if (message.contains(msg + " ver:" + AuthenticationContext.getVersionName())) {
                     response.mTag = tag;
@@ -72,6 +72,7 @@ public class TestLogResponse {
 
     /**
      * Check log message for segments since some of the responses include server generated traceid, timeStamp etc.
+     *
      * @param msgs
      */
     public void listenLogForMessageSegments(final String... msgs) {
@@ -81,7 +82,7 @@ public class TestLogResponse {
 
             @Override
             public void Log(String tag, String message, String additionalMessage, LogLevel level,
-                    ADALError errorCode) {
+                            ADALError errorCode) {
                 for (String msg : msgs) {
                     if (message.contains(msg) || additionalMessage.contains(msg)) {
                         response.mTag = tag;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -46,7 +46,8 @@ final class Util {
     /**
      * Private constructor to prevent the class from being initiated.
      */
-    private Util() { }
+    private Util() {
+    }
 
     public static final int TEST_PASSWORD_EXPIRATION = 1387227772;
     static final String TEST_IDTOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiJlNzBiMTE1ZS1hYzBhLTQ4MjMtODVkYS04ZjRiN2I0ZjAwZTYiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwibmJmIjoxMzc2NDI4MzEwLCJleHAiOjEzNzY0NTcxMTAsInZlciI6IjEuMCIsInRpZCI6IjMwYmFhNjY2LThkZjgtNDhlNy05N2U2LTc3Y2ZkMDk5NTk2MyIsIm9pZCI6IjRmODU5OTg5LWEyZmYtNDExZS05MDQ4LWMzMjIyNDdhYzYyYyIsInVwbiI6ImFkbWluQGFhbHRlc3RzLm9ubWljcm9zb2Z0LmNvbSIsInVuaXF1ZV9uYW1lIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwic3ViIjoiVDU0V2hGR1RnbEJMN1VWYWtlODc5UkdhZEVOaUh5LXNjenNYTmFxRF9jNCIsImZhbWlseV9uYW1lIjoiU2VwZWhyaSIsImdpdmVuX25hbWUiOiJBZnNoaW4ifQ.";
@@ -70,15 +71,15 @@ final class Util {
         final String email = "emailField";
         final String claims = String.format(sIdTokenClaims, tid, oid, upn, uniqueName, sub, familyName,
                 givenName, altsecid, idp, email);
-        return String.format("%s.%s.", 
-                new String(Base64.encode(sIdTokenHeader.getBytes(AuthenticationConstants.ENCODING_UTF8), 
-                        Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE), 
-                        AuthenticationConstants.ENCODING_UTF8), 
-                new String(Base64.encode(claims.getBytes(AuthenticationConstants.ENCODING_UTF8), 
+        return String.format("%s.%s.",
+                new String(Base64.encode(sIdTokenHeader.getBytes(AuthenticationConstants.ENCODING_UTF8),
+                        Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE),
+                        AuthenticationConstants.ENCODING_UTF8),
+                new String(Base64.encode(claims.getBytes(AuthenticationConstants.ENCODING_UTF8),
                         Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE),
                         AuthenticationConstants.ENCODING_UTF8));
-        }
-    
+    }
+
     static TokenCacheItem getTokenCacheItem(final String authority, final String resource,
                                             final String clientId, final String userId,
                                             final String displayableId) {
@@ -93,8 +94,8 @@ final class Util {
         tokenCacheItem.setRefreshToken("refreshToken=");
         tokenCacheItem.setExpiresOn(expiredTime.getTime());
         tokenCacheItem.setUserInfo(new UserInfo(userId, "givenName", "familyName",
-            "identityProvider", displayableId));
-        
+                "identityProvider", displayableId));
+
         return tokenCacheItem;
     }
 
@@ -121,7 +122,7 @@ final class Util {
 
         return responseJsonObject.toString();
     }
-    
+
     static String getSuccessResponseWithoutRefreshToken() throws JSONException {
         return getCommonSuccessResponseData().toString();
     }
@@ -137,7 +138,7 @@ final class Util {
 
         return responseJsonObject;
     }
-    
+
     static String getErrorResponseBody(final String errorCode) throws JSONException {
         final JSONObject jsonObject = new JSONObject();
         jsonObject.put(AuthenticationConstants.OAuth2.ERROR, errorCode);
@@ -154,41 +155,41 @@ final class Util {
         jsonObject.put(AuthenticationConstants.AAD.CORRELATION_ID, "b73106d5-419b-4163-8bc6-d2c18f1b1a13");
         return jsonObject.toString();
     }
-    
-    static byte[] getPoseMessage(final String refreshToken, final String clientId, final String resource) 
+
+    static byte[] getPoseMessage(final String refreshToken, final String clientId, final String resource)
             throws UnsupportedEncodingException {
         return String.format("%s=%s&%s=%s&%s=%s&%s=%s",
                 AuthenticationConstants.OAuth2.GRANT_TYPE, urlFormEncode(AuthenticationConstants.OAuth2.REFRESH_TOKEN),
                 AuthenticationConstants.OAuth2.REFRESH_TOKEN, urlFormEncode(refreshToken),
-                AuthenticationConstants.OAuth2.CLIENT_ID, urlFormEncode(clientId), 
+                AuthenticationConstants.OAuth2.CLIENT_ID, urlFormEncode(clientId),
                 AuthenticationConstants.AAD.RESOURCE, urlFormEncode(resource)).getBytes();
     }
-    
+
     static String urlFormEncode(String source) throws UnsupportedEncodingException {
         return URLEncoder.encode(source, AuthenticationConstants.ENCODING_UTF8);
     }
-    
-    static AuthenticationResult getAuthenticationResult(final boolean isMRRT, final String displayableId, 
-            final String userId, final String familyClientId) {
+
+    static AuthenticationResult getAuthenticationResult(final boolean isMRRT, final String displayableId,
+                                                        final String userId, final String familyClientId) {
         Calendar expiredTime = new GregorianCalendar();
         Logger.d("Test", "Time now:" + expiredTime.toString());
         expiredTime.add(Calendar.MINUTE, -TOKENS_EXPIRES_MINUTE);
         final UserInfo userInfo = new UserInfo(userId, "GivenName", "FamilyName", "idp", displayableId);
-        final AuthenticationResult authResult = new AuthenticationResult("accessToken", "refresh_token", expiredTime.getTime(), 
+        final AuthenticationResult authResult = new AuthenticationResult("accessToken", "refresh_token", expiredTime.getTime(),
                 isMRRT, userInfo, "TenantId", "IdToken", null);
-        
+
         if (StringExtensions.isNullOrBlank(familyClientId)) {
             return authResult;
         }
-        
+
         authResult.setFamilyClientId(familyClientId);
         return authResult;
     }
-    
+
     static InputStream createInputStream(final String input) {
-        return  new ByteArrayInputStream(input.getBytes());
+        return new ByteArrayInputStream(input.getBytes());
     }
-    
+
     static void prepareMockedUrlConnection(final HttpURLConnection mockedConnection) throws IOException {
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Mockito.doNothing().when(mockedConnection).setConnectTimeout(Mockito.anyInt());

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -86,7 +86,7 @@ class AcquireTokenRequest {
         mDiscovery = new Discovery(mContext);
 
         if (authContext.getCache() != null && apiEvent != null) {
-            mTokenCacheAccessor = new TokenCacheAccessor(authContext.getCache(),
+            mTokenCacheAccessor = new TokenCacheAccessor(appContext.getApplicationContext(), authContext.getCache(),
                     authContext.getAuthority(), apiEvent.getTelemetryRequestId());
         }
         mBrokerProxy = new BrokerProxy(appContext);

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -88,6 +88,7 @@ class AcquireTokenRequest {
         if (authContext.getCache() != null && apiEvent != null) {
             mTokenCacheAccessor = new TokenCacheAccessor(appContext.getApplicationContext(), authContext.getCache(),
                     authContext.getAuthority(), apiEvent.getTelemetryRequestId());
+            mTokenCacheAccessor.setValidateAuthorityHost(mAuthContext.getValidateAuthority());
         }
         mBrokerProxy = new BrokerProxy(appContext);
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1226,7 +1226,7 @@ public class AuthenticationContext {
          * apps. So the client ID for the FoCI token cache item is hard coded
          * below.
          */
-        final TokenCacheAccessor tokenCacheAccessor = new TokenCacheAccessor(mTokenCacheStore, this.getAuthority(),
+        final TokenCacheAccessor tokenCacheAccessor = new TokenCacheAccessor(this.mContext.getApplicationContext(), mTokenCacheStore, this.getAuthority(),
                 Telemetry.registerNewRequest());
         final TokenCacheItem tokenItem;
         try {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -69,6 +69,12 @@ public class AuthenticationResult implements Serializable {
 
     private Date mExpiresOn;
 
+    //Number of seconds the token is valid
+    private Long mExpiresIn;
+
+    //Number of milliseconds since the unix epoch
+    private Long mResponseReceived;
+
     private String mErrorCode;
 
     private String mErrorDescription;
@@ -216,6 +222,14 @@ public class AuthenticationResult implements Serializable {
     public Date getExpiresOn() {
         return DateExtensions.createCopy(mExpiresOn);
     }
+
+    public Long getExpiresIn() { return mExpiresIn;}
+
+    public void setExpiresIn(final Long expiresIn) { mExpiresIn = expiresIn; }
+
+    public Long getResponseReceived() {return mResponseReceived;}
+
+    public void setResponseReceived(final Long responseReceived) { mResponseReceived = responseReceived;}
 
     /**
      * Multi-resource refresh tokens can be used to request token for another

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -62,6 +62,7 @@ final class CoreAdapter {
         adTokenResponse.setIdToken(result.getIdToken());
         adTokenResponse.setExpiresIn(result.getExpiresIn());
         adTokenResponse.setResponseReceivedTime(result.getResponseReceived());
+        adTokenResponse.setFamilyId(result.getFamilyClientId());
         // TODO populate other missing fields...
         return adTokenResponse;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -2,6 +2,7 @@ package com.microsoft.aad.adal;
 
 import com.microsoft.identity.common.Account;
 import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryAccount;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryTokenResponse;
 
 /**
@@ -59,8 +60,16 @@ final class CoreAdapter {
         adTokenResponse.setExpiresOn(result.getExpiresOn());
         adTokenResponse.setExtExpiresOn(result.getExtendedExpiresOn());
         adTokenResponse.setIdToken(result.getIdToken());
+        adTokenResponse.setExpiresIn(result.getExpiresIn());
+        adTokenResponse.setResponseReceivedTime(result.getResponseReceived());
         // TODO populate other missing fields...
         return adTokenResponse;
+
+    }
+
+    public static AzureActiveDirectoryCloud asAadCloud(final InstanceDiscoveryMetadata cloud){
+        final AzureActiveDirectoryCloud adCloud = new AzureActiveDirectoryCloud(cloud.getPreferredNetwork(), cloud.getPreferredCache(), cloud.getAliases());
+        return adCloud;
     }
 
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -61,6 +61,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
     private static final String TAG = "DefaultTokenCacheStore";
 
     private SharedPreferencesFileManager mPrefs;
+
     private Context mContext;
 
     private Gson mGson = new GsonBuilder()
@@ -107,6 +108,11 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
         // notify developers. 
         validateSecretKeySetting();
     }
+
+    Context getContext() {
+        return mContext.getApplicationContext();
+    }
+
 
     /**
      * Method that allows to mock StorageHelper class and use custom encryption in UTs.

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -264,7 +264,10 @@ class Oauth2 {
             // Token response
             boolean isMultiResourceToken = false;
             String expiresIn = response.get(AuthenticationConstants.OAuth2.EXPIRES_IN);
+            Long expiresInLong;
             Calendar expires = new GregorianCalendar();
+
+            expiresInLong = (expiresIn == null || expiresIn.isEmpty() ? ((long) AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC) : Long.parseLong(expiresIn));
 
             // Compute token expiration
             expires.add(
@@ -303,6 +306,9 @@ class Oauth2 {
             result = new AuthenticationResult(
                     response.get(AuthenticationConstants.OAuth2.ACCESS_TOKEN), refreshToken, expires.getTime(),
                     isMultiResourceToken, userinfo, tenantId, rawIdToken, null);
+
+            result.setExpiresIn(expiresInLong);
+            result.setResponseReceived(System.currentTimeMillis());
 
             if (response.containsKey(AuthenticationConstants.OAuth2.EXT_EXPIRES_IN)) {
                 final String extendedExpiresIn = response.get(AuthenticationConstants.OAuth2.EXT_EXPIRES_IN);


### PR DESCRIPTION
Update ADAL to leverage common core for caching.  Changes include:

- TokenCacheAccessor - Update to use common cache when saving tokens (based on whether DefaultTokenCache was in use)
- Updates to tests to fix issues related to when Authority Host / Cloud Metadata data was loaded
- Updates to tests to include raw id_tokens to ensure proper behavior in common (TODO: Add support for ADFS.... we may only want to support common cache in the case of AAD)
