### PR TITLE
Added Acquire Token test cases with login hints

### DIFF
--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicLoginHintTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenBasicLoginHintTest.java
@@ -1,0 +1,114 @@
+package com.microsoft.identity.common.test.automation;
+
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
+import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
+import com.microsoft.identity.common.test.automation.utility.Scenario;
+import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
+
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.thucydides.core.annotations.Managed;
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.junit.annotations.TestData;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.appium.java_client.service.local.AppiumDriverLocalService;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(SerenityParameterizedRunner.class)
+public class AcquireTokenBasicLoginHintTest {
+    @TestData
+    public static Collection<Object[]> FederationProviders() {
+
+        return Arrays.asList(new Object[][]{
+                {"ADFSv2"},
+                {"ADFSv3"},
+                {"ADFSv4"},
+                {"PingFederate"},
+                {"Shibboleth"}
+        });
+    }
+
+    static AppiumDriverLocalService appiumService = null;
+
+    @Managed(driver = "Appium")
+    WebDriver hisMobileDevice;
+
+    @BeforeClass
+    public static void startAppiumServer() throws IOException {
+        appiumService = AppiumDriverLocalService.buildDefaultService();
+        appiumService.start();
+    }
+
+    @AfterClass
+    public static void stopAppiumServer() {
+        appiumService.stop();
+    }
+
+    private User james;
+    private String federationProvider;
+
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+    public AcquireTokenBasicLoginHintTest(String federationProvider) {
+        this.federationProvider = federationProvider;
+    }
+
+    @Before
+    public void jamesCanUseAMobileDevice() {
+        TestConfigurationQuery query = new TestConfigurationQuery();
+        query.federationProvider = this.federationProvider;
+        query.isFederated = true;
+        query.userType = "Member";
+        james = getUser(query);
+        james.can(BrowseTheWeb.with(hisMobileDevice));
+    }
+
+    private static User getUser(TestConfigurationQuery query) {
+
+        Scenario scenario = Scenario.GetScenario(query);
+
+        User newUser = User.named("james");
+        newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
+        newUser.setTokenRequest(scenario.getTokenRequest());
+        newUser.setCredential(scenario.getCredential());
+        return newUser;
+    }
+
+
+    @Test
+    public void should_be_able_to_acquire_token_with_login_hint() {
+
+        james.attemptsTo(
+                acquireToken.withUserIdentifier(james.getCredential().userName),
+                clickDone,
+                readCache);
+
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
+
+    }
+
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentLoginHint.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentLoginHint.java
@@ -1,0 +1,142 @@
+package com.microsoft.identity.common.test.automation;
+
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.AccessToken;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
+import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
+import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
+import com.microsoft.identity.common.test.automation.utility.Scenario;
+import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
+
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.thucydides.core.annotations.Managed;
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.junit.annotations.TestData;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.appium.java_client.service.local.AppiumDriverLocalService;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.givenThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static net.serenitybdd.screenplay.GivenWhenThen.when;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test case : https://identitydivision.visualstudio.com/IDDP/_workitems/edit/98555
+ */
+
+@RunWith(SerenityParameterizedRunner.class)
+public class AcquireTokenSilentLoginHint {
+
+    @TestData
+    public static Collection<Object[]> FederationProviders(){
+
+
+        return Arrays.asList(new Object[][]{
+                {"ADFSv2"},
+                {"ADFSv3"},
+                {"ADFSv4"},
+                {"PingFederate"},
+                {"Shibboleth"}
+
+        });
+
+    }
+
+    @Steps
+    AcquireTokenSilent acquireTokenSilent;
+
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+    static AppiumDriverLocalService appiumService = null;
+
+    @Managed(driver="Appium")
+    WebDriver hisMobileDevice;
+
+    @BeforeClass
+    public static void startAppiumServer() throws IOException {
+        appiumService = AppiumDriverLocalService.buildDefaultService();
+        appiumService.start();
+    }
+
+    @AfterClass
+    public static void stopAppiumServer() {
+        appiumService.stop();
+    }
+
+    private User james;
+    private String federationProvider;
+
+    public AcquireTokenSilentLoginHint(String federationProvider){
+        this.federationProvider = federationProvider;
+    }
+
+    @Before
+    public void jamesCanUseAMobileDevice(){
+        TestConfigurationQuery query = new TestConfigurationQuery();
+        query.federationProvider = this.federationProvider;
+        query.isFederated = true;
+        query.userType = "Member";
+        james = getUser(query);
+        james.can(BrowseTheWeb.with(hisMobileDevice));
+    }
+
+    private static User getUser(TestConfigurationQuery query){
+
+        Scenario scenario = Scenario.GetScenario(query);
+
+        User newUser = User.named("james");
+        newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
+        newUser.setTokenRequest(scenario.getTokenRequest());
+        newUser.setSilentTokenRequest(scenario.getSilentTokenRequest());
+        newUser.setCredential(scenario.getCredential());
+
+        return newUser;
+    }
+
+
+    @Test
+    public void should_be_able_to_acquire_token_and_then_acquire_silent_with_login_hint() {
+
+        givenThat(james).wasAbleTo(
+                acquireToken,
+                clickDone,
+                readCache);
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
+
+        String accessToken1 = james.asksFor(AccessToken.displayed());
+
+        james.attemptsTo(clickDone);
+
+        when(james).attemptsTo(
+                acquireTokenSilent.withUserIdentifier(james.getCredential().userName),
+                clickDone,
+                readCache);
+
+        then(james).should(seeThat(AccessToken.displayed(), is(accessToken1)));
+
+
+    }
+
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
@@ -15,6 +15,8 @@ import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.waits.WaitUntil;
 import net.thucydides.core.annotations.Steps;
 
+import org.apache.http.util.TextUtils;
+
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class AcquireToken implements Task{
@@ -38,12 +40,19 @@ public class AcquireToken implements Task{
                 Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
                 closeKeyboard,
                 WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
-                Click.on(Request.SUBMIT_REQUEST_BUTTON),
-                WaitUntil.the(SignInPageUserName.USERNAME, isVisible()).forNoMoreThan(10).seconds(),
-                new EnterUserNameForSignInDisambiguation(),
-                WaitUntil.the(SignInPagePassword.PASSWORD, isVisible()).forNoMoreThan(10).seconds(),
-                signInUser
+                Click.on(Request.SUBMIT_REQUEST_BUTTON)
         );
+
+        // If userIdentifier was not provided in acquire token call , attempt to enter username for sign in
+        if(TextUtils.isEmpty(userIdentifier)){
+            actor.attemptsTo(
+                    WaitUntil.the(SignInPageUserName.USERNAME, isVisible()).forNoMoreThan(10).seconds(),
+                    new EnterUserNameForSignInDisambiguation(),
+                    WaitUntil.the(SignInPagePassword.PASSWORD, isVisible()).forNoMoreThan(10).seconds()
+            );
+        }
+
+        actor.attemptsTo(signInUser);
     }
 
     public AcquireToken withPrompt(String prompt){

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
@@ -4,7 +4,7 @@ import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
 import com.microsoft.identity.common.test.automation.ui.Main;
 import com.microsoft.identity.common.test.automation.ui.Request;
-import com.microsoft.identity.common.test.automation.ui.Results;
+import com.microsoft.identity.common.test.automation.utility.TokenRequest;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
@@ -17,12 +17,16 @@ import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisi
 
 public class AcquireTokenSilent implements Task{
 
+    private String userIdentifier;
+
     @Steps
     CloseKeyboard closeKeyboard;
 
     @Override
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
+        TokenRequest tokenRequest = user.getTokenRequest();
+        tokenRequest.setUserIdentitfier(userIdentifier);
         actor.attemptsTo(
                 WaitUntil.the(Main.ACQUIRE_TOKEN_SILENT, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Main.ACQUIRE_TOKEN_SILENT),
@@ -30,6 +34,11 @@ public class AcquireTokenSilent implements Task{
                 closeKeyboard,
                 Click.on(Request.SUBMIT_REQUEST_BUTTON)
         );
+    }
+
+    public AcquireTokenSilent withUserIdentifier(String userIdentifier){
+        this.userIdentifier = userIdentifier;
+        return this;
     }
 
 }


### PR DESCRIPTION
Test Case 1 : Call Acquire token with login hint
Test Case 2: Acquire Token interactively, then call Acquire token silent with login hint 
Made appropriate changes to AcquireToken and AcquireTokenSilent tasks to ensure we do not try to enter username in cases where login hint is provided