### PR TITLE
Addressed cache item deletion issue due to authority not being updated to preferred cache one

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -328,11 +328,11 @@ public final class AcquireTokenSilentHandlerTest {
         Mockito.verify(mockedWebRequestHandler).sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(), webRequestHandlerArgument.capture(), Mockito.anyString());
         assertTrue(Arrays.equals(postMessage, webRequestHandlerArgument.getValue()));
 
-        // verify regular token entry not existed
-        assertNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_USERID)));
-        assertNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_UPN)));
+        // verify that RT is not deleted as the token is different from the MRRT token
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_USERID)));
+        assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, resource, clientId, TEST_IDTOKEN_UPN)));
 
-        // verify MRRT entry exist
+        // verify MRRT entry is deleted
         assertNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_USERID)));
         assertNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(VALID_AUTHORITY, clientId, TEST_IDTOKEN_UPN)));
 

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -290,8 +290,9 @@ class TokenCacheAccessor {
             try {
                 mAuthority = getAuthorityUrlWithPreferredCache();
             } catch (final MalformedURLException e) {
-                //TODO : Understand what can be done here
-                Logger.d(TAG + methodName, "Authority from preferred caches is invalid");
+                // This should never happen. If the exception is thrown, mAuthority will  have the value passed from the request.
+                com.microsoft.identity.common.internal.logging.Logger.error(TAG, "Authority from preferred cache is invalid", null);
+                com.microsoft.identity.common.internal.logging.Logger.errorPII(TAG, "Failed with Exception", e);
             }
             // remove Item if oauth2_error is invalid_grant
             Logger.v(TAG + methodName, "Received INVALID_GRANT error code, remove existing cache entry.");
@@ -393,9 +394,8 @@ class TokenCacheAccessor {
         }
 
         for (final String key : keys) {
-          // mTokenCacheStore.removeItem(key);
             TokenCacheItem cacheItem = mTokenCacheStore.getItem(key);
-            if(cacheItem!=null && cacheItem.getRefreshToken().equals(toBeDeletedCacheItem.getRefreshToken())) {
+            if (cacheItem != null && cacheItem.getRefreshToken().equals(toBeDeletedCacheItem.getRefreshToken())) {
                 mTokenCacheStore.removeItem(key);
             }
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -289,9 +289,9 @@ class TokenCacheAccessor {
             // make sure to set authority to the one in preferred cache
             try {
                 mAuthority = getAuthorityUrlWithPreferredCache();
-            }catch (MalformedURLException e){
+            } catch (final MalformedURLException e) {
                 //TODO : Understand what can be done here
-                Logger.d(TAG + methodName,  "Authority from preferred caches is invalid");
+                Logger.d(TAG + methodName, "Authority from preferred caches is invalid");
             }
             // remove Item if oauth2_error is invalid_grant
             Logger.v(TAG + methodName, "Received INVALID_GRANT error code, remove existing cache entry.");
@@ -393,6 +393,7 @@ class TokenCacheAccessor {
         }
 
         for (final String key : keys) {
+          // mTokenCacheStore.removeItem(key);
             TokenCacheItem cacheItem = mTokenCacheStore.getItem(key);
             if(cacheItem!=null && cacheItem.getRefreshToken().equals(toBeDeletedCacheItem.getRefreshToken())) {
                 mTokenCacheStore.removeItem(key);

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -286,6 +286,13 @@ class TokenCacheAccessor {
                 throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, e.getMessage(), e);
             }
         } else if (AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(result.getErrorCode())) {
+            // make sure to set authority to the one in preferred cache
+            try {
+                mAuthority = getAuthorityUrlWithPreferredCache();
+            }catch (MalformedURLException e){
+                //TODO : Understand what can be done here
+                Logger.d(TAG + methodName,  "Authority from preferred caches is invalid");
+            }
             // remove Item if oauth2_error is invalid_grant
             Logger.v(TAG + methodName, "Received INVALID_GRANT error code, remove existing cache entry.");
             removeTokenCacheItem(cachedItem, resource);
@@ -347,7 +354,7 @@ class TokenCacheAccessor {
      *
      * @throws AuthenticationException
      */
-    void removeTokenCacheItem(final TokenCacheItem tokenCacheItem, final String resource)
+    void removeTokenCacheItem(final TokenCacheItem toBeDeletedCacheItem, final String resource)
             throws AuthenticationException {
         final String methodName = ":removeTokenCacheItem";
         final CacheEvent cacheEvent = new CacheEvent(EventStrings.TOKEN_CACHE_DELETE);
@@ -355,23 +362,23 @@ class TokenCacheAccessor {
         Telemetry.getInstance().startEvent(mTelemetryRequestId, EventStrings.TOKEN_CACHE_DELETE);
 
         final List<String> keys;
-        final TokenEntryType tokenEntryType = tokenCacheItem.getTokenEntryType();
+        final TokenEntryType tokenEntryType = toBeDeletedCacheItem.getTokenEntryType();
         switch (tokenEntryType) {
 
             case REGULAR_TOKEN_ENTRY:
                 cacheEvent.setTokenTypeRT(true);
                 Logger.v(TAG + methodName, "Regular RT was used to get access token, remove entries "
                         + "for regular RT entries.");
-                keys = getKeyListToRemoveForRT(tokenCacheItem);
+                keys = getKeyListToRemoveForRT(toBeDeletedCacheItem);
                 break;
             case MRRT_TOKEN_ENTRY:
                 // We delete both MRRT and RT in this case.
                 cacheEvent.setTokenTypeMRRT(true);
                 Logger.v(TAG + methodName, "MRRT was used to get access token, remove entries for both "
                         + "MRRT entries and regular RT entries.");
-                keys = getKeyListToRemoveForMRRT(tokenCacheItem);
+                keys = getKeyListToRemoveForMRRT(toBeDeletedCacheItem);
 
-                final TokenCacheItem regularRTItem = new TokenCacheItem(tokenCacheItem);
+                final TokenCacheItem regularRTItem = new TokenCacheItem(toBeDeletedCacheItem);
                 regularRTItem.setResource(resource);
                 keys.addAll(getKeyListToRemoveForRT(regularRTItem));
                 break;
@@ -379,14 +386,17 @@ class TokenCacheAccessor {
                 cacheEvent.setTokenTypeFRT(true);
                 Logger.v(TAG + methodName, "FRT was used to get access token, remove entries for "
                         + "FRT entries.");
-                keys = getKeyListToRemoveForFRT(tokenCacheItem);
+                keys = getKeyListToRemoveForFRT(toBeDeletedCacheItem);
                 break;
             default:
                 throw new AuthenticationException(ADALError.INVALID_TOKEN_CACHE_ITEM);
         }
 
         for (final String key : keys) {
-            mTokenCacheStore.removeItem(key);
+            TokenCacheItem cacheItem = mTokenCacheStore.getItem(key);
+            if(cacheItem!=null && cacheItem.getRefreshToken().equals(toBeDeletedCacheItem.getRefreshToken())) {
+                mTokenCacheStore.removeItem(key);
+            }
         }
         Telemetry.getInstance().stopEvent(mTelemetryRequestId, cacheEvent,
                 EventStrings.TOKEN_CACHE_DELETE);


### PR DESCRIPTION
Changes to ensure if we delete cache items only if the target refresh token matches.
TODO: Understand and make changes if needed on a MalformedURLException on getAuthorityUrlWithPreferredCache() method.
