### PR TITLE
Run findbugs task after assembleDebug

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -292,6 +292,7 @@ task checkstyle(type: Checkstyle) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
-        task.dependsOn 'checkstyle', 'pmd', 'findbugs', 'lint'
+        task.dependsOn 'checkstyle', 'pmd', 'lint'
+        task.finalizedBy 'findbugs'
     }
 }


### PR DESCRIPTION
Ensures `classes` directory isn't empty when `findbugs` task is executed. Runs _after_ `assembleDebug` or `assembleRelease`