### PR TITLE
Added Tests to verify Acquire Token with Refresh Token after AccessToken expiry

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2286,6 +2286,7 @@ public final class AuthenticationContextTest {
 
         final String response = "{\"access_token\":\"accesstoken"
                 + "\",\"token_type\":\"Bearer\",\"expires_in\":\"29344\",\"expires_on\":\"1368768616\","
+                + "\"resource\":1,"
                 + "\"refresh_token\":\""
                 + "refreshToken" + "\",\"scope\":\"*\",\"id_token\":\"" + TEST_IDTOKEN + "\", \"client_info\":\"" + Util.TEST_CLIENT_INFO + "\"}";
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
@@ -2330,8 +2331,6 @@ public final class AuthenticationContextTest {
 
         assertEquals("Token is returned from refresh token request", expectedAT,
                 callback.getAuthenticationResult().getAccessToken());
-        assertFalse("Multiresource is not set in the mocked response",
-                callback.getAuthenticationResult().getIsMultiResourceRefreshToken());
 
         // Same call again to use it from cache
         signal = new CountDownLatch(1);
@@ -2344,21 +2343,6 @@ public final class AuthenticationContextTest {
 
         assertEquals("Same token in response as in cache for same call", expectedAT,
                 callback.getAuthenticationResult().getAccessToken());
-
-        // Empty userid will prompt.
-        // Items are linked to userid. If it is not there, it can't use for
-        // refresh or access token.
-        signal = new CountDownLatch(1);
-        testActivity = new MockActivity(signal);
-        callback = new MockAuthenticationCallback(signal);
-        context.acquireToken(testActivity.getTestActivity(), resource, "ClienTid", "redirectUri", "", callback);
-        signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
-
-        assertNull("Result is null since it tries to start activity",
-                callback.getAuthenticationResult());
-        assertEquals("Activity was attempted to start.",
-                AuthenticationConstants.UIRequest.BROWSER_FLOW,
-                testActivity.mStartActivityRequestCode);
 
         clearCache(context);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -64,7 +64,7 @@ final class CoreAdapter {
         return new UserInfo(
                 account.getUserId(),
                 account.getName(),
-                account.getLastName(),
+                account.getFamilyName(),
                 account.getIdentityProvider(),
                 account.getDisplayableId()
         );

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.aad.adal;
 
 import com.microsoft.identity.common.Account;

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -327,7 +327,7 @@ class TokenCacheAccessor {
         AzureActiveDirectory ad = new AzureActiveDirectory();
         AzureActiveDirectoryTokenResponse tokenResponse = CoreAdapter.asAadTokenResponse(result);
         AzureActiveDirectoryOAuth2Configuration config = new AzureActiveDirectoryOAuth2Configuration();
-        config.setAuthorityHostValdiationEnabled(this.isValidateAuthorityHost());
+        config.setAuthorityHostValidationEnabled(this.isValidateAuthorityHost());
         AzureActiveDirectoryOAuth2Strategy strategy = ad.createOAuth2Strategy(config);
         AzureActiveDirectoryAuthorizationRequest request = new AzureActiveDirectoryAuthorizationRequest();
         request.setClientId(clientId);

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenAfterExpireAT.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenAfterExpireAT.java
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.not;
  */
 
 @RunWith(SerenityParameterizedRunner.class)
-public class AcquireTokenSilentAfterExpireAT {
+public class AcquireTokenAfterExpireAT {
 
     @TestData
     public static Collection<Object[]> FederationProviders(){
@@ -93,7 +93,7 @@ public class AcquireTokenSilentAfterExpireAT {
     private User james;
     private String federationProvider;
 
-    public AcquireTokenSilentAfterExpireAT(String federationProvider){
+    public AcquireTokenAfterExpireAT(String federationProvider){
         this.federationProvider = federationProvider;
     }
 
@@ -135,7 +135,9 @@ public class AcquireTokenSilentAfterExpireAT {
         james.attemptsTo(clickDone, expireAccessToken, clickDone);
 
         when(james).attemptsTo(
-                acquireTokenSilent.withUniqueId(james.getCacheResult().uniqueUserId),
+                acquireToken
+                        .tokenExists(true)
+                        .withUserIdentifier(james.getCacheResult().displayableId),
                 clickDone,
                 readCache);
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentAfterExpireAT.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentAfterExpireAT.java
@@ -1,0 +1,147 @@
+package com.microsoft.identity.common.test.automation;
+
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.AccessToken;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
+import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
+import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
+import com.microsoft.identity.common.test.automation.tasks.ExpireAccessToken;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
+import com.microsoft.identity.common.test.automation.utility.Scenario;
+import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
+
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.thucydides.core.annotations.Managed;
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.junit.annotations.TestData;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.appium.java_client.service.local.AppiumDriverLocalService;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.givenThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static net.serenitybdd.screenplay.GivenWhenThen.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Test case : https://identitydivision.visualstudio.com/IDDP/_workitems/edit/98555
+ */
+
+@RunWith(SerenityParameterizedRunner.class)
+public class AcquireTokenSilentAfterExpireAT {
+
+    @TestData
+    public static Collection<Object[]> FederationProviders(){
+
+
+        return Arrays.asList(new Object[][]{
+                {"ADFSv2"}//,
+//                {"ADFSv3"},
+//                {"ADFSv4"},
+//                {"PingFederate"},
+//                {"Shibboleth"}
+
+        });
+
+    }
+
+    @Steps
+    AcquireTokenSilent acquireTokenSilent;
+
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ExpireAccessToken expireAccessToken;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+    static AppiumDriverLocalService appiumService = null;
+
+    @Managed(driver="Appium")
+    WebDriver hisMobileDevice;
+
+    @BeforeClass
+    public static void startAppiumServer() throws IOException {
+        appiumService = AppiumDriverLocalService.buildDefaultService();
+        appiumService.start();
+    }
+
+    @AfterClass
+    public static void stopAppiumServer() {
+        appiumService.stop();
+    }
+
+    private User james;
+    private String federationProvider;
+
+    public AcquireTokenSilentAfterExpireAT(String federationProvider){
+        this.federationProvider = federationProvider;
+    }
+
+    @Before
+    public void jamesCanUseAMobileDevice(){
+        TestConfigurationQuery query = new TestConfigurationQuery();
+        query.federationProvider = this.federationProvider;
+        query.isFederated = true;
+        query.userType = "Member";
+        james = getUser(query);
+        james.can(BrowseTheWeb.with(hisMobileDevice));
+    }
+
+    private static User getUser(TestConfigurationQuery query){
+
+        Scenario scenario = Scenario.GetScenario(query);
+
+        User newUser = User.named("james");
+        newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
+        newUser.setTokenRequest(scenario.getTokenRequest());
+        newUser.setSilentTokenRequest(scenario.getSilentTokenRequest());
+        newUser.setCredential(scenario.getCredential());
+
+        return newUser;
+    }
+
+
+    @Test
+    public void should_be_able_to_new_access_token_after_expiry_on_silent() {
+
+        givenThat(james).wasAbleTo(
+                acquireToken,
+                clickDone,
+                readCache);
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
+
+        String accessToken1 = james.asksFor(AccessToken.displayed());
+
+        james.attemptsTo(clickDone, expireAccessToken, clickDone);
+
+        when(james).attemptsTo(
+                acquireTokenSilent.withUserIdentifier(james.getCredential().userName),
+                clickDone,
+                readCache);
+
+        then(james).should(seeThat(AccessToken.displayed(), not(accessToken1)));
+
+
+    }
+
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentAfterExpireAT.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentAfterExpireAT.java
@@ -135,7 +135,7 @@ public class AcquireTokenSilentAfterExpireAT {
         james.attemptsTo(clickDone, expireAccessToken, clickDone);
 
         when(james).attemptsTo(
-                acquireTokenSilent.withUserIdentifier(james.getCredential().userName),
+                acquireTokenSilent.withUniqueId(james.getCacheResult().uniqueUserId),
                 clickDone,
                 readCache);
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentAfterExpireATAndRT.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentAfterExpireATAndRT.java
@@ -1,0 +1,151 @@
+package com.microsoft.identity.common.test.automation;
+
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.ClickDone;
+import com.microsoft.identity.common.test.automation.questions.ADALError;
+import com.microsoft.identity.common.test.automation.questions.TokenCacheItemCount;
+import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
+import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
+import com.microsoft.identity.common.test.automation.tasks.ExpireATAndInvalidateRT;
+import com.microsoft.identity.common.test.automation.tasks.ReadCache;
+import com.microsoft.identity.common.test.automation.ui.Results;
+import com.microsoft.identity.common.test.automation.utility.Scenario;
+import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;
+
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+import net.thucydides.core.annotations.Managed;
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.junit.annotations.TestData;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.appium.java_client.service.local.AppiumDriverLocalService;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.givenThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static net.serenitybdd.screenplay.GivenWhenThen.when;
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
+import static org.hamcrest.Matchers.is;
+
+//import com.microsoft.identity.common.test.automation.tasks.ExpireAccessToken;
+
+/**
+ * Test case : https://identitydivision.visualstudio.com/IDDP/_workitems/edit/98555
+ */
+
+@RunWith(SerenityParameterizedRunner.class)
+public class AcquireTokenSilentAfterExpireATAndRT {
+
+    @TestData
+    public static Collection<Object[]> FederationProviders(){
+
+
+        return Arrays.asList(new Object[][]{
+                {"ADFSv2"}/*,
+                {"ADFSv3"},
+                {"ADFSv4"},
+                {"PingFederate"},
+                {"Shibboleth"}*/
+
+        });
+
+    }
+
+    @Steps
+    AcquireTokenSilent acquireTokenSilent;
+
+    @Steps
+    AcquireToken acquireToken;
+
+    @Steps
+    ExpireATAndInvalidateRT expireATAndInvalidateRT;
+
+    @Steps
+    ReadCache readCache;
+
+    @Steps
+    ClickDone clickDone;
+
+    static AppiumDriverLocalService appiumService = null;
+
+    @Managed(driver="Appium")
+    WebDriver hisMobileDevice;
+
+    @BeforeClass
+    public static void startAppiumServer() throws IOException {
+        appiumService = AppiumDriverLocalService.buildDefaultService();
+        appiumService.start();
+    }
+
+    @AfterClass
+    public static void stopAppiumServer() {
+        appiumService.stop();
+    }
+
+    private User james;
+    private String federationProvider;
+
+    public AcquireTokenSilentAfterExpireATAndRT(String federationProvider){
+        this.federationProvider = federationProvider;
+    }
+
+    @Before
+    public void jamesCanUseAMobileDevice(){
+        TestConfigurationQuery query = new TestConfigurationQuery();
+        query.federationProvider = this.federationProvider;
+        query.isFederated = true;
+        query.userType = "Member";
+        james = getUser(query);
+        james.can(BrowseTheWeb.with(hisMobileDevice));
+    }
+
+    private static User getUser(TestConfigurationQuery query){
+
+        Scenario scenario = Scenario.GetScenario(query);
+
+        User newUser = User.named("james");
+        newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
+        newUser.setTokenRequest(scenario.getTokenRequest());
+        newUser.setSilentTokenRequest(scenario.getSilentTokenRequest());
+        newUser.setCredential(scenario.getCredential());
+
+        return newUser;
+    }
+
+
+    @Test
+    public void should_not_be_able_access_token_after_at_rt_expiry_on_silent() {
+
+        givenThat(james).wasAbleTo(
+                acquireToken,
+                clickDone,
+                readCache);
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(6)));
+
+        james.attemptsTo(clickDone, expireATAndInvalidateRT, clickDone);
+
+        when(james).attemptsTo(
+                acquireTokenSilent.withUniqueId(james.getCacheResult().uniqueUserId),
+                WaitUntil.the(Results.RESULT_FIELD, isVisible()).forNoMoreThan(10).seconds());
+
+        then(james).should(seeThat(ADALError.displayed(), is(com.microsoft.identity.common.adal.error.ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED.name())));
+
+        when(james).attemptsTo(clickDone, readCache);
+        then(james).should(seeThat(TokenCacheItemCount.displayed(), is(0)));
+
+
+    }
+
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentBasicTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentBasicTest.java
@@ -85,6 +85,7 @@ public class AcquireTokenSilentBasicTest {
         User newUser = User.named("james");
         newUser.setFederationProvider(scenario.getTestConfiguration().getUsers().getFederationProvider());
         newUser.setTokenRequest(scenario.getTokenRequest());
+        newUser.setSilentTokenRequest(scenario.getSilentTokenRequest());
         newUser.setCredential(scenario.getCredential());
 
         return newUser;

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentBasicTest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/AcquireTokenSilentBasicTest.java
@@ -1,7 +1,6 @@
 package com.microsoft.identity.common.test.automation;
 
 import com.microsoft.identity.common.test.automation.actors.User;
-import com.microsoft.identity.common.test.automation.tasks.AcquireToken;
 import com.microsoft.identity.common.test.automation.tasks.AcquireTokenSilent;
 import com.microsoft.identity.common.test.automation.utility.Scenario;
 import com.microsoft.identity.common.test.automation.utility.TestConfigurationQuery;

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/actors/User.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/actors/User.java
@@ -1,12 +1,11 @@
 package com.microsoft.identity.common.test.automation.actors;
 
 import com.google.gson.Gson;
+import com.microsoft.identity.common.test.automation.model.TokenCacheItemReadResult;
 import com.microsoft.identity.common.test.automation.utility.Credential;
 import com.microsoft.identity.common.test.automation.utility.TokenRequest;
 
 import net.serenitybdd.screenplay.Actor;
-
-import jdk.nashorn.internal.parser.Token;
 
 public class User extends Actor {
 
@@ -14,6 +13,7 @@ public class User extends Actor {
     private TokenRequest silentTokenRequest;
     private String federationProvider;
     private Credential credential;
+    private TokenCacheItemReadResult cacheResult;
 
     public void setTokenRequest(TokenRequest tokenRequest){
         this.tokenRequest = tokenRequest;
@@ -69,5 +69,16 @@ public class User extends Actor {
     }
 
 
+    public TokenCacheItemReadResult getCacheResult() {
+        return cacheResult;
+    }
 
+    public void setCacheResult(TokenCacheItemReadResult cacheResult) {
+        this.cacheResult = cacheResult;
+    }
+
+    public String getCacheResultAsJson(){
+        String cacheJson = new Gson().toJson(this.cacheResult);
+        return cacheJson;
+    }
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/model/ADALErrorResult.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/model/ADALErrorResult.java
@@ -1,0 +1,13 @@
+package com.microsoft.identity.common.test.automation.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ADALErrorResult {
+
+    @SerializedName(Constants.ADAL_ERROR_DATA.ERROR)
+    public String error;
+
+    @SerializedName(Constants.ADAL_ERROR_DATA.ERROR_DESCRIPTION)
+    public String errorDescription;
+
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/model/Constants.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/model/Constants.java
@@ -48,4 +48,9 @@ public class Constants {
         static final String GIVEN_NAME = Constants.GIVEN_NAME;
         static final String IDENTITY_PROVIDER = Constants.IDENTITY_PROVIDER;
     }
+
+    protected static class ADAL_ERROR_DATA {
+        static final String ERROR = "error";
+        static final String ERROR_DESCRIPTION = "error_description";
+    }
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/model/ResultsMapper.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/model/ResultsMapper.java
@@ -16,4 +16,9 @@ public class ResultsMapper {
         return readCacheResult;
 
     }
+
+    public static ADALErrorResult GetADALErrorResultFromString(String results){
+        ADALErrorResult adalErrorResult = (ADALErrorResult) ObjectMapper.deserializeJsonStringToObject(results, ADALErrorResult.class);
+        return adalErrorResult;
+    }
 }

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/ADALError.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/ADALError.java
@@ -1,0 +1,22 @@
+package com.microsoft.identity.common.test.automation.questions;
+
+import com.microsoft.identity.common.test.automation.model.ADALErrorResult;
+import com.microsoft.identity.common.test.automation.model.ResultsMapper;
+import com.microsoft.identity.common.test.automation.ui.Results;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.questions.Text;
+
+public class ADALError implements Question<String> {
+    @Override
+    public String answeredBy(Actor actor) {
+        String results = Text.of(Results.RESULT_FIELD).viewedBy(actor).asString();
+        ADALErrorResult adalErrorResult = ResultsMapper.GetADALErrorResultFromString(results);
+        return adalErrorResult.error;
+    }
+
+    public static Question<String> displayed(){
+        return new ADALError();
+    }
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
@@ -1,5 +1,6 @@
 package com.microsoft.identity.common.test.automation.questions;
 
+import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.model.ReadCacheResult;
 import com.microsoft.identity.common.test.automation.model.ResultsMapper;
 import com.microsoft.identity.common.test.automation.ui.Results;
@@ -13,6 +14,8 @@ public class AccessToken implements Question<String> {
     public String answeredBy(Actor actor) {
         String results = Text.of(Results.RESULT_FIELD).viewedBy(actor).asString();
         ReadCacheResult readCacheResult = ResultsMapper.GetReadCacheResultFromString(results);
+        User user = (User) actor;
+        user.setCacheResult(readCacheResult.tokenCacheItems.get(0));
         return readCacheResult.tokenCacheItems.get(0).accessToken;
     }
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
@@ -3,6 +3,7 @@ package com.microsoft.identity.common.test.automation.questions;
 import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.model.ReadCacheResult;
 import com.microsoft.identity.common.test.automation.model.ResultsMapper;
+import com.microsoft.identity.common.test.automation.model.TokenCacheItemReadResult;
 import com.microsoft.identity.common.test.automation.ui.Results;
 
 import net.serenitybdd.screenplay.Actor;
@@ -16,7 +17,15 @@ public class AccessToken implements Question<String> {
         ReadCacheResult readCacheResult = ResultsMapper.GetReadCacheResultFromString(results);
         User user = (User) actor;
         user.setCacheResult(readCacheResult.tokenCacheItems.get(0));
-        return readCacheResult.tokenCacheItems.get(0).accessToken;
+        //TODO : Understand why access token could be null in a cache item
+        String accessToken = null;
+        for(TokenCacheItemReadResult readResult :  readCacheResult.tokenCacheItems){
+            if(readResult.accessToken != null){
+                accessToken = readResult.accessToken;
+                break;
+            }
+        }
+        return accessToken;
     }
 
     public static Question<String>  displayed(){

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/AccessToken.java
@@ -17,7 +17,6 @@ public class AccessToken implements Question<String> {
         ReadCacheResult readCacheResult = ResultsMapper.GetReadCacheResultFromString(results);
         User user = (User) actor;
         user.setCacheResult(readCacheResult.tokenCacheItems.get(0));
-        //TODO : Understand why access token could be null in a cache item
         String accessToken = null;
         for(TokenCacheItemReadResult readResult :  readCacheResult.tokenCacheItems){
             if(readResult.accessToken != null){

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/TokenCacheItemCount.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/TokenCacheItemCount.java
@@ -1,14 +1,16 @@
 package com.microsoft.identity.common.test.automation.questions;
 
-import com.microsoft.identity.common.internal.net.ObjectMapper;
 import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.model.ReadCacheResult;
 import com.microsoft.identity.common.test.automation.model.ResultsMapper;
+import com.microsoft.identity.common.test.automation.model.TokenCacheItemReadResult;
 import com.microsoft.identity.common.test.automation.ui.Results;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Question;
 import net.serenitybdd.screenplay.questions.Text;
+
+import java.util.List;
 
 public class TokenCacheItemCount implements Question<Integer> {
 
@@ -16,8 +18,11 @@ public class TokenCacheItemCount implements Question<Integer> {
     public Integer answeredBy(Actor actor) {
         String results = Text.of(Results.RESULT_FIELD).viewedBy(actor).asString();
         ReadCacheResult readCacheResult = ResultsMapper.GetReadCacheResultFromString(results);
-        User user = (User) actor;
-        user.setCacheResult(readCacheResult.tokenCacheItems.get(0));
+        List<TokenCacheItemReadResult> tokenCacheItems= readCacheResult.tokenCacheItems;
+        if(tokenCacheItems!=null && !tokenCacheItems.isEmpty()) {
+            User user = (User) actor;
+            user.setCacheResult(readCacheResult.tokenCacheItems.get(0));
+        }
         return readCacheResult.itemCount;
     }
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/TokenCacheItemCount.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/questions/TokenCacheItemCount.java
@@ -1,6 +1,7 @@
 package com.microsoft.identity.common.test.automation.questions;
 
 import com.microsoft.identity.common.internal.net.ObjectMapper;
+import com.microsoft.identity.common.test.automation.actors.User;
 import com.microsoft.identity.common.test.automation.model.ReadCacheResult;
 import com.microsoft.identity.common.test.automation.model.ResultsMapper;
 import com.microsoft.identity.common.test.automation.ui.Results;
@@ -15,6 +16,8 @@ public class TokenCacheItemCount implements Question<Integer> {
     public Integer answeredBy(Actor actor) {
         String results = Text.of(Results.RESULT_FIELD).viewedBy(actor).asString();
         ReadCacheResult readCacheResult = ResultsMapper.GetReadCacheResultFromString(results);
+        User user = (User) actor;
+        user.setCacheResult(readCacheResult.tokenCacheItems.get(0));
         return readCacheResult.itemCount;
     }
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
@@ -32,8 +32,12 @@ public class AcquireToken implements Task{
     public <T extends Actor> void performAs(T actor) {
         User user = (User) actor;
         TokenRequest tokenRequest = user.getTokenRequest();
-        tokenRequest.setPromptBehavior(prompt);
-        tokenRequest.setUserIdentitfier(userIdentifier);
+        if(!TextUtils.isEmpty(prompt)) {
+            tokenRequest.setPromptBehavior(prompt);
+        }
+        if(!TextUtils.isEmpty(userIdentifier)) {
+            tokenRequest.setUserIdentitfier(userIdentifier);
+        }
         SignInUser signInUser = SignInUser.GetSignInUserByFederationProvider(user.getFederationProvider());
 
         actor.attemptsTo(

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireToken.java
@@ -26,14 +26,16 @@ public class AcquireToken implements Task{
 
     String prompt;
     String userIdentifier;
+    boolean tokenExists;
 
     @Override
     public <T extends Actor> void performAs(T actor) {
-        User user = (User)actor;
+        User user = (User) actor;
         TokenRequest tokenRequest = user.getTokenRequest();
         tokenRequest.setPromptBehavior(prompt);
         tokenRequest.setUserIdentitfier(userIdentifier);
         SignInUser signInUser = SignInUser.GetSignInUserByFederationProvider(user.getFederationProvider());
+
         actor.attemptsTo(
                 WaitUntil.the(Main.ACQUIRE_TOKEN_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Main.ACQUIRE_TOKEN_BUTTON),
@@ -42,17 +44,18 @@ public class AcquireToken implements Task{
                 WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Request.SUBMIT_REQUEST_BUTTON)
         );
-
-        // If userIdentifier was not provided in acquire token call , attempt to enter username for sign in
-        if(TextUtils.isEmpty(userIdentifier)){
-            actor.attemptsTo(
-                    WaitUntil.the(SignInPageUserName.USERNAME, isVisible()).forNoMoreThan(10).seconds(),
-                    new EnterUserNameForSignInDisambiguation(),
-                    WaitUntil.the(SignInPagePassword.PASSWORD, isVisible()).forNoMoreThan(10).seconds()
-            );
+        // // acquire token does an interactive flow there is no token
+        if (!tokenExists) {
+            // If userIdentifier was not provided in acquire token call , attempt to enter username for sign in
+            if (TextUtils.isEmpty(userIdentifier)) {
+                actor.attemptsTo(
+                        WaitUntil.the(SignInPageUserName.USERNAME, isVisible()).forNoMoreThan(10).seconds(),
+                        new EnterUserNameForSignInDisambiguation(),
+                        WaitUntil.the(SignInPagePassword.PASSWORD, isVisible()).forNoMoreThan(10).seconds()
+                );
+            }
+            actor.attemptsTo(signInUser);
         }
-
-        actor.attemptsTo(signInUser);
     }
 
     public AcquireToken withPrompt(String prompt){
@@ -62,6 +65,11 @@ public class AcquireToken implements Task{
 
     public AcquireToken withUserIdentifier(String userIdentifier){
         this.userIdentifier = userIdentifier;
+        return this;
+    }
+
+    public AcquireToken tokenExists(boolean tokenExists) {
+        this.tokenExists = tokenExists;
         return this;
     }
 

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
@@ -18,6 +18,7 @@ import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisi
 public class AcquireTokenSilent implements Task{
 
     private String userIdentifier;
+    private String uniqueId;
 
     @Steps
     CloseKeyboard closeKeyboard;
@@ -27,6 +28,7 @@ public class AcquireTokenSilent implements Task{
         User user = (User)actor;
         TokenRequest tokenRequest = user.getTokenRequest();
         tokenRequest.setUserIdentitfier(userIdentifier);
+        tokenRequest.setUniqueUserId(uniqueId);
         actor.attemptsTo(
                 WaitUntil.the(Main.ACQUIRE_TOKEN_SILENT, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Main.ACQUIRE_TOKEN_SILENT),
@@ -34,6 +36,11 @@ public class AcquireTokenSilent implements Task{
                 closeKeyboard,
                 Click.on(Request.SUBMIT_REQUEST_BUTTON)
         );
+    }
+
+    public AcquireTokenSilent withUniqueId(String uniqueId){
+        this.uniqueId = uniqueId;
+        return this;
     }
 
     public AcquireTokenSilent withUserIdentifier(String userIdentifier){

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
@@ -21,6 +21,7 @@ public class AcquireTokenSilent implements Task{
 
     private String userIdentifier;
     private String uniqueId;
+    private String authority;
 
     @Steps
     CloseKeyboard closeKeyboard;
@@ -32,7 +33,7 @@ public class AcquireTokenSilent implements Task{
         if(!TextUtils.isEmpty(userIdentifier)) {
             tokenRequest.setUserIdentitfier(userIdentifier);
         }
-        if(TextUtils.isEmpty(uniqueId)) {
+        if(!TextUtils.isEmpty(uniqueId)) {
             tokenRequest.setUniqueUserId(uniqueId);
         }
         actor.attemptsTo(

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/AcquireTokenSilent.java
@@ -13,6 +13,8 @@ import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.waits.WaitUntil;
 import net.thucydides.core.annotations.Steps;
 
+import org.apache.http.util.TextUtils;
+
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 public class AcquireTokenSilent implements Task{
@@ -27,11 +29,16 @@ public class AcquireTokenSilent implements Task{
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         TokenRequest tokenRequest = user.getTokenRequest();
-        tokenRequest.setUserIdentitfier(userIdentifier);
-        tokenRequest.setUniqueUserId(uniqueId);
+        if(!TextUtils.isEmpty(userIdentifier)) {
+            tokenRequest.setUserIdentitfier(userIdentifier);
+        }
+        if(TextUtils.isEmpty(uniqueId)) {
+            tokenRequest.setUniqueUserId(uniqueId);
+        }
         actor.attemptsTo(
                 WaitUntil.the(Main.ACQUIRE_TOKEN_SILENT, isVisible()).forNoMoreThan(10).seconds(),
                 Click.on(Main.ACQUIRE_TOKEN_SILENT),
+
                 Enter.theValue(user.getSilentTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
                 closeKeyboard,
                 Click.on(Request.SUBMIT_REQUEST_BUTTON)

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireATAndInvalidateRT.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireATAndInvalidateRT.java
@@ -1,0 +1,40 @@
+package com.microsoft.identity.common.test.automation.tasks;
+
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
+import com.microsoft.identity.common.test.automation.ui.Main;
+import com.microsoft.identity.common.test.automation.ui.Request;
+import com.microsoft.identity.common.test.automation.utility.TokenRequest;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+import net.thucydides.core.annotations.Steps;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
+
+public class ExpireATAndInvalidateRT implements Task {
+
+    @Steps
+    CloseKeyboard closeKeyboard;
+
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        User user = (User)actor;
+        TokenRequest tokenRequest = user.getTokenRequest();
+        tokenRequest.setAuthority(user.getCacheResult().authority);
+        tokenRequest.setUserIdentitfier(user.getCredential().userName);
+        tokenRequest.setUniqueUserId(user.getCacheResult().uniqueUserId);
+        tokenRequest.setTenantId(user.getCacheResult().tenantId);
+      actor.attemptsTo(
+              WaitUntil.the(Main.EXPIRE_AT_INVALIDATE_RT,  isVisible()).forNoMoreThan(10).seconds(),
+              Click.on(Main.EXPIRE_AT_INVALIDATE_RT),
+              Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
+              closeKeyboard,
+              WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
+              Click.on(Request.SUBMIT_REQUEST_BUTTON)
+     );
+    }
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
@@ -29,7 +29,7 @@ public class ExpireAccessToken implements Task {
       actor.attemptsTo(
               WaitUntil.the(Main.EXPIRE_ACCESS_TOKEN,  isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Main.EXPIRE_ACCESS_TOKEN),
-              Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
+              Enter.theValue(user.getCacheResultAsJson()).into(Request.REQUEST_INFO_FIELD),
               closeKeyboard,
               WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Request.SUBMIT_REQUEST_BUTTON)

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
@@ -31,7 +31,7 @@ public class ExpireAccessToken implements Task {
         actor.attemptsTo(
               WaitUntil.the(Main.EXPIRE_ACCESS_TOKEN,  isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Main.EXPIRE_ACCESS_TOKEN),
-              Enter.theValue(user.getCacheResultAsJson()).into(Request.REQUEST_INFO_FIELD),
+              Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
               closeKeyboard,
               WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Request.SUBMIT_REQUEST_BUTTON)

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
@@ -24,12 +24,14 @@ public class ExpireAccessToken implements Task {
     public <T extends Actor> void performAs(T actor) {
         User user = (User)actor;
         TokenRequest tokenRequest = user.getTokenRequest();
-        tokenRequest.setAuthority("https://login.windows.net/common");
+        tokenRequest.setAuthority(user.getCacheResult().authority);
         tokenRequest.setUserIdentitfier(user.getCredential().userName);
+        tokenRequest.setUniqueUserId(user.getCacheResult().uniqueUserId);
+        tokenRequest.setTenantId(user.getCacheResult().tenantId);
       actor.attemptsTo(
               WaitUntil.the(Main.EXPIRE_ACCESS_TOKEN,  isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Main.EXPIRE_ACCESS_TOKEN),
-              Enter.theValue(user.getCacheResultAsJson()).into(Request.REQUEST_INFO_FIELD),
+              Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
               closeKeyboard,
               WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Request.SUBMIT_REQUEST_BUTTON)

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
@@ -28,10 +28,10 @@ public class ExpireAccessToken implements Task {
         tokenRequest.setUserIdentitfier(user.getCredential().userName);
         tokenRequest.setUniqueUserId(user.getCacheResult().uniqueUserId);
         tokenRequest.setTenantId(user.getCacheResult().tenantId);
-      actor.attemptsTo(
+        actor.attemptsTo(
               WaitUntil.the(Main.EXPIRE_ACCESS_TOKEN,  isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Main.EXPIRE_ACCESS_TOKEN),
-              Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
+              Enter.theValue(user.getCacheResultAsJson()).into(Request.REQUEST_INFO_FIELD),
               closeKeyboard,
               WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
               Click.on(Request.SUBMIT_REQUEST_BUTTON)

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/tasks/ExpireAccessToken.java
@@ -1,0 +1,38 @@
+package com.microsoft.identity.common.test.automation.tasks;
+
+import com.microsoft.identity.common.test.automation.actors.User;
+import com.microsoft.identity.common.test.automation.interactions.CloseKeyboard;
+import com.microsoft.identity.common.test.automation.ui.Main;
+import com.microsoft.identity.common.test.automation.ui.Request;
+import com.microsoft.identity.common.test.automation.utility.TokenRequest;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.waits.WaitUntil;
+import net.thucydides.core.annotations.Steps;
+
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
+
+public class ExpireAccessToken implements Task {
+
+    @Steps
+    CloseKeyboard closeKeyboard;
+
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        User user = (User)actor;
+        TokenRequest tokenRequest = user.getTokenRequest();
+        tokenRequest.setAuthority("https://login.windows.net/common");
+        tokenRequest.setUserIdentitfier(user.getCredential().userName);
+      actor.attemptsTo(
+              WaitUntil.the(Main.EXPIRE_ACCESS_TOKEN,  isVisible()).forNoMoreThan(10).seconds(),
+              Click.on(Main.EXPIRE_ACCESS_TOKEN),
+              Enter.theValue(user.getTokenRequestAsJson()).into(Request.REQUEST_INFO_FIELD),
+              closeKeyboard,
+              WaitUntil.the(Request.SUBMIT_REQUEST_BUTTON, isVisible()).forNoMoreThan(10).seconds(),
+              Click.on(Request.SUBMIT_REQUEST_BUTTON)
+      );
+    }
+}

--- a/automation/src/test/java/com/microsoft/identity/common/test/automation/utility/TokenRequest.java
+++ b/automation/src/test/java/com/microsoft/identity/common/test/automation/utility/TokenRequest.java
@@ -32,6 +32,8 @@ public class TokenRequest {
     private String mUserIdentifierType = null;
     @SerializedName("unique_id")
     private String mUniqueUserId = null;
+    @SerializedName("tenant_id")
+    private String mTenantId;
 
 
     public String getClientId() {
@@ -120,5 +122,13 @@ public class TokenRequest {
 
     public void setUniqueUserId(String uniqueUserId){
         this.mUniqueUserId = uniqueUserId;
+    }
+
+    public String getTenantId(){
+        return mTenantId;
+    }
+
+    public void setTenantId(String tenantId){
+        mTenantId = tenantId;
     }
 }

--- a/automationtestapp/build.gradle
+++ b/automationtestapp/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     adalImplementation project(':adal')
     //msalRImplementation group: 'com.microsoft.identity.client', name: 'msal', version: "$rootProject.ext.msal"
     adalRImplementation group: 'com.microsoft.aad', name: 'adal', version: "$rootProject.ext.adalLegacy"
+    implementation project(":common")
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     androidTestImplementation "junit:junit:$rootProject.ext.junitVersion"

--- a/automationtestapp/src/main/java/com/microsoft/aad/automation/testapp/SignInActivity.java
+++ b/automationtestapp/src/main/java/com/microsoft/aad/automation/testapp/SignInActivity.java
@@ -81,7 +81,7 @@ public class SignInActivity extends AppCompatActivity {
     public static final String TENANT_ID = "tenant_id";
     public static final String USER_IDENTIFIER_TYPE = "user_identifier_type";
     public static final String CORRELATION_ID = "correlation_id";
-    public static final String FAMLIY_CLIENT_ID = "family_client_id";
+    public static final String FAMLIY_CLIENT_ID = "foci";
 
     static final String INVALID_REFRESH_TOKEN = "some invalid refresh token";
 
@@ -248,8 +248,10 @@ public class SignInActivity extends AppCompatActivity {
             throw new IllegalArgumentException("redirect_uri");
         }
 
-        if (flowCode == MainActivity.INVALIDATE_ACCESS_TOKEN && TextUtils.isEmpty(inputItems.get(USER_IDENTIFIER))) {
-            throw new IllegalArgumentException("user identifier");
+        if (flowCode == MainActivity.INVALIDATE_ACCESS_TOKEN &&
+                (TextUtils.isEmpty(inputItems.get(USER_IDENTIFIER))
+                        && TextUtils.isEmpty(inputItems.get(UNIQUE_ID)) && TextUtils.isEmpty(inputItems.get(DISPLAYABLE_ID)))) {
+            throw new IllegalArgumentException("user identifier, unique id or displayable id");
         }
     }
 
@@ -317,9 +319,11 @@ public class SignInActivity extends AppCompatActivity {
         final ITokenCacheStore tokenCacheStore = mAuthenticationContext.getCache();
         int count = 0;
         for (String userId : getCacheIdentifiers()) {
-            String cacheKeyRT = createCacheKeyForRTEntry(mAuthority, mResource, mClientId, userId);
-            final TokenCacheItem tokenCacheItemRT = tokenCacheStore.getItem(cacheKeyRT);
-            count += tokenExpired(tokenCacheItemRT, cacheKeyRT, tokenCacheStore);
+            if(!TextUtils.isEmpty(mResource)) {
+                String cacheKeyRT = createCacheKeyForRTEntry(mAuthority, mResource, mClientId, userId);
+                final TokenCacheItem tokenCacheItemRT = tokenCacheStore.getItem(cacheKeyRT);
+                count += tokenExpired(tokenCacheItemRT, cacheKeyRT, tokenCacheStore);
+            }
 
             String cacheKeyMRRT = createCacheKeyForMRRT(mAuthority, mClientId, userId);
             final TokenCacheItem tokenCacheItemMRRT = tokenCacheStore.getItem(cacheKeyMRRT);
@@ -331,8 +335,6 @@ public class SignInActivity extends AppCompatActivity {
                 count += tokenExpired(tokenCacheItemFRRT, cacheKeyFRT, tokenCacheStore);
             }
         }
-
-
         return count;
     }
 

--- a/automationtestapp/src/main/java/com/microsoft/aad/automation/testapp/SignInActivity.java
+++ b/automationtestapp/src/main/java/com/microsoft/aad/automation/testapp/SignInActivity.java
@@ -265,11 +265,9 @@ public class SignInActivity extends AppCompatActivity {
         mExtraQueryParam = inputItems.get(EXTRA_QUERY_PARAM);
         mValidateAuthority = inputItems.get(VALIDATE_AUTHORITY) == null ? true : Boolean.valueOf(
                 inputItems.get(VALIDATE_AUTHORITY));
-
         if (!TextUtils.isEmpty(inputItems.get(UNIQUE_ID))) {
             mUserId = inputItems.get(UNIQUE_ID);
         }
-
         if (!TextUtils.isEmpty(inputItems.get(DISPLAYABLE_ID)) || !TextUtils.isEmpty(inputItems.get("user_identifier"))) {
             mLoginHint = inputItems.get(DISPLAYABLE_ID) == null ? inputItems.get("user_identifier") : inputItems.get("displayable_id");
         }


### PR DESCRIPTION
- Added a test case AcquireTokenSilentAfterExpireAT 
- Added a test case AcquireTokenAfterExpireAT
- Changes to the automation app to create cache keys w.r.t to new Common cache changes
- Added the token result to User object. It is used to expire Access token