### PR TITLE
Parse any/all challenges served in WWW-Authenticate headers

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
@@ -182,6 +182,17 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
         Logger.getInstance().setExternalLogger(null);
     }
 
+    @Test
+    public void testSuccessfullyParsesWhenBearerNotFirstClaim()
+            throws ClassNotFoundException, InvocationTargetException, IllegalAccessException {
+        Method m = getParseResponseMethod();
+
+        verifyAuthenticationParam(
+                m,
+                "Basic realm=\"https://login.microsoftonline.com/tenant\", Bearer scope=\"blah=scope, scope=blah\" , authorization_uri=\"https://login.windows.net/tenant\"",
+                "https://login.windows.net/tenant", null);
+    }
+
     private void verifyAuthenticationParam(Method m, String headerValue, String authorizationUri,
                                            String resource) throws IllegalAccessException, InvocationTargetException {
         AuthenticationParameters param = (AuthenticationParameters) m.invoke(null,

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
@@ -25,6 +25,7 @@ package com.microsoft.aad.adal;
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
 
 import com.microsoft.aad.adal.AuthenticationParameters.AuthenticationParamCallback;
 import com.microsoft.aad.adal.Logger.ILogger;
@@ -109,7 +110,7 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
 
         // empty value inside the authorization_uri will throw exception
         assertThrowsException(ResourceAuthenticationChallengeException.class,
-                AuthenticationParameters.AUTH_HEADER_INVALID_FORMAT.toLowerCase(), new ThrowableRunnable() {
+                AuthenticationParameters.AUTH_HEADER_MISSING_AUTHORITY.toLowerCase(), new ThrowableRunnable() {
 
                     @Override
                     public void run() throws ResourceAuthenticationChallengeException {
@@ -251,7 +252,7 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
         callParseResponseForException(
                 new HttpWebResponse(HttpURLConnection.HTTP_UNAUTHORIZED, null, getHeader("WWW-Authenticate",
                         "Bearer authorization_uri= ")),
-                AuthenticationParameters.AUTH_HEADER_INVALID_FORMAT);
+                AuthenticationParameters.AUTH_HEADER_MISSING_AUTHORITY);
 
         callParseResponseForException(
                 new HttpWebResponse(HttpURLConnection.HTTP_UNAUTHORIZED, null, getHeader("WWW-Authenticate",
@@ -266,7 +267,7 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
         callParseResponseForException(
                 new HttpWebResponse(HttpURLConnection.HTTP_UNAUTHORIZED, null, getHeader("WWW-Authenticate",
                         "Bearer    \t authorization_uri=,something=a ")),
-                AuthenticationParameters.AUTH_HEADER_INVALID_FORMAT);
+                AuthenticationParameters.AUTH_HEADER_MISSING_AUTHORITY);
     }
 
     class LogCallback implements ILogger {
@@ -313,9 +314,10 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
             param = (AuthenticationParameters) m.invoke(null, response);
             assertTrue("expected to fail", false);
         } catch (Exception exception) {
+            Log.e("TestParser", "msg: " + exception.getCause().getMessage());
             assertNotNull("Exception is not null", exception);
             assertNull("Param is expected to be null", param);
-            assertTrue("Check header exception", exception.getCause().getMessage() == message);
+            assertTrue("Check header exception", exception.getCause().getMessage().equals(message));
         }
     }
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationParamsTests.java
@@ -25,7 +25,6 @@ package com.microsoft.aad.adal;
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
-import android.util.Log;
 
 import com.microsoft.aad.adal.AuthenticationParameters.AuthenticationParamCallback;
 import com.microsoft.aad.adal.Logger.ILogger;
@@ -325,7 +324,6 @@ public class AuthenticationParamsTests extends AndroidTestHelper {
             param = (AuthenticationParameters) m.invoke(null, response);
             assertTrue("expected to fail", false);
         } catch (Exception exception) {
-            Log.e("TestParser", "msg: " + exception.getCause().getMessage());
             assertNotNull("Exception is not null", exception);
             assertNull("Param is expected to be null", param);
             assertTrue("Check header exception", exception.getCause().getMessage().equals(message));

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -384,12 +384,10 @@ public class AuthenticationParameters {
 
                 // We should now have a left-side and right-side
                 if (splitOnUnquotedEquals.length != 2) {
-                    // Is this really what you want?
                     throw new ResourceAuthenticationChallengeException(AUTH_HEADER_INVALID_FORMAT);
-                    //continue; // If there's no key/value pair, skip this token
                 }
 
-                // Create the keys/values, trimming off any bogus whitespace
+                // Create the keys/values, trimming off any excess whitespace
                 final String key = splitOnUnquotedEquals[0].trim();
                 final String value = splitOnUnquotedEquals[1].trim();
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationParameters.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationParameters.java
@@ -203,7 +203,6 @@ public class AuthenticationParameters {
             throw new ResourceAuthenticationChallengeException(AUTH_HEADER_MISSING);
         }
 
-        //testing...
         final List<Challenge> challenges = Challenge.parseChallenges(authenticateHeader);
 
         // Grab the Bearer challenge


### PR DESCRIPTION
This closes #992 

These changes add support for parsing any/all challenge schemes served by `WWW-Authenticate` headers. It also changes the `Exception` message to be more accurate, in instances where parsing fails due to absent or malformed `authorization_uri` parameters.

New tests have been added to satisfy the problem description in #992 