### PR TITLE
Issue 1115-Resiliency fix to not crash the app

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2610,34 +2610,42 @@ public final class AuthenticationContextTest {
      * Test the deserialize() function where the deserialize input is null. The
      * function is expected to throw IllegalArgumentException
      */
-    @Test
-    public void testDeserializeNullSerializedBlob() {
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeserializeNullSerializedBlob() throws AuthenticationException {
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         addFRTCacheItem(mockCache);
         final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
-        try {
-            context.deserialize(null);
-        } catch (final Exception exception) {
-            assertTrue("argument exception", exception instanceof IllegalArgumentException);
-        }
+        context.deserialize(null);
+    }
+
+    /**
+     * Test the deserialize() function where the deserialize input is a json
+     * token which has no tokencacheitems . The function is expected to
+     * throw AuthenticationException
+     *
+     * @throws AuthenticationException
+     */
+    @Test(expected = AuthenticationException.class)
+    public void testDeserializeNoTokenCacheItem() throws AuthenticationException {
+        final String additionalAttributeString = "{\"version\":1}";
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
+        context.deserialize(additionalAttributeString);
     }
 
     /**
      * Test the deserialize() function where the deserialize input is a random
      * string. The function is expected to throw AuthenticationException
      */
-    @Test
-    public void testDeserializeRandomString() {
+    @Test(expected = DeserializationAuthenticationException.class)
+    public void testDeserializeRandomString() throws AuthenticationException {
         final String ramdomString = "abc";
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
-        try {
-            context.deserialize(ramdomString);
-        } catch (final Exception exception) {
-            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
-        }
+        context.deserialize(ramdomString);
     }
 
     /**
@@ -2646,43 +2654,43 @@ public final class AuthenticationContextTest {
      * the tokenCacheItem. The function is expected to throw
      * AuthenticationException
      */
-    @Test
-    public void testDeserializeMissingAttribute() {
+    @Test(expected = DeserializationAuthenticationException.class)
+    public void testDeserializeMissingAttribute() throws AuthenticationException {
         final String missingAttributeString = "{\"tokenCacheItems\":[{\"authority\":\"https://login.windows.net/ComMon/\",\"refresh_token\":\"FRT\",\"foci\":\"1\"}],\"version\":1}";
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
-        try {
-            context.deserialize(missingAttributeString);
-        } catch (final Exception exception) {
-            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
-        }
+        context.deserialize(missingAttributeString);
     }
 
-    @Test
-    public void testDeserializeMissingAuthority() {
+    /**
+     * Test the deserialize() function where the deserialize input is a json
+     * token which missing authority which is needed in the deserialization of
+     * the tokenCacheItem. The function is expected to throw
+     * DeserializationAuthenticationException
+     */
+    @Test(expected = DeserializationAuthenticationException.class)
+    public void testDeserializeMissingAuthority() throws AuthenticationException {
         final String missingAttributeString = "{\"tokenCacheItems\":[{\"refresh_token\":\"FRT\",\"foci\":\"1\"}],\"version\":1}";
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
-        try {
-            context.deserialize(missingAttributeString);
-        } catch (final Exception exception) {
-            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
-        }
+        context.deserialize(missingAttributeString);
     }
 
-    @Test
-    public void testDeserializeMissingClientId() {
+    /**
+     * Test the deserialize() function where the deserialize input is a json
+     * token which missing Client Id which is needed in the deserialization of
+     * the tokenCacheItem. The function is expected to throw
+     * DeserializationAuthenticationException
+     */
+    @Test(expected = DeserializationAuthenticationException.class)
+    public void testDeserializeMissingClientId() throws AuthenticationException {
         final String missingAttributeString = "{\"tokenCacheItems\":[{\"authority\":\"https://login.windows.net/ComMon/\",\"refresh_token\":\"FRT\"}],\"version\":1}";
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
-        try {
-            context.deserialize(missingAttributeString);
-        } catch (final Exception exception) {
-            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
-        }
+        context.deserialize(missingAttributeString);
     }
 
     /**
@@ -2707,17 +2715,13 @@ public final class AuthenticationContextTest {
      * with expected one. The calling should throw the
      * DeserializationAuthenticationException
      */
-    @Test
-    public void testDeserializeDifferentVersion() {
+    @Test(expected = DeserializationAuthenticationException.class)
+    public void testDeserializeDifferentVersion() throws AuthenticationException {
         final String differentVersionString = "{\"tokenCacheItems\":[{\"authority\":\"https://login.windows.net/ComMon/\",\"refresh_token\":\"FRT\",\"id_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiJlNzBiMTE1ZS1hYzBhLTQ4MjMtODVkYS04ZjRiN2I0ZjAwZTYiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwibmJmIjoxMzc2NDI4MzEwLCJleHAiOjEzNzY0NTcxMTAsInZlciI6IjEuMCIsInRpZCI6IjMwYmFhNjY2LThkZjgtNDhlNy05N2U2LTc3Y2ZkMDk5NTk2MyIsIm9pZCI6IjRmODU5OTg5LWEyZmYtNDExZS05MDQ4LWMzMjIyNDdhYzYyYyIsInVwbiI6ImFkbWluQGFhbHRlc3RzLm9ubWljcm9zb2Z0LmNvbSIsInVuaXF1ZV9uYW1lIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwic3ViIjoiVDU0V2hGR1RnbEJMN1VWYWtlODc5UkdhZEVOaUh5LXNjenNYTmFxRF9jNCIsImZhbWlseV9uYW1lIjoiU2VwZWhyaSIsImdpdmVuX25hbWUiOiJBZnNoaW4ifQ.\",\"foci\":\"1\"}],\"version\":2}";
         final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
         final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
-        try {
-            context.deserialize(differentVersionString);
-        } catch (final Exception exception) {
-            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
-        }
+        context.deserialize(differentVersionString);
     }
 
     private String getErrorResponseBody(final String errorCode) {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2659,6 +2659,32 @@ public final class AuthenticationContextTest {
         }
     }
 
+    @Test
+    public void testDeserializeMissingAuthority() {
+        final String missingAttributeString = "{\"tokenCacheItems\":[{\"refresh_token\":\"FRT\",\"foci\":\"1\"}],\"version\":1}";
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
+        try {
+            context.deserialize(missingAttributeString);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
+        }
+    }
+
+    @Test
+    public void testDeserializeMissingClientId() {
+        final String missingAttributeString = "{\"tokenCacheItems\":[{\"authority\":\"https://login.windows.net/ComMon/\",\"refresh_token\":\"FRT\"}],\"version\":1}";
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final DefaultTokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
+        try {
+            context.deserialize(missingAttributeString);
+        } catch (final Exception exception) {
+            assertTrue("argument exception", exception instanceof DeserializationAuthenticationException);
+        }
+    }
+
     /**
      * Test the deserialize() function where the deserialize input is a json
      * token which has one additional attribute. The function is expected to

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,8 +1278,8 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
-        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
-                (StringExtensions.isNullOrBlank(tokenCacheItem.getClientId()) && StringExtensions.isNullOrBlank(tokenCacheItem.getFamilyClientId()))) {
+        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
+                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())) {
             throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT,
                     "Failed to import the serialized blob because authority or client id is null/empty.");
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,6 +1278,11 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
+        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
+                (StringExtensions.isNullOrBlank(tokenCacheItem.getClientId()) && StringExtensions.isNullOrBlank(tokenCacheItem.getFamilyClientId()))) {
+            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT,
+                    "Failed to import the serialized blob because authority or client id is null/empty.");
+        }
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,10 +1278,10 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
-        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
-                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())) {
-            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT,
-                    "Failed to import the serialized blob because authority or client id is null/empty.");
+        if(tokenCacheItem==null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
+                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())){
+            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT, "Failed to import the serialized blob "
+                    + "because authority or client id is null/empty.");
         }
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,7 +1278,7 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
-        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
+        if (StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
                 (StringExtensions.isNullOrBlank(tokenCacheItem.getClientId()) && StringExtensions.isNullOrBlank(tokenCacheItem.getFamilyClientId()))) {
             throw new DeserializationAuthenticationException("Failed to deserialize the blob because authority or client id is null/empty.");
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1278,10 +1278,9 @@ public class AuthenticationContext {
         // first, we'll fall back to passed in authority host and all the aliased hosts if necessary; If app receives the blob has the old
         // version of adal, since all the apps using token share library are using login.windows.net, token lookup will keep working.
         final TokenCacheItem tokenCacheItem = SSOStateSerializer.deserialize(serializedBlob);
-        if(tokenCacheItem==null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority())
-                || StringExtensions.isNullOrBlank(tokenCacheItem.getClientId())){
-            throw new UsageAuthenticationException(ADALError.FAIL_TO_IMPORT, "Failed to import the serialized blob "
-                    + "because authority or client id is null/empty.");
+        if (tokenCacheItem == null || StringExtensions.isNullOrBlank(tokenCacheItem.getAuthority()) ||
+                (StringExtensions.isNullOrBlank(tokenCacheItem.getClientId()) && StringExtensions.isNullOrBlank(tokenCacheItem.getFamilyClientId()))) {
+            throw new DeserializationAuthenticationException("Failed to deserialize the blob because authority or client id is null/empty.");
         }
         final String cacheKey = CacheKey.createCacheKey(tokenCacheItem);
         this.getCache().setItem(cacheKey, tokenCacheItem);

--- a/adal/src/main/java/com/microsoft/aad/adal/SSOStateSerializer.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/SSOStateSerializer.java
@@ -120,7 +120,7 @@ final class SSOStateSerializer {
      * @return TokenCacheItem
      * @throws AuthenticationException
      */
-    private TokenCacheItem internalDeserialize(String serializedBlob) throws AuthenticationException {
+    private TokenCacheItem internalDeserialize(final String serializedBlob) throws AuthenticationException {
         try {
             final JSONObject jsonObject = new JSONObject(serializedBlob);
             if (jsonObject.getInt("version") == this.getVersion()) {
@@ -160,7 +160,7 @@ final class SSOStateSerializer {
      * @return TokenCacheItem
      * @throws AuthenticationException
      */
-    static TokenCacheItem deserialize(String serializedBlob) throws AuthenticationException {
+    static TokenCacheItem deserialize(final String serializedBlob) throws AuthenticationException {
         SSOStateSerializer ssoStateSerializer = new SSOStateSerializer();
         return ssoStateSerializer.internalDeserialize(serializedBlob);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -397,7 +397,7 @@ class TokenCacheAccessor {
         final List<TokenCacheItem> regularRTsMatchingRequest = new ArrayList<>();
         while (allItems.hasNext()) {
             final TokenCacheItem tokenCacheItem = allItems.next();
-            if (tokenCacheItem.getAuthority().equalsIgnoreCase(mAuthority) && clientId.equalsIgnoreCase(tokenCacheItem.getClientId())
+            if (mAuthority.equalsIgnoreCase(tokenCacheItem.getAuthority()) && clientId.equalsIgnoreCase(tokenCacheItem.getClientId())
                     && resource.equalsIgnoreCase(tokenCacheItem.getResource()) && !tokenCacheItem.getIsMultiResourceRefreshToken()) {
                 regularRTsMatchingRequest.add(tokenCacheItem);
             }


### PR DESCRIPTION
Added validation checks for authority and clientid when constructing TokenCacheItem from SSOStateSerializer
Flipped the comparision check for authority in isMultipleRTsMatchingGivenAppAndResource method
Unit test cases