### PR TITLE
Return AuthenticationCallback results on the UI thread (if the AT/ATS call was invoked there)

### DIFF
--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -197,13 +197,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     private void showMessage(final String msg) {
         Log.v(TAG, msg);
-        getHandler().post(new Runnable() {
-
-            @Override
-            public void run() {
-                Toast.makeText(MainActivity.this, msg, Toast.LENGTH_LONG).show();
-            }
-        });
+        Toast.makeText(MainActivity.this, msg, Toast.LENGTH_LONG).show();
     }
 
     /**

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -29,6 +29,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -262,6 +263,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         Telemetry.getInstance().registerDispatcher(telemetryDispatcher, true);
     }
 
+    private void verifyThread() {
+        final boolean onUiThread = Looper.getMainLooper().getThread() == Thread.currentThread();
+        Log.d(TAG, "AuthenticationCallback returned on UI thread? [" + onUiThread + "]");
+    }
+
     private void callAcquireTokenWithResource(final String resource, PromptBehavior prompt, final String loginHint,
                                               final String clientId, final String redirectUri, final String extraQp) {
         mAuthContext.acquireToken(MainActivity.this, resource, clientId, redirectUri, loginHint,
@@ -269,6 +275,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
                     @Override
                     public void onSuccess(AuthenticationResult authenticationResult) {
+                        verifyThread();
                         mAuthResult = authenticationResult;
                         showMessage("Response from broker: " + authenticationResult.getAccessToken());
 
@@ -280,6 +287,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
                     @Override
                     public void onError(Exception exc) {
+                        verifyThread();
                         showMessage("MainActivity userapp:" + exc.getMessage());
                     }
                 });
@@ -320,12 +328,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
             @Override
             public void onSuccess(AuthenticationResult authenticationResult) {
+                verifyThread();
                 mAuthResult = authenticationResult;
                 showMessage("Response from broker: " + authenticationResult.getAccessToken());
             }
 
             @Override
             public void onError(Exception exc) {
+                verifyThread();
                 showMessage("Error occurred when acquiring token silently: " + exc.getMessage());
             }
         });


### PR DESCRIPTION
See issue raised by #1076 

~This PR does *not* fix the issue, but adds logging to accompany newly created test cases for this problem.~

Edit - PR has been updated to resolve #1076 (see commit ae859af88b4571ef6ecfb881547ddf7ba00e2122)

```
Interactive Auth w/o Broker | AuthenticationCallback returns on UI Thread - Test Case 345978
Interactive Auth w/  Broker | AuthenticationCallback returns on UI Thread - Test Case 345980
Silent Auth w/o Broker      | AuthenticationCallback returns on UI Thread - Test Case 345991
Silent Auth w/  Broker      | AuthenticationCallback returns on UI Thread - Test Case 346012
```