### PR TITLE
Update the sample app to support the silent auth of sov cloud account

### DIFF
--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -48,6 +48,7 @@ import com.microsoft.aad.adal.AuthenticationContext;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.IDispatcher;
+import com.microsoft.aad.adal.Logger;
 import com.microsoft.aad.adal.PromptBehavior;
 import com.microsoft.aad.adal.Telemetry;
 
@@ -301,10 +302,24 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             if (null != authResult.getAuthority()) {
                 //Save the preferred authority into the shared preference
                 prefEditor.putString((authResult.getUserInfo().getDisplayableId().trim() + ":" + authority.trim() +  ":authority").toLowerCase(), authResult.getAuthority().trim().toLowerCase());
+            } else {
+                Logger.w(TAG, "The authority of " +
+                        "authentication result should not be null.");
+                final Toast toast = Toast.makeText(mApplicationContext,
+                        "Warning: the result authority is null," +
+                                "Silent auth for Sovereign account will fail. ", Toast.LENGTH_SHORT);
+                toast.show();
             }
 
             if (null != authResult.getUserInfo() && null != authResult.getUserInfo().getUserId()) {
                 prefEditor.putString((authResult.getUserInfo().getDisplayableId().trim() + ":" + authority.trim() + ":userId").toLowerCase(), authResult.getUserInfo().getUserId().trim().toLowerCase());
+            } else {
+                Logger.w(TAG, "The userInfo of " +
+                        "authentication result should not be null.");
+                final Toast toast = Toast.makeText(mApplicationContext,
+                        "Warning: the result userInfo is null. " +
+                                "Silent auth without userID will fail. ", Toast.LENGTH_SHORT);
+                toast.show();
             }
 
             prefEditor.apply();


### PR DESCRIPTION
RFC #1101 
For the client app, to support the sov cloud accounts, it should maintain the authority returned from AuthenticationResult and use it for the future silent auth purpose.

In the sample app, it demonstrate an example where we use the shared preference to keep the cloud authorities.
