### PR TITLE
Changes to get the existing tests working and added new tests

### DIFF
--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicPromptAlwaysTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicPromptAlwaysTest.java
@@ -32,9 +32,11 @@ import static net.serenitybdd.screenplay.GivenWhenThen.then;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(SerenityParameterizedRunner.class)
-public class AcquireTokenBasicPromptAutoTest {
+public class AcquireTokenBasicPromptAlwaysTest {
+
     @TestData
     public static Collection<Object[]> FederationProviders() {
+
 
         return Arrays.asList(new Object[][]{
                 {"ADFSv2"},
@@ -42,7 +44,9 @@ public class AcquireTokenBasicPromptAutoTest {
                 {"ADFSv4"},
                 {"PingFederate"},
                 {"Shibboleth"}
+
         });
+
     }
 
     static AppiumDriverLocalService appiumService = null;
@@ -73,7 +77,7 @@ public class AcquireTokenBasicPromptAutoTest {
     @Steps
     ClickDone clickDone;
 
-    public AcquireTokenBasicPromptAutoTest(String federationProvider) {
+    public AcquireTokenBasicPromptAlwaysTest(String federationProvider) {
         this.federationProvider = federationProvider;
     }
 
@@ -95,6 +99,7 @@ public class AcquireTokenBasicPromptAutoTest {
         newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
         newUser.setTokenRequest(scenario.getTokenRequest());
         newUser.setCredential(scenario.getCredential());
+
         return newUser;
     }
 
@@ -103,7 +108,7 @@ public class AcquireTokenBasicPromptAutoTest {
     public void should_be_able_to_acquire_token() {
 
         james.attemptsTo(
-                acquireToken.withPrompt("Auto"),
+                acquireToken.withPrompt("Always"),
                 clickDone,
                 readCache);
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicPromptAutoTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicPromptAutoTest.java
@@ -1,8 +1,10 @@
 package com.microsoft.identity.common.test.automation;
 
 import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
 import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
-import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
 import com.microsoft.identity.common.test.automation.utility.Scenario;
 import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
 
@@ -25,30 +27,28 @@ import java.util.Collection;
 
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static org.hamcrest.Matchers.is;
+
 @RunWith(SerenityParameterizedRunner.class)
-public class AcquireTokenSilentBasicTest {
-
+public class AcquireTokenBasicPromptAutoTest {
     @TestData
-    public static Collection<Object[]> FederationProviders(){
-
+    public static Collection<Object[]> FederationProviders() {
 
         return Arrays.asList(new Object[][]{
-                {"ADFSv2"},
-                {"ADFSv3"},
-                {"ADFSv4"},
-                {"PingFederate"},
-                {"Shibboleth"}
+                {"ADFSv2"}//,
+//                {"ADFSv3"},
+//                {"ADFSv4"},
+//                {"PingFederate"},
+//                {"Shibboleth"}
 
         });
-
     }
-
-    @Steps
-    AcquireTokenSilent acquireTokenSilent;
 
     static AppiumDriverLocalService appiumService = null;
 
-    @Managed(driver="Appium")
+    @Managed(driver = "Appium")
     WebDriver hisMobileDevice;
 
     @BeforeClass
@@ -65,12 +65,21 @@ public class AcquireTokenSilentBasicTest {
     private User james;
     private String federationProvider;
 
-    public AcquireTokenSilentBasicTest(String federationProvider){
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+    public AcquireTokenBasicPromptAutoTest(String federationProvider) {
         this.federationProvider = federationProvider;
     }
 
     @Before
-    public void jamesCanUseAMobileDevice(){
+    public void jamesCanUseAMobileDevice() {
         TestConfigurationQuery query = new TestConfigurationQuery();
         query.federationProvider = this.federationProvider;
         query.isFederated = true;
@@ -79,7 +88,11 @@ public class AcquireTokenSilentBasicTest {
         james.can(BrowseTheWeb.with(hisMobileDevice));
     }
 
-    private static User getUser(TestConfigurationQuery query){
+    public AcquireTokenBasicPromptAutoTest() {
+        super();
+    }
+
+    private static User getUser(TestConfigurationQuery query) {
 
         Scenario scenario = Scenario.GetScenario(query);
 
@@ -87,15 +100,19 @@ public class AcquireTokenSilentBasicTest {
         newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
         newUser.setTokenRequest(scenario.getTokenRequest());
         newUser.setCredential(scenario.getCredential());
-
         return newUser;
     }
 
 
     @Test
-    public void should_be_able_to_acquire_token_silent() {
+    public void should_be_able_to_acquire_token() {
 
-        james.attemptsTo(acquireTokenSilent);
+        james.attemptsTo(
+                acquireToken.withPrompt("Auto"),
+                clickDone,
+                readCache);
+
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
 
     }
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicPromptNullTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicPromptNullTest.java
@@ -1,8 +1,10 @@
 package com.microsoft.identity.common.test.automation;
 
 import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
 import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
-import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
 import com.microsoft.identity.common.test.automation.utility.Scenario;
 import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
 
@@ -25,11 +27,15 @@ import java.util.Collection;
 
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static org.hamcrest.Matchers.is;
+
 @RunWith(SerenityParameterizedRunner.class)
-public class AcquireTokenSilentBasicTest {
+public class AcquireTokenBasicPromptNullTest {
 
     @TestData
-    public static Collection<Object[]> FederationProviders(){
+    public static Collection<Object[]> FederationProviders() {
 
 
         return Arrays.asList(new Object[][]{
@@ -43,12 +49,9 @@ public class AcquireTokenSilentBasicTest {
 
     }
 
-    @Steps
-    AcquireTokenSilent acquireTokenSilent;
-
     static AppiumDriverLocalService appiumService = null;
 
-    @Managed(driver="Appium")
+    @Managed(driver = "Appium")
     WebDriver hisMobileDevice;
 
     @BeforeClass
@@ -65,12 +68,21 @@ public class AcquireTokenSilentBasicTest {
     private User james;
     private String federationProvider;
 
-    public AcquireTokenSilentBasicTest(String federationProvider){
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+    public AcquireTokenBasicPromptNullTest(String federationProvider) {
         this.federationProvider = federationProvider;
     }
 
     @Before
-    public void jamesCanUseAMobileDevice(){
+    public void jamesCanUseAMobileDevice() {
         TestConfigurationQuery query = new TestConfigurationQuery();
         query.federationProvider = this.federationProvider;
         query.isFederated = true;
@@ -79,7 +91,7 @@ public class AcquireTokenSilentBasicTest {
         james.can(BrowseTheWeb.with(hisMobileDevice));
     }
 
-    private static User getUser(TestConfigurationQuery query){
+    private static User getUser(TestConfigurationQuery query) {
 
         Scenario scenario = Scenario.GetScenario(query);
 
@@ -93,9 +105,14 @@ public class AcquireTokenSilentBasicTest {
 
 
     @Test
-    public void should_be_able_to_acquire_token_silent() {
+    public void should_be_able_to_acquire_token() {
 
-        james.attemptsTo(acquireTokenSilent);
+        james.attemptsTo(
+                acquireToken.withPrompt(null),
+                clickDone,
+                readCache);
+
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
 
     }
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicTest.java
@@ -1,35 +1,35 @@
 package com.microsoft.identity.common.test.automation;
 
-        import com.microsoft.identity.common.test.automation.actors.User;
-        import com.microsoft.identity.common.test.automation.interactions.ClickDone;
-        import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
-        import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
-        import com.microsoft.identity.common.test.automation.tasks.ReadCache;
-        import com.microsoft.identity.common.test.automation.utility.Scenario;
-        import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
+import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
+import com.microsoft.identity.common.test.automation.utility.Scenario;
+import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
 
-        import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
-        import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
-        import net.thucydides.core.annotations.Managed;
-        import net.thucydides.core.annotations.Steps;
-        import net.thucydides.junit.annotations.TestData;
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.thucydides.core.annotations.Managed;
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.junit.annotations.TestData;
 
-        import org.junit.AfterClass;
-        import org.junit.Before;
-        import org.junit.BeforeClass;
-        import org.junit.Test;
-        import org.junit.runner.RunWith;
-        import org.openqa.selenium.WebDriver;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
 
-        import java.io.IOException;
-        import java.util.Arrays;
-        import java.util.Collection;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
-        import io.appium.java_client.service.local.AppiumDriverLocalService;
+import io.appium.java_client.service.local.AppiumDriverLocalService;
 
-        import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
-        import static net.serenitybdd.screenplay.GivenWhenThen.then;
-        import static org.hamcrest.Matchers.is;
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static org.hamcrest.Matchers.is;
 
 @RunWith(SerenityParameterizedRunner.class)
 public class AcquireTokenBasicTest {
@@ -40,10 +40,10 @@ public class AcquireTokenBasicTest {
 
         return Arrays.asList(new Object[][]{
                 {"ADFSv2"},
-                //{"ADFSv3"},
-                {"ADFSv4"}//,
-                //{"PingFederate"}//,
-                //{"Shibboleth"}
+                {"ADFSv3"},
+                {"ADFSv4"},
+                {"PingFederate"},
+                {"Shibboleth"}
 
         });
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenInteractiveThenSilentBasicTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenInteractiveThenSilentBasicTest.java
@@ -42,9 +42,9 @@ public class AcquireTokenInteractiveThenSilentBasicTest {
         return Arrays.asList(new Object[][]{
                 {"ADFSv2"},
                 {"ADFSv3"},
-                {"ADFSv4"}//,
-                //{"PingFederate"},
-                //{"Shibboleth"}
+                {"ADFSv4"},
+                {"PingFederate"},
+                {"Shibboleth"}
 
         });
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenPromptAutoThenAlwaysTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenPromptAutoThenAlwaysTest.java
@@ -1,8 +1,11 @@
 package com.microsoft.identity.common.test.automation;
 
 import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.AccessToken;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
 import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
-import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
 import com.microsoft.identity.common.test.automation.utility.Scenario;
 import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
 
@@ -25,12 +28,21 @@ import java.util.Collection;
 
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 
+import static net.serenitybdd.screenplay.GivenWhenThen.and;
+import static net.serenitybdd.screenplay.GivenWhenThen.givenThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static net.serenitybdd.screenplay.GivenWhenThen.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Test case : https://identitydivision.visualstudio.com/IDDP/DevEx-Client-SDK/_testManagement?planId=345909&suiteId=345910&_a=tests
+ */
 @RunWith(SerenityParameterizedRunner.class)
-public class AcquireTokenSilentBasicTest {
-
+public class AcquireTokenPromptAutoThenAlwaysTest {
     @TestData
-    public static Collection<Object[]> FederationProviders(){
-
+    public static Collection<Object[]> FederationProviders() {
 
         return Arrays.asList(new Object[][]{
                 {"ADFSv2"},
@@ -40,15 +52,11 @@ public class AcquireTokenSilentBasicTest {
                 {"Shibboleth"}
 
         });
-
     }
-
-    @Steps
-    AcquireTokenSilent acquireTokenSilent;
 
     static AppiumDriverLocalService appiumService = null;
 
-    @Managed(driver="Appium")
+    @Managed(driver = "Appium")
     WebDriver hisMobileDevice;
 
     @BeforeClass
@@ -65,12 +73,22 @@ public class AcquireTokenSilentBasicTest {
     private User james;
     private String federationProvider;
 
-    public AcquireTokenSilentBasicTest(String federationProvider){
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+
+    public AcquireTokenPromptAutoThenAlwaysTest(String federationProvider) {
         this.federationProvider = federationProvider;
     }
 
     @Before
-    public void jamesCanUseAMobileDevice(){
+    public void jamesCanUseAMobileDevice() {
         TestConfigurationQuery query = new TestConfigurationQuery();
         query.federationProvider = this.federationProvider;
         query.isFederated = true;
@@ -79,24 +97,33 @@ public class AcquireTokenSilentBasicTest {
         james.can(BrowseTheWeb.with(hisMobileDevice));
     }
 
-    private static User getUser(TestConfigurationQuery query){
-
+    private static User getUser(TestConfigurationQuery query) {
         Scenario scenario = Scenario.GetScenario(query);
-
         User newUser = User.named("james");
         newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
         newUser.setTokenRequest(scenario.getTokenRequest());
         newUser.setCredential(scenario.getCredential());
-
         return newUser;
     }
 
-
     @Test
-    public void should_be_able_to_acquire_token_silent() {
+    public void should_be_able_to_acquire_token_refresh_auto() {
+        givenThat(james).wasAbleTo(
+                acquireToken.withPrompt("Auto").withUserIdentifier(james.getTokenRequest().getUserIdentitfier()),
+                clickDone,
+                readCache);
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
 
-        james.attemptsTo(acquireTokenSilent);
+        //Store the access token temporarily to compare later
+        String accessToken1 = james.asksFor(AccessToken.displayed());
+        james.attemptsTo(clickDone);
+
+        when(james).attemptsTo(
+                acquireToken.withPrompt("Always").withUserIdentifier(null),
+                clickDone,
+                readCache);
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
+        and(james).should(seeThat(AccessToken.displayed(), not(accessToken1)));
 
     }
-
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/interactions/ClickDone.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/interactions/ClickDone.java
@@ -1,17 +1,20 @@
 package com.microsoft.identity.common.test.automation.interactions;
 
-import com.microsoft.identity.common.test.automation.ui.Main;
 import com.microsoft.identity.common.test.automation.ui.Results;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Interaction;
 import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class ClickDone implements Interaction {
 
     @Override
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
+                WaitUntil.the(Results.DONE_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Results.DONE_BUTTON)
         );
     }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/interactions/CloseKeyboard.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/interactions/CloseKeyboard.java
@@ -3,11 +3,18 @@ package com.microsoft.identity.common.test.automation.interactions;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Interaction;
 import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.thucydides.core.webdriver.WebDriverFacade;
+
+import io.appium.java_client.android.AndroidDriver;
 
 public class CloseKeyboard implements Interaction {
 
     @Override
     public <T extends Actor> void performAs(T actor) {
-        BrowseTheWeb.as(actor).getDriver().navigate().back();
+        WebDriverFacade facade = (WebDriverFacade)BrowseTheWeb.as(actor).getDriver();
+        AndroidDriver androidDriver = (AndroidDriver)facade.getProxiedDriver();
+        if(androidDriver.isKeyboardShown()) {
+            androidDriver.hideKeyboard();
+        }
     }
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
@@ -1,0 +1,22 @@
+package com.microsoft.identity.common.test.automation.questions;
+
+import com.microsoft.identity.common.test.automation.model.ReadCacheResult;
+import com.microsoft.identity.common.test.automation.model.ResultsMapper;
+import com.microsoft.identity.common.test.automation.ui.Results;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.questions.Text;
+
+public class AccessToken implements Question<String> {
+    @Override
+    public String answeredBy(Actor actor) {
+        String results = Text.of(Results.RESULT_FIELD).viewedBy(actor).asString();
+        ReadCacheResult readCacheResult = ResultsMapper.GetReadCacheResultFromString(results);
+        return readCacheResult.tokenCacheItems.get(0).accessToken;
+    }
+
+    public static Question<String>  displayed(){
+         return new AccessToken();
+    }
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
@@ -4,12 +4,18 @@ import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
 import com.microsoft.identity.common.test.automation.ui.Main;
 import com.microsoft.identity.common.test.automation.ui.Request;
+import com.microsoft.identity.common.test.automation.ui.googleplaystore.AppDetailView;
+import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPagePassword;
+import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPageUserName;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.waits.WaitUntil;
 import net.thucydides.core.annotations.Steps;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class AcquireToken implements Task{
 
@@ -22,11 +28,15 @@ public class AcquireToken implements Task{
         User user = (User)actor;
         SignInUser signInUser = SignInUser.GetSignInUserByFederationProvider(user.getFederationProvider());
         actor.attemptsTo(
+                WaitUntil.the(Main.ACQUIRE_TOKEN_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Main.ACQUIRE_TOKEN_BUTTON),
                 Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
                 closeKeyboard,
+                WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Request.SUBMIT_REQUEST_BUTTON),
+                WaitUntil.the(SignInPageUserName.USERNAME, isVisible()).forNoMoreThan(10).seconds(),
                 new EnterUserNameForSignInDisambiguation(),
+                WaitUntil.the(SignInPagePassword.PASSWORD, isVisible()).forNoMoreThan(10).seconds(),
                 signInUser
         );
     }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
@@ -4,9 +4,9 @@ import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
 import com.microsoft.identity.common.test.automation.ui.Main;
 import com.microsoft.identity.common.test.automation.ui.Request;
-import com.microsoft.identity.common.test.automation.ui.googleplaystore.AppDetailView;
 import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPagePassword;
 import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPageUserName;
+import com.microsoft.identity.common.test.automation.utility.TokenRequest;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
@@ -22,10 +22,15 @@ public class AcquireToken implements Task{
     @Steps
     CloseKeyboard closeKeyboard;
 
+    String prompt;
+    String userIdentifier;
 
     @Override
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
+        TokenRequest tokenRequest = user.getTokenRequest();
+        tokenRequest.setPromptBehavior(prompt);
+        tokenRequest.setUserIdentitfier(userIdentifier);
         SignInUser signInUser = SignInUser.GetSignInUserByFederationProvider(user.getFederationProvider());
         actor.attemptsTo(
                 WaitUntil.the(Main.ACQUIRE_TOKEN_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
@@ -39,6 +44,16 @@ public class AcquireToken implements Task{
                 WaitUntil.the(SignInPagePassword.PASSWORD, isVisible()).forNoMoreThan(10).seconds(),
                 signInUser
         );
+    }
+
+    public AcquireToken withPrompt(String prompt){
+            this.prompt = prompt;
+            return this;
+    }
+
+    public AcquireToken withUserIdentifier(String userIdentifier){
+        this.userIdentifier = userIdentifier;
+        return this;
     }
 
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
@@ -10,7 +10,10 @@ import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.waits.WaitUntil;
 import net.thucydides.core.annotations.Steps;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class AcquireTokenSilent implements Task{
 
@@ -21,6 +24,7 @@ public class AcquireTokenSilent implements Task{
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         actor.attemptsTo(
+                WaitUntil.the(Main.ACQUIRE_TOKEN_SILENT, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Main.ACQUIRE_TOKEN_SILENT),
                 Enter.theValue(user.getSilentTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
                 closeKeyboard,

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ClearCache.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ClearCache.java
@@ -1,0 +1,18 @@
+package com.microsoft.identity.common.test.automation.tasks;
+
+import com.microsoft.identity.common.test.automation.ui.Main;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Click;
+
+public class ClearCache implements Task {
+
+
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Click.on(Main.CLEAR_CACHE)
+        );
+    }
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/EnterUserNameForSignInDisambiguation.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/EnterUserNameForSignInDisambiguation.java
@@ -7,6 +7,9 @@ import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 
 public class EnterUserNameForSignInDisambiguation implements Task {
@@ -15,6 +18,7 @@ public class EnterUserNameForSignInDisambiguation implements Task {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         user.attemptsTo(
+                WaitUntil.the(SignInPageUserName.USERNAME, isVisible()).forNoMoreThan(10).seconds(),
                 Enter.theValue(user.getCredential().userName).into(SignInPageUserName.USERNAME),
                 Click.on(SignInPageUserName.NEXT_BUTTON)
         );

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserADFSv2.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserADFSv2.java
@@ -1,14 +1,15 @@
 package com.microsoft.identity.common.test.automation.tasks;
 
 import com.microsoft.identity.common.test.automation.actors.User;
-import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPageUserName;
 import com.microsoft.identity.common.test.automation.ui.identityproviders.ADFSv2.SignInPage;
-
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.actions.EnterValueIntoTarget;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class SignInUserADFSv2 extends SignInUser {
 
@@ -16,6 +17,7 @@ public class SignInUserADFSv2 extends SignInUser {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         user.attemptsTo(
+                WaitUntil.the(SignInPage.USERNAME_FIELD, isVisible()).forNoMoreThan(10).seconds(),
                 Enter.theValue(user.getCredential().userName).into(SignInPage.USERNAME_FIELD),
                 //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
                 new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserADFSv3.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserADFSv3.java
@@ -19,11 +19,11 @@ public class SignInUserADFSv3 extends SignInUser {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         user.attemptsTo(
-            //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
-            WaitUntil.the(SignInPage.PASSWORD_FIELD, isVisible()).forNoMoreThan(10).seconds(),
-            new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),
-            new CloseKeyboard(),
-            Click.on(SignInPage.SIGN_IN_BUTTON)
+                //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
+                WaitUntil.the(SignInPage.PASSWORD_FIELD, isVisible()).forNoMoreThan(10).seconds(),
+                new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),
+                new CloseKeyboard(),
+                Click.on(SignInPage.SIGN_IN_BUTTON)
         );
     }
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserADFSv4.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserADFSv4.java
@@ -8,6 +8,9 @@ import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.actions.EnterValueIntoTarget;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class SignInUserADFSv4 extends SignInUser {
 
@@ -15,9 +18,11 @@ public class SignInUserADFSv4 extends SignInUser {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         user.attemptsTo(
-            //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
-            new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),
-            Click.on(SignInPage.SIGN_IN_BUTTON)
+                //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
+                WaitUntil.the(SignInPage.PASSWORD_FIELD, isVisible()).forNoMoreThan(10).seconds(),
+                new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),
+                WaitUntil.the(SignInPage.SIGN_IN_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
+                Click.on(SignInPage.SIGN_IN_BUTTON)
         );
     }
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserPing.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserPing.java
@@ -2,14 +2,15 @@ package com.microsoft.identity.common.test.automation.tasks;
 
 import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
-import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPageUserName;
 import com.microsoft.identity.common.test.automation.ui.identityproviders.PingFederate.SignInPage;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.actions.EnterValueIntoTarget;
+import net.serenitybdd.screenplay.waits.WaitUntil;
 
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 
 public class SignInUserPing extends SignInUser {
@@ -19,10 +20,12 @@ public class SignInUserPing extends SignInUser {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         user.attemptsTo(
-                Enter.theValue(user.getCredential().userName).into(SignInPage.USERNAME_FIELD),
+                WaitUntil.the(SignInPage.USERNAME_FIELD, isVisible()).forNoMoreThan(10).seconds(),
+                Enter.theValue(user.getCredential().userName.split("@")[0]).into(SignInPage.USERNAME_FIELD),
                 //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
                 new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),
                 new CloseKeyboard(),
+                WaitUntil.the(SignInPage.SIGN_IN_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(SignInPage.SIGN_IN_BUTTON)
         );
     }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserShibboleth.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/SignInUserShibboleth.java
@@ -2,14 +2,15 @@ package com.microsoft.identity.common.test.automation.tasks;
 
 import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
-import com.microsoft.identity.common.test.automation.ui.identityproviders.AADV1.SignInPageUserName;
 import com.microsoft.identity.common.test.automation.ui.identityproviders.Shibboleth.SignInPage;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.actions.EnterValueIntoTarget;
+import net.serenitybdd.screenplay.waits.WaitUntil;
 
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 
 public class SignInUserShibboleth extends SignInUser {
@@ -19,7 +20,8 @@ public class SignInUserShibboleth extends SignInUser {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         user.attemptsTo(
-                Enter.theValue(user.getCredential().userName).into(SignInPage.USERNAME_FIELD),
+                WaitUntil.the(SignInPage.USERNAME_FIELD, isVisible()).forNoMoreThan(10).seconds(),
+                Enter.theValue(user.getCredential().userName.split("@")[0]).into(SignInPage.USERNAME_FIELD),
                 //Not using static method here to avoid logging the password via instrumentation... this won't show up as a step
                 new EnterValueIntoTarget(user.getCredential().password, SignInPage.PASSWORD_FIELD),
                 new CloseKeyboard(),

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/ui/identityproviders/ADFSv3/SignInPage.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/ui/identityproviders/ADFSv3/SignInPage.java
@@ -7,6 +7,5 @@ import io.appium.java_client.MobileBy;
 public class SignInPage {
     public static Target USERNAME_FIELD = Target.the("Username field").located(MobileBy.AndroidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(0)"));
     public static Target PASSWORD_FIELD = Target.the("Password field").located(MobileBy.AndroidUIAutomator("new UiSelector().className(\"android.widget.EditText\").instance(1)"));
-    public static Target SIGN_IN_BUTTON = Target.the("SignIn button").located(MobileBy.AndroidUIAutomator("new UiSelector().className(\"android.view.View\").resourceId(\"submissionArea\")"));
-
+    public static Target SIGN_IN_BUTTON = Target.the("SignIn button").located(MobileBy.AndroidUIAutomator("new UiSelector().className(\"android.view.View\").resourceId(\"submitButton\")"));
 }


### PR DESCRIPTION
Changes to get tests working
- Added WaitUntil.the methods as needed to ensure we give enough time for the UI to populate.
- Added  changes to CloseKeyboard Interactions as suggested by Shane.
- Modified the resource id name for Sign Button of ADFS V3.
- Tested changes on Nokia 7.1.2, Emulator(Nexus 6P, 8.1)

New Test cases
1) Added AcquireTokenBasicPromptAutoTest class to test PromptBehavior.Auto
2) Added AcquireTokenBasicPromptNullTest class to test PromptBehavior.Null
3) Added AcquireTokenBasicPromptAlwaysTest class to test PromptBehavior.Always
4)  Added AcquireTokenPromptAutoThenAlwaysTest class to test the case where a token is acquired using PromptBehavior.Auto and then an acquireToken with  PromptBehavior.Always is called.
