### PR TITLE
[PAUSED - DO NOT MERGE] Fix the cache key bug when deleting the cache item.

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -381,10 +381,10 @@ class TokenCacheAccessor {
      */
     private List<String> getKeyListToRemoveForRT(final TokenCacheItem cachedItem) {
         final List<String> keysToRemove = new ArrayList<>();
-        keysToRemove.add(CacheKey.createCacheKeyForRTEntry(mAuthority, cachedItem.getResource(), cachedItem.getClientId(), null));
+        keysToRemove.add(CacheKey.createCacheKeyForRTEntry(cachedItem.getAuthority(), cachedItem.getResource(), cachedItem.getClientId(), null));
         if (cachedItem.getUserInfo() != null) {
-            keysToRemove.add(CacheKey.createCacheKeyForRTEntry(mAuthority, cachedItem.getResource(), cachedItem.getClientId(), cachedItem.getUserInfo().getDisplayableId()));
-            keysToRemove.add(CacheKey.createCacheKeyForRTEntry(mAuthority, cachedItem.getResource(), cachedItem.getClientId(), cachedItem.getUserInfo().getUserId()));
+            keysToRemove.add(CacheKey.createCacheKeyForRTEntry(cachedItem.getAuthority(), cachedItem.getResource(), cachedItem.getClientId(), cachedItem.getUserInfo().getDisplayableId()));
+            keysToRemove.add(CacheKey.createCacheKeyForRTEntry(cachedItem.getAuthority(), cachedItem.getResource(), cachedItem.getClientId(), cachedItem.getUserInfo().getUserId()));
         }
         
         return keysToRemove;


### PR DESCRIPTION
To-do 
1. add unit tests
2. Add logging into the cache flow.

I did a E2E verification on the sample app and the tokens are deleted successfully.