### PR TITLE
URL Query Parameter Parsing | Fix for #1078

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
@@ -308,14 +308,6 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
 
         try {
             m.invoke(handler, CERT_REDIRECT
-                    + "?Nonce=2&CertAuthoritiesMissing=ABC&Version=1.0&SubmitUrl=1&Context=1");
-            Assert.fail("No exception");
-        } catch (Exception ex) {
-            assertTrue("Argument exception", ex.getCause().getMessage().contains("CertAuthorities"));
-        }
-
-        try {
-            m.invoke(handler, CERT_REDIRECT
                     + "?Nonce=2&CertAuthorities=ABC&Version=1.0&SubmitUrlMissing=1&Context=1");
             Assert.fail("No exception");
         } catch (Exception ex) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
@@ -308,6 +308,13 @@ public class ChallengeResponseBuilderTests extends AndroidTestHelper {
 
         try {
             m.invoke(handler, CERT_REDIRECT
+                    + "?Nonce=2&CertAuthorities=&Version=1.0&SubmitUrl=1&Context=1");
+        } catch (Exception ex) {
+            Assert.fail("No exception");
+        }
+
+        try {
+            m.invoke(handler, CERT_REDIRECT
                     + "?Nonce=2&CertAuthorities=ABC&Version=1.0&SubmitUrlMissing=1&Context=1");
             Assert.fail("No exception");
         } catch (Exception ex) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HashMapExtensionTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HashMapExtensionTests.java
@@ -118,5 +118,12 @@ public class HashMapExtensionTests extends AndroidTestHelper {
         assertTrue(result.containsKey("d"));
         assertTrue(result.containsValue("f"));
         assertTrue(result.size() == 1);
+
+        result = (HashMap<String, String>) m.invoke(object, "=b&c=");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertTrue(result.containsKey("c"));
+        assertFalse(result.containsValue("b"));
+        assertTrue(result.size() == 1);
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HashMapExtensionTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HashMapExtensionTests.java
@@ -59,7 +59,7 @@ public class HashMapExtensionTests extends AndroidTestHelper {
         final String methodName = "urlFormDecode";
         Object object = ReflectionUtils.getNonPublicInstance("com.microsoft.aad.adal.HashMapExtensions");
         Method m = ReflectionUtils.getTestMethod(object, methodName, String.class);
-        HashMap<String, String> result = (HashMap<String, String>) m.invoke(object, "nokeyvalue");
+        HashMap<String, String> result = (HashMap<String, String>) m.invoke(object, "");
         assertNotNull(result);
         assertTrue(result.isEmpty());
 
@@ -76,10 +76,6 @@ public class HashMapExtensionTests extends AndroidTestHelper {
         assertTrue(result.isEmpty());
 
         result = (HashMap<String, String>) m.invoke(object, "&=");
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-
-        result = (HashMap<String, String>) m.invoke(object, "&a=");
         assertNotNull(result);
         assertTrue(result.isEmpty());
 

--- a/adal/src/main/java/com/microsoft/aad/adal/ChallengeResponseBuilder.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ChallengeResponseBuilder.java
@@ -76,6 +76,8 @@ class ChallengeResponseBuilder {
 
         /**
          * Authorization endpoint will return accepted authorities.
+         * The mCertAuthorities could be empty when either no certificate or no permission for ADFS
+         * service account for the Device container in AD.
          */
         private List<String> mCertAuthorities;
 
@@ -208,6 +210,10 @@ class ChallengeResponseBuilder {
                 key = key.trim();
                 value = StringExtensions.removeQuoteInHeaderValue(value.trim());
                 headerItems.put(key, value);
+            }  else if (pair.size() == 1 && !StringExtensions.isNullOrBlank(pair.get(0))) {
+                // The value list could be null when either no certificate or no permission
+                // for ADFS service account for the Device container in AD.
+                headerItems.put(StringExtensions.urlFormDecode(pair.get(0)).trim(), StringExtensions.urlFormDecode(""));
             } else {
                 // invalid format
                 throw new AuthenticationException(ADALError.DEVICE_CERTIFICATE_REQUEST_INVALID,

--- a/adal/src/main/java/com/microsoft/aad/adal/HashMapExtensions.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HashMapExtensions.java
@@ -71,21 +71,27 @@ final class HashMapExtensions {
             while (parameterTokenizer.hasMoreTokens()) {
                 String pair = parameterTokenizer.nextToken();
                 String[] elements = pair.split("=");
+                String value = null;
+                String key = null;
 
                 if (elements.length == 2) {
-                    String key = null;
-                    String value = null;
                     try {
                         key = StringExtensions.urlFormDecode(elements[0].trim());
                         value = StringExtensions.urlFormDecode(elements[1].trim());
                     } catch (UnsupportedEncodingException e) {
                         Logger.i(TAG, ADALError.ENCODING_IS_NOT_SUPPORTED.getDescription(), e.getMessage(), null);
                     }
-
-                    if (!StringExtensions.isNullOrBlank(key)
-                            && !StringExtensions.isNullOrBlank(value)) {
-                        result.put(key, value);
+                } else if (elements.length == 1) {
+                    try {
+                        key = StringExtensions.urlFormDecode(elements[0].trim());
+                        value = "";
+                    } catch (UnsupportedEncodingException e) {
+                        Logger.i(TAG, ADALError.ENCODING_IS_NOT_SUPPORTED.getDescription(), e.getMessage(), null);
                     }
+                }
+
+                if (!StringExtensions.isNullOrBlank(key)) {
+                    result.put(key, value);
                 }
             }
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/HashMapExtensions.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/HashMapExtensions.java
@@ -80,6 +80,7 @@ final class HashMapExtensions {
                         value = StringExtensions.urlFormDecode(elements[1].trim());
                     } catch (UnsupportedEncodingException e) {
                         Logger.i(TAG, ADALError.ENCODING_IS_NOT_SUPPORTED.getDescription(), e.getMessage(), null);
+                        continue;
                     }
                 } else if (elements.length == 1) {
                     try {
@@ -87,6 +88,7 @@ final class HashMapExtensions {
                         value = "";
                     } catch (UnsupportedEncodingException e) {
                         Logger.i(TAG, ADALError.ENCODING_IS_NOT_SUPPORTED.getDescription(), e.getMessage(), null);
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
RFC  #1078 

Update the URI parsing to handle the situation when parsing the key with empty value case.

This is because the certAuthorities list returned from server could be null when either no certificate or no permission for ADFS service account for the Device container in AD. We should return the NoDeviceCertResponse instead of throwing the DEVICE_CERTIFICATE_RESPONSE_FAILED AuthenticationException. In addition, we should not store the key value when parsing failed.

  