### PR TITLE
Adds Broker Connection Error Stack Traces to Telemetry

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -153,6 +153,9 @@ final class BrokerAccountServiceHandler {
         final Throwable throwable = exception.getAndSet(null);
         //AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING will be thrown if there is any exception thrown during binding the service.
         if (throwable != null) {
+            // Record this throwable to the BrokerEvent for reporting via telemetry
+            brokerEvent.setBrokerAccountServiceConnectionErrorInfo(throwable);
+
             if (throwable instanceof RemoteException) {
                 Logger.e(TAG + methodName, "Get error when trying to get token from broker. ", throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
@@ -207,6 +210,9 @@ final class BrokerAccountServiceHandler {
         final Throwable throwable = exception.getAndSet(null);
         //AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING will be thrown if there is any exception thrown during binding the service.
         if (throwable != null) {
+            // Record this throwable to the BrokerEvent for reporting via telemetry
+            brokerEvent.setBrokerAccountServiceConnectionErrorInfo(throwable);
+
             if (throwable instanceof RemoteException) {
                 Logger.e(TAG, "Get error when trying to get token from broker. ",
                         throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -670,6 +670,9 @@ class BrokerProxy implements IBrokerProxy {
             //
             // TODO add retry logic since authenticator is not responding to
             // the request
+            // TODO (2/13/2018) -- This is kind of strange. Rather than throw an AuthenticationException here this code just returns null and lets
+            // the result-check inside of AcquireTokenWithBrokerRequest#acquireTokenWithBrokerInteractively(IWindowComponent) throw it with a
+            // different error: ADALError.DEVELOPER_ACTIVITY_IS_NOT_RESOLVED --  is this preferable? Why not just throw this Exception here?
             Logger.e(TAG + methodName, AUTHENTICATOR_CANCELS_REQUEST, "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, e);
         } catch (IOException e) {
             // Authenticator gets problem from webrequest or file read/write

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -620,7 +620,9 @@ class BrokerProxy implements IBrokerProxy {
             intent = BrokerAccountServiceHandler.getInstance().getIntentForInteractiveRequest(mContext, brokerEvent);
             if (intent == null) {
                 Logger.e(TAG, "Received null intent from broker interactive request.", null, ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
-                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Received null intent from broker interactive request.");
+                final AuthenticationException authenticationException = new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Received null intent from broker interactive request.");
+                brokerEvent.setBrokerAccountServiceConnectionErrorInfo(authenticationException);
+                throw authenticationException;
             } else {
                 intent.putExtras(requestBundle);
             }

--- a/adal/src/main/java/com/microsoft/aad/adal/ExceptionExtensions.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ExceptionExtensions.java
@@ -34,7 +34,7 @@ final class ExceptionExtensions {
     private ExceptionExtensions() {
         // Intentionally left blank
     }
-    static String getExceptionMessage(Exception ex) {
+    static String getExceptionMessage(Throwable ex) {
         String message = null;
 
         if (ex != null) {

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
@@ -57,6 +57,14 @@ final class BrokerEvent extends DefaultEvent {
         setProperty(EventStrings.BROKER_ACCOUNT_SERVICE_CONNECTED, Boolean.toString(true));
     }
 
+    void setBrokerAccountServiceConnectionErrorInfo(final String errorInfo) {
+        setProperty(EventStrings.BROKER_ACCOUNT_SERVICE_CONNECTION_ERROR_INFO, errorInfo);
+    }
+
+    void setBrokerAccountServiceConnectionErrorInfo(final Throwable throwable) {
+        setProperty(EventStrings.BROKER_ACCOUNT_SERVICE_CONNECTION_ERROR_INFO, ExceptionExtensions.getExceptionMessage(throwable));
+    }
+
     void setServerErrorCode(final String errorCode) {
         if (!StringExtensions.isNullOrBlank(errorCode) && !errorCode.equals("0")) {
             setProperty(EventStrings.SERVER_ERROR_CODE, errorCode.trim());

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -165,6 +165,8 @@ final class EventStrings {
 
     static final String BROKER_ACCOUNT_SERVICE_CONNECTED = EVENT_PREFIX + "broker_account_service_connected";
 
+    static final String BROKER_ACCOUNT_SERVICE_CONNECTION_ERROR_INFO = "broker_account_service_connection_error_info";
+
     // API ID
     static final String API_ID = EVENT_PREFIX + "api_id";
 


### PR DESCRIPTION
Closes #1118 

This change adds 2 new methods to `BrokerEvent` to record `Exceptions` thrown while trying to connect to the `BrokerAccountService`.

A new string has been added for telemetry: `BROKER_ACCOUNT_SERVICE_CONNECTION_ERROR_INFO `