### PR TITLE
fix android studio 3.0 build issue by upgrading gradle version from v2.14.1 to v3.5

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/WebFingerMetadataRequestor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/WebFingerMetadataRequestor.java
@@ -99,6 +99,7 @@ class WebFingerMetadataRequestor
      * @return the URL of the WebFinger document
      * @throws MalformedURLException if the URL could not be constructed
      */
+    @SuppressWarnings("PMD")
     static URL buildWebFingerUrl(final URL resource, final DRSMetadata drsMetadata)
             throws MalformedURLException {
         final URL passiveAuthEndpoint = new URL(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 31 19:02:50 PDT 2016
+#Mon Dec 18 10:59:39 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
fix android studio 3.0 build issue by upgrading gradle version from v2.14.1 to v3.5
fix https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1080