### PR TITLE
Issue 1115 - Resiliency fix to not crash the app

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2286,6 +2286,7 @@ public final class AuthenticationContextTest {
 
         final String response = "{\"access_token\":\"accesstoken"
                 + "\",\"token_type\":\"Bearer\",\"expires_in\":\"29344\",\"expires_on\":\"1368768616\","
+                + "\"resource\":1,"
                 + "\"refresh_token\":\""
                 + "refreshToken" + "\",\"scope\":\"*\",\"id_token\":\"" + TEST_IDTOKEN + "\", \"client_info\":\"" + Util.TEST_CLIENT_INFO + "\"}";
         final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
@@ -2330,8 +2331,6 @@ public final class AuthenticationContextTest {
 
         assertEquals("Token is returned from refresh token request", expectedAT,
                 callback.getAuthenticationResult().getAccessToken());
-        assertFalse("Multiresource is not set in the mocked response",
-                callback.getAuthenticationResult().getIsMultiResourceRefreshToken());
 
         // Same call again to use it from cache
         signal = new CountDownLatch(1);
@@ -2344,21 +2343,6 @@ public final class AuthenticationContextTest {
 
         assertEquals("Same token in response as in cache for same call", expectedAT,
                 callback.getAuthenticationResult().getAccessToken());
-
-        // Empty userid will prompt.
-        // Items are linked to userid. If it is not there, it can't use for
-        // refresh or access token.
-        signal = new CountDownLatch(1);
-        testActivity = new MockActivity(signal);
-        callback = new MockAuthenticationCallback(signal);
-        context.acquireToken(testActivity.getTestActivity(), resource, "ClienTid", "redirectUri", "", callback);
-        signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
-
-        assertNull("Result is null since it tries to start activity",
-                callback.getAuthenticationResult());
-        assertEquals("Activity was attempted to start.",
-                AuthenticationConstants.UIRequest.BROWSER_FLOW,
-                testActivity.mStartActivityRequestCode);
 
         clearCache(context);
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2659,6 +2659,32 @@ public final class AuthenticationContextTest {
         }
     }
 
+    @Test
+    public void testDeserializeMissingAuthority() {
+        final String missingAttributeString = "{\"tokenCacheItems\":[{\"refresh_token\":\"FRT\",\"foci\":\"1\"}],\"version\":1}";
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
+        try {
+            context.deserialize(missingAttributeString);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
+        }
+    }
+
+    @Test
+    public void testDeserializeMissingClientId() {
+        final String missingAttributeString = "{\"tokenCacheItems\":[{\"authority\":\"https://login.windows.net/ComMon/\",\"refresh_token\":\"FRT\"}],\"version\":1}";
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
+        try {
+            context.deserialize(missingAttributeString);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
+        }
+    }
+
     /**
      * Test the deserialize() function where the deserialize input is a json
      * token which has one additional attribute. The function is expected to

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1280,8 +1280,7 @@ public class AuthenticationContext {
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
         if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
                 (StringExtensions.isNullOrBlank(tokenCacheItem.getClientId()) && StringExtensions.isNullOrBlank(tokenCacheItem.getFamilyClientId()))) {
-            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT,
-                    "Failed to import the serialized blob because authority or client id is null/empty.");
+            throw new DeserializationAuthenticationException("Failed to deserialize the blob because authority or client id is null/empty.");
         }
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,10 +1278,10 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
-        if(tokenCacheItem==null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
-                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())){
-            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT, "Failed to import the serialized blob "
-                    + "because authority or client id is null/empty.");
+        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
+                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())) {
+            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT,
+                    "Failed to import the serialized blob because authority or client id is null/empty.");
         }
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,6 +1278,11 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
+        if(tokenCacheItem==null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
+                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())){
+            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT, "Failed to import the serialized blob "
+                    + "because authority or client id is null/empty.");
+        }
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,8 +1278,8 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
-        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
-                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())) {
+        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
+                (StringExtensions.isNullOrBlank(tokenCacheItem.getClientId()) && StringExtensions.isNullOrBlank(tokenCacheItem.getFamilyClientId()))) {
             throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT,
                     "Failed to import the serialized blob because authority or client id is null/empty.");
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/CoreAdapter.java
@@ -64,7 +64,7 @@ final class CoreAdapter {
         return new UserInfo(
                 account.getUserId(),
                 account.getName(),
-                account.getLastName(),
+                account.getFamilyName(),
                 account.getIdentityProvider(),
                 account.getDisplayableId()
         );

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -327,7 +327,7 @@ class TokenCacheAccessor {
         AzureActiveDirectory ad = new AzureActiveDirectory();
         AzureActiveDirectoryTokenResponse tokenResponse = CoreAdapter.asAadTokenResponse(result);
         AzureActiveDirectoryOAuth2Configuration config = new AzureActiveDirectoryOAuth2Configuration();
-        config.setAuthorityHostValdiationEnabled(this.isValidateAuthorityHost());
+        config.setAuthorityHostValidationEnabled(this.isValidateAuthorityHost());
         AzureActiveDirectoryOAuth2Strategy strategy = ad.createOAuth2Strategy(config);
         AzureActiveDirectoryAuthorizationRequest request = new AzureActiveDirectoryAuthorizationRequest();
         request.setClientId(clientId);

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -397,7 +397,7 @@ class TokenCacheAccessor {
         final List<TokenCacheItem> regularRTsMatchingRequest = new ArrayList<>();
         while (allItems.hasNext()) {
             final TokenCacheItem tokenCacheItem = allItems.next();
-            if (tokenCacheItem.getAuthority().equalsIgnoreCase(mAuthority) && clientId.equalsIgnoreCase(tokenCacheItem.getClientId())
+            if (mAuthority.equalsIgnoreCase(tokenCacheItem.getAuthority()) && clientId.equalsIgnoreCase(tokenCacheItem.getClientId())
                     && resource.equalsIgnoreCase(tokenCacheItem.getResource()) && !tokenCacheItem.getIsMultiResourceRefreshToken()) {
                 regularRTsMatchingRequest.add(tokenCacheItem);
             }


### PR DESCRIPTION
Added validation checks for authority and clientid when constructing TokenCacheItem from SSOStateSerializer
Flipped the comparision check for authority in isMultipleRTsMatchingGivenAppAndResource method