### PR TITLE
[1.13.3] Adds Broker Connection Error Stack Traces to Telemetry

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -152,14 +152,23 @@ final class BrokerAccountServiceHandler {
         final Throwable throwable = exception.getAndSet(null);
         //AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING will be thrown if there is any exception thrown during binding the service.
         if (throwable != null) {
+            // Record this throwable to the BrokerEvent for reporting via telemetry
+            brokerEvent.setBrokerAccountServiceConnectionErrorInfo(throwable);
+
             if (throwable instanceof RemoteException) {
                 Logger.e(TAG, "Get error when trying to get token from broker: " + throwable.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_REMOTE_ERROR);
+                Telemetry.getInstance().stopEvent(brokerEvent.getTelemetryRequestId(), brokerEvent, EventStrings.BROKER_REQUEST_SILENT);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
             } else if (throwable instanceof InterruptedException) {
                 Logger.e(TAG, "The broker account service binding call is interrupted. "  + throwable.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_EXCEPTION, throwable);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_INTERRUPTED_ERROR);
+                Telemetry.getInstance().stopEvent(brokerEvent.getTelemetryRequestId(), brokerEvent, EventStrings.BROKER_REQUEST_SILENT);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
             } else {
                 Logger.e(TAG, "Get error when trying to bind the broker account service." + throwable.getMessage(), "", ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_BIND_ERROR);
+                Telemetry.getInstance().stopEvent(brokerEvent.getTelemetryRequestId(), brokerEvent, EventStrings.BROKER_REQUEST_SILENT);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable.getMessage(), throwable);
             }
         }
@@ -206,21 +215,30 @@ final class BrokerAccountServiceHandler {
         final Throwable throwable = exception.getAndSet(null);
         //AuthenticationException with error code BROKER_AUTHENTICATOR_NOT_RESPONDING will be thrown if there is any exception thrown during binding the service.
         if (throwable != null) {
+            // Record this throwable to the BrokerEvent for reporting via telemetry
+            brokerEvent.setBrokerAccountServiceConnectionErrorInfo(throwable);
+
             if (throwable instanceof RemoteException) {
                 Logger.e(TAG, "Get error when trying to get token from broker. ",
                         throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_REMOTE_ERROR);
+                Telemetry.getInstance().stopEvent(brokerEvent.getTelemetryRequestId(), brokerEvent, EventStrings.BROKER_REQUEST_INTERACTIVE);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING,
                         throwable.getMessage(),
                         throwable);
             } else if (throwable instanceof InterruptedException) {
                 Logger.e(TAG, "The broker account service binding call is interrupted. ",
                         throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_EXCEPTION, throwable);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_INTERRUPTED_ERROR);
+                Telemetry.getInstance().stopEvent(brokerEvent.getTelemetryRequestId(), brokerEvent, EventStrings.BROKER_REQUEST_INTERACTIVE);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING,
                         throwable.getMessage(),
                         throwable);
             } else {
                 Logger.e(TAG, "Didn't receive the activity to launch from broker. ",
                         throwable.getMessage(), ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, throwable);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_ACTIVITY_RESOLUTION_ERROR);
