### PR TITLE
Updates constructor call to MsalOAuth2TokenCache, closes #1180

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -37,8 +37,8 @@ import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Configuration;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryTokenResponse;
-import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -330,7 +330,7 @@ class TokenCacheAccessor {
         AzureActiveDirectoryTokenResponse tokenResponse = CoreAdapter.asAadTokenResponse(result);
         AzureActiveDirectoryOAuth2Configuration config = new AzureActiveDirectoryOAuth2Configuration();
         config.setAuthorityHostValdiationEnabled(this.isValidateAuthorityHost());
-        OAuth2Strategy strategy = ad.createOAuth2Strategy(config);
+        AzureActiveDirectoryOAuth2Strategy strategy = ad.createOAuth2Strategy(config);
         AzureActiveDirectoryAuthorizationRequest request = new AzureActiveDirectoryAuthorizationRequest();
         request.setClientId(clientId);
         request.setScope(resource);

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -30,7 +30,6 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.cache.ADALOAuth2TokenCache;
 import com.microsoft.identity.common.internal.cache.AccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.CacheKeyValueDelegate;
-import com.microsoft.identity.common.internal.cache.DefaultSsoValidator;
 import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
 import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
@@ -40,7 +39,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.azureactivedir
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Configuration;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryTokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
-import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -64,7 +62,7 @@ class TokenCacheAccessor {
 
     private final String mTelemetryRequestId;
     private boolean mUseCommonCache = false;
-    private OAuth2TokenCache mCommonCache = null;
+    private ADALOAuth2TokenCache mCommonCache = null;
     private boolean mValidateAuthorityHost = true;
 
     TokenCacheAccessor(final Context appContext, final ITokenCacheStore tokenCacheStore, final String authority, final String telemetryRequestId) {
@@ -96,8 +94,7 @@ class TokenCacheAccessor {
                 new MsalOAuth2TokenCache(
                         appContext,
                         accountCredentialCache,
-                        new MicrosoftStsAccountCredentialAdapter(),
-                        new DefaultSsoValidator()
+                        new MicrosoftStsAccountCredentialAdapter()
                 );
 
         sharedSSOCaches.add(msalOAuth2TokenCache);


### PR DESCRIPTION
Update to support new MsalOAuth2TokenCache constructor + changing left-side declaration of common cache to ADALOAuth2TokenCache to use saveTokens implementation that doesn't throw ClientException.

Please note: this commit points to `common/289_save-validation`

The following PR should merge prior to this change:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/81

Closes #1180 
