### PR TITLE
Closes #950 (Updates x-client-sku)

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -308,7 +308,7 @@ public class OauthTests {
         final Oauth2 oauth2 = createOAuthInstance(request);
 
         final String actualCodeRequestUrl = oauth2.getCodeRequestUrl();
-        assertTrue("Matching message", actualCodeRequestUrl.contains(AAD.ADAL_ID_PLATFORM + "=Android"));
+        assertTrue("Matching message", actualCodeRequestUrl.contains(AAD.ADAL_ID_PLATFORM + "=ADAL.Android"));
         assertTrue("Matching message",
                 actualCodeRequestUrl.contains(AAD.ADAL_ID_VERSION + "=" + AuthenticationContext.getVersionName()));
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -290,7 +290,7 @@ public final class AuthenticationConstants {
         public static final String ADAL_ID_DM = "x-client-DM";
 
         /** String of platform value for the sdk. */
-        public static final String ADAL_ID_PLATFORM_VALUE = "Android";
+        public static final String ADAL_ID_PLATFORM_VALUE = "ADAL.Android";
 
         /** String for request id returned from Evo. **/
         public static final String REQUEST_ID_HEADER = "x-ms-request-id";

--- a/adal/src/main/java/com/microsoft/aad/adal/WebRequestHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/WebRequestHandler.java
@@ -82,7 +82,7 @@ public class WebRequestHandler implements IWebRequestHandler {
             headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, mRequestCorrelationId.toString());
         }
 
-        headers.put(AuthenticationConstants.AAD.ADAL_ID_PLATFORM, "Android");
+        headers.put(AuthenticationConstants.AAD.ADAL_ID_PLATFORM, AuthenticationConstants.AAD.ADAL_ID_PLATFORM_VALUE);
         headers.put(AuthenticationConstants.AAD.ADAL_ID_VERSION, AuthenticationContext.getVersionName());
         headers.put(AuthenticationConstants.AAD.ADAL_ID_OS_VER, "" + Build.VERSION.SDK_INT);
         headers.put(AuthenticationConstants.AAD.ADAL_ID_DM, android.os.Build.MODEL);


### PR DESCRIPTION
Updates the value of `x-client-sku` from `Android` -> `ADAL.Android`

Per [this comment](https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/950#issuecomment-338765840) from @nazukj, telemetry dashboards should be updated to account for this change.