### PR TITLE
Shoatman add client info to refresh token request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-26.0.2
+    - build-tools-27.0.3
     - android-25
     - android-21
     - extra

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -136,7 +136,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
         html.enabled = true
     }
 
-    jacocoClasspath = configurations['androidJacocoAnt']
+    jacocoClasspath = configurations['jacocoAnt']
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*', '**/AuthenticationConstants*.*', '**/IBrokerAccountService*.*', '**/EventStrings.class']
     def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2286,6 +2286,7 @@ public final class AuthenticationContextTest {
 
         final String response = "{\"access_token\":\"accesstoken"
                 + "\",\"token_type\":\"Bearer\",\"expires_in\":\"29344\",\"expires_on\":\"1368768616\","
+                + "\"resource\":1,"
                 + "\"refresh_token\":\""
                 + "refreshToken" + "\",\"scope\":\"*\",\"id_token\":\"" + TEST_IDTOKEN + "\", \"client_info\":\"" + Util.TEST_CLIENT_INFO + "\"}";
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
@@ -2330,8 +2331,6 @@ public final class AuthenticationContextTest {
 
         assertEquals("Token is returned from refresh token request", expectedAT,
                 callback.getAuthenticationResult().getAccessToken());
-        assertFalse("Multiresource is not set in the mocked response",
-                callback.getAuthenticationResult().getIsMultiResourceRefreshToken());
 
         // Same call again to use it from cache
         signal = new CountDownLatch(1);
@@ -2344,21 +2343,6 @@ public final class AuthenticationContextTest {
 
         assertEquals("Same token in response as in cache for same call", expectedAT,
                 callback.getAuthenticationResult().getAccessToken());
-
-        // Empty userid will prompt.
-        // Items are linked to userid. If it is not there, it can't use for
-        // refresh or access token.
-        signal = new CountDownLatch(1);
-        testActivity = new MockActivity(signal);
-        callback = new MockAuthenticationCallback(signal);
-        context.acquireToken(testActivity.getTestActivity(), resource, "ClienTid", "redirectUri", "", callback);
-        signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
-
-        assertNull("Result is null since it tries to start activity",
-                callback.getAuthenticationResult());
-        assertEquals("Activity was attempted to start.",
-                AuthenticationConstants.UIRequest.BROWSER_FLOW,
-                testActivity.mStartActivityRequestCode);
 
         clearCache(context);
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -361,7 +361,7 @@ public class OauthTests {
         final Oauth2 oauth2 = createOAuthInstance(request);
         assertEquals(
                 "Token request",
-                "grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&resource=resource%2520+",
+                "grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+",
                 oauth2.buildRefreshTokenRequestMessage("refreshToken23434="));
 
         // without resource
@@ -372,7 +372,7 @@ public class OauthTests {
         final Oauth2 oauthWithoutResource = createOAuthInstance(requestWithoutResource);
         assertEquals(
                 "Token request",
-                "grant_type=refresh_token&refresh_token=refreshToken234343455%3D&client_id=client+1234567890-%2B%3D%3B%27",
+                "grant_type=refresh_token&refresh_token=refreshToken234343455%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1",
                 oauthWithoutResource.buildRefreshTokenRequestMessage("refreshToken234343455="));
     }
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -159,10 +159,11 @@ final class Util {
 
     static byte[] getPoseMessage(final String refreshToken, final String clientId, final String resource)
             throws UnsupportedEncodingException {
-        return String.format("%s=%s&%s=%s&%s=%s&%s=%s",
+        return String.format("%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
                 AuthenticationConstants.OAuth2.GRANT_TYPE, urlFormEncode(AuthenticationConstants.OAuth2.REFRESH_TOKEN),
                 AuthenticationConstants.OAuth2.REFRESH_TOKEN, urlFormEncode(refreshToken),
                 AuthenticationConstants.OAuth2.CLIENT_ID, urlFormEncode(clientId),
+                AuthenticationConstants.OAuth2.CLIENT_INFO, urlFormEncode(AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE),
                 AuthenticationConstants.AAD.RESOURCE, urlFormEncode(resource)).getBytes();
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -222,7 +222,7 @@ class Oauth2 {
     public String buildRefreshTokenRequestMessage(String refreshToken)
             throws UnsupportedEncodingException {
         Logger.v(TAG, "Building request message for redeeming token with refresh token.");
-        String message = String.format("%s=%s&%s=%s&%s=%s",
+        String message = String.format("%s=%s&%s=%s&%s=%s&%s=%s",
                 AuthenticationConstants.OAuth2.GRANT_TYPE,
                 StringExtensions.urlFormEncode(AuthenticationConstants.OAuth2.REFRESH_TOKEN),
 
@@ -230,7 +230,12 @@ class Oauth2 {
                 StringExtensions.urlFormEncode(refreshToken),
 
                 AuthenticationConstants.OAuth2.CLIENT_ID,
-                StringExtensions.urlFormEncode(mRequest.getClientId()));
+                StringExtensions.urlFormEncode(mRequest.getClientId()
+                ),
+
+                AuthenticationConstants.OAuth2.CLIENT_INFO,
+                AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE
+        );
 
         if (!StringExtensions.isNullOrBlank(mRequest.getResource())) {
             message = String.format("%s&%s=%s", message, AuthenticationConstants.AAD.RESOURCE,

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -327,7 +327,7 @@ class TokenCacheAccessor {
         AzureActiveDirectory ad = new AzureActiveDirectory();
         AzureActiveDirectoryTokenResponse tokenResponse = CoreAdapter.asAadTokenResponse(result);
         AzureActiveDirectoryOAuth2Configuration config = new AzureActiveDirectoryOAuth2Configuration();
-        config.setAuthorityHostValdiationEnabled(this.isValidateAuthorityHost());
+        config.setAuthorityHostValidationEnabled(this.isValidateAuthorityHost());
         AzureActiveDirectoryOAuth2Strategy strategy = ad.createOAuth2Strategy(config);
         AzureActiveDirectoryAuthorizationRequest request = new AzureActiveDirectoryAuthorizationRequest();
         request.setClientId(clientId);

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -300,7 +300,7 @@ class TokenCacheAccessor {
             return;
         }
 
-        if (mUseCommonCache == true) {
+        if (mUseCommonCache && !UrlExtensions.isADFSAuthority(new URL(mAuthority))) {
             updateTokenCacheUsingCommonCache(resource, clientId, result);
             return;
         }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath "com.android.tools.build:gradle:$rootProject.ext.gradleVersion"
         classpath "com.github.dcendents:android-maven-gradle-plugin:$rootProject.ext.androidMavenGradlePluginVersion"
         classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:$rootProject.ext.gradleVersion"
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath "com.github.dcendents:android-maven-gradle-plugin:$rootProject.ext.androidMavenGradlePluginVersion"
         classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
     }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,7 +5,7 @@ ext {
     automationAppMinSDKVersion = 21
     targetSdkVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "26.0.2"
+    buildToolsVersion = "27.0.3"
 
     // Plugins
     gradleVersion = "3.0.1"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,7 +8,7 @@ ext {
     buildToolsVersion = "27.0.3"
 
     // Plugins
-    gradleVersion = "3.0.1"
+    gradleVersion = "3.1.2"
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 20 07:21:39 PST 2018
+#Wed May 23 06:25:42 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.microsoft.aad.adal.userappwithbroker"
@@ -16,10 +15,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+    buildToolsVersion '27.0.3'
 }
 
 dependencies {
     // Compile Dependencies
-    compile "com.android.support:design:$rootProject.ext.supportLibraryVersion"
-    compile project(':adal')
+    implementation "com.android.support:design:$rootProject.ext.supportLibraryVersion"
+    implementation project(':adal')
 }

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -15,7 +15,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
-    buildToolsVersion '27.0.3'
+    buildToolsVersion rootProject.ext.buildToolsVersion
 }
 
 dependencies {


### PR DESCRIPTION
Added client_info to token response.  
Corrected unit tests broken by this change and by the change in common for null user cache entry.