### PR TITLE
Clean up the lint and check-style errors

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -83,6 +83,7 @@ android {
         disable 'GradleDependency'
         disable 'GradleOverrides'
         disable 'OldTargetApi'
+        disable 'PackageManagerGetSignatures'
     }
 
     libraryVariants.all { variant ->

--- a/adal/src/main/java/com/microsoft/aad/adal/Logger.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Logger.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 
 package com.microsoft.aad.adal;
-import com.microsoft.aad.adal.BuildConfig;
 
 import android.annotation.SuppressLint;
 import android.util.Log;


### PR DESCRIPTION
1. Fix the checkstyle error.
2. Suppress the PackageManagerGetSignatures warning which is already validated properly. [RFC](https://github.com/AzureAD/azure-activedirectory-library-for-android-unity-fork/pull/189)