+                Telemetry.getInstance().stopEvent(brokerEvent.getTelemetryRequestId(), brokerEvent, EventStrings.BROKER_REQUEST_INTERACTIVE);
                 throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING,
                         "Didn't receive the activity to launch from broker: " + throwable.getMessage(),
                         throwable);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -596,7 +596,10 @@ class BrokerProxy implements IBrokerProxy {
             intent = BrokerAccountServiceHandler.getInstance().getIntentForInteractiveRequest(mContext, brokerEvent);
             if (intent == null) {
                 Logger.e(TAG, "Received null intent from broker interactive request.", null, ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING);
-                throw new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Received null intent from broker interactive request.");
+                final AuthenticationException authenticationException = new AuthenticationException(ADALError.BROKER_AUTHENTICATOR_NOT_RESPONDING, "Received null intent from broker interactive request.");
+                brokerEvent.setBrokerAccountServiceConnectionErrorInfo(authenticationException);
+                brokerEvent.setBrokerError(BrokerEvent.BrokerError.BROKER_INTENT_MALFORMED_OR_NULL);
+                throw authenticationException;
             } else {
                 intent.putExtras(requestBundle);
             }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -315,6 +315,9 @@ class BrokerProxy implements IBrokerProxy {
 
         verifyNotOnMainThread();
 
+        // populate BrokerEvent info re installed Brokers
+        setAndLogBrokerInstallationStatuses(brokerEvent);
+
         final Bundle requestBundle = getBrokerOptions(request);
 
         // check if broker supports the new service, if it does not we need to switch back to the old way
@@ -331,6 +334,16 @@ class BrokerProxy implements IBrokerProxy {
         }
 
         return getResultFromBrokerResponse(bundleResult, request);
+    }
+
+    private void setAndLogBrokerInstallationStatuses(final BrokerEvent brokerEvent) {
+        final boolean isCompanyPortalInstalled = PackageHelper.isCompanyPortalInstalled(mContext.getPackageManager());
+        brokerEvent.setCompanyPortalInstalled(isCompanyPortalInstalled);
+        Logger.d(TAG, "Is Company Portal installed? [" + isCompanyPortalInstalled + "]");
+
+        final boolean isMicrosoftAuthenticatorInstalled = PackageHelper.isMicrosoftAuthenticatorInstalled(mContext.getPackageManager());
+        brokerEvent.setMicrosoftAuthenticatorInstalled(isMicrosoftAuthenticatorInstalled);
+        Logger.d(TAG, "Is Microsoft Authenticator installed? [" +isCompanyPortalInstalled + "]");
     }
 
     private Bundle getAuthTokenFromAccountManager(final AuthenticationRequest request, final Bundle requestBundle) throws AuthenticationException {
@@ -590,6 +603,9 @@ class BrokerProxy implements IBrokerProxy {
     @Override
     public Intent getIntentForBrokerActivity(final AuthenticationRequest request, final BrokerEvent brokerEvent)
             throws AuthenticationException {
+        // populate BrokerEvent info re installed Brokers
+        setAndLogBrokerInstallationStatuses(brokerEvent);
+
         final Bundle requestBundle = getBrokerOptions(request);
         final Intent intent;
         if (isBrokerAccountServiceSupported()) {

--- a/adal/src/main/java/com/microsoft/aad/adal/ExceptionExtensions.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ExceptionExtensions.java
@@ -23,8 +23,7 @@
 
 package com.microsoft.aad.adal;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import android.util.Log;
 
 /**
  * A helper for getting logging info out of an Exception.
@@ -34,6 +33,7 @@ final class ExceptionExtensions {
     private ExceptionExtensions() {
         // Intentionally left blank
     }
+
     static String getExceptionMessage(Exception ex) {
         String message = null;
 
@@ -41,9 +41,7 @@ final class ExceptionExtensions {
             message = ex.getMessage();
 
             if (message == null) {
-                final StringWriter sw = new StringWriter();
-                ex.printStackTrace(new PrintWriter(sw));
-                message = sw.toString();
+                message = Log.getStackTraceString(ex);
             }
         }
         

--- a/adal/src/main/java/com/microsoft/aad/adal/PackageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/PackageHelper.java
@@ -59,6 +59,23 @@ class PackageHelper {
         mAcctManager = AccountManager.get(mContext);
     }
 
+    static boolean isCompanyPortalInstalled(final PackageManager pkgManager) {
+        return isPackageInstalled(pkgManager, "com.microsoft.windowsintune.companyportal");
+    }
+
+    static boolean isMicrosoftAuthenticatorInstalled(final PackageManager pkgManger) {
+        return isPackageInstalled(pkgManger, "com.azure.authenticator");
+    }
+
+    private static boolean isPackageInstalled(final PackageManager packageManager, final String packageName) {
+        try {
+            packageManager.getPackageInfo(packageName, 0);
+            return true;
+        } catch (NameNotFoundException e) {
+            return false;
+        }
+    }
+
     /**
      * Reads first signature in the list for given package name.
      * 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/BrokerEvent.java
@@ -101,6 +101,14 @@ final class BrokerEvent extends DefaultEvent {
         }
     }
 
+    void setCompanyPortalInstalled(final boolean isInstalled) {
+        setProperty(EventStrings.IS_COMPANY_PORTAL_INSTALLED, isInstalled ? "yes" : "no");
+    }
+
+    void setMicrosoftAuthenticatorInstalled(final boolean isInstalled) {
+        setProperty(EventStrings.IS_MICROSOFT_AUTHENTICATOR_INSTALLED, isInstalled ? "yes" : "no");
+    }
+
     @Override
     public void processEvent(final Map<String, String> dispatchMap) {
         final List<Pair<String, String>> eventList = getEventList();

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -165,6 +165,10 @@ final class EventStrings {
 
     static final String BROKER_ACCOUNT_SERVICE_CONNECTED = EVENT_PREFIX + "broker_account_service_connected";
 
+    static final String BROKER_ACCOUNT_SERVICE_CONNECTION_ERROR_INFO = EVENT_PREFIX + "broker_account_service_connection_error_info";
+
+    static final String BROKER_ACCOUNT_SERVICE_ERROR = EVENT_PREFIX + "broker_account_service_error";
+
     // API ID
     static final String API_ID = EVENT_PREFIX + "api_id";
 

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -169,6 +169,10 @@ final class EventStrings {
 
     static final String BROKER_ACCOUNT_SERVICE_ERROR = EVENT_PREFIX + "broker_account_service_error";
 
+    static final String IS_COMPANY_PORTAL_INSTALLED = EVENT_PREFIX  + "is_company_portal_installed";
+
+    static final String IS_MICROSOFT_AUTHENTICATOR_INSTALLED = EVENT_PREFIX + "is_microsoft_authenticator_installed";
+
     // API ID
     static final String API_ID = EVENT_PREFIX + "api_id";
 


### PR DESCRIPTION
Changes to ADAL `1.13.3` to include additional telemetry fields to aid in troubleshooting broker issues.

The following new pieces of information will be included:
-	`broker_account_service_error` (suberror code enum to distinguish which code path triggered BROKER_AUTHENTICATOR_NOT_RESPONDING)
-	`broker_account_service_connection_error_info` (stack trace information for why the exception was thrown, can be optionally disabled through new static flag on `BrokerEvent` object)
-	two new fields to track installation/non-installation of brokers:
o	`is_company_portal_installed` (`yes`/`no`)
o	`is_microsoft_authenticator_installed` (`yes`/`no`)
-	BUGFIX: previously, if `BROKER_AUTHENTICATOR_NOT_RESPONDING` was thrown, the `broker_app` field was not sent. This has been corrected in this build.
