### PR TITLE
Updates README instructions for submodule/common use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To build with Gradle,
 * Go to the root folder where you cloned this repo
 * To run the sample app, connect the test device and run the command: `./gradlew :userappwithbroker:installDebug`
 * You should see app 'Fancy ADAL Test App' installed on the test device
-* Select an authority, [optionally] enter a login hint and/or query parameters, and clikc `Acquire Token` to enter credentials with AAD
+* Select an authority, [optionally] enter a login hint and/or query parameters, and click `Acquire Token` to enter credentials with AAD
 
 To build with Maven, you can use the pom.xml at top level
 

--- a/README.md
+++ b/README.md
@@ -67,18 +67,18 @@ To build with Gradle,
 * Clone this repo in to a directory of your choice
 * Setup emulator with SDK 23
 * Go to the root folder where you cloned this repo
-* To run the sample app, connect the test device and run the command: `./gradlew :sample:installDebug`
-* You should see app 'hello' installed in the test device
-* Enter test user credentials to try
+* To run the sample app, connect the test device and run the command: `./gradlew :userappwithbroker:installDebug`
+* You should see app 'Fancy ADAL Test App' installed on the test device
+* Select an authority, [optionally] enter a login hint and/or query parameters, and clikc `Acquire Token` to enter credentials with AAD
 
 To build with Maven, you can use the pom.xml at top level
 
 * Clone this repo in to a directory of your choice
-* Follow the steps at [Prerequests section to setup your maven for android](https://github.com/MSOpenTech/azure-activedirectory-library-for-android/wiki/Setting-up-maven-environment-for-Android)
+* Follow the steps at [Prerequisites section to setup your maven for android](https://github.com/AzureAD/azure-activedirectory-library-for-android/wiki/Maven)
 * Setup emulator with SDK 19
 * Go to the root folder where you cloned this repo
 * Run the command: `mvn clean install`
-* Change the directory to the Quick Start sample: `cd samples\hello`
+* Change the directory to the Quick Start sample: `cd userappwithbroker/`
 * Run the command: `mvn android:deploy android:run`
 * You should see app launching
 * Enter test user credentials to try!

--- a/README.md
+++ b/README.md
@@ -92,18 +92,14 @@ We've made it easy for you to have multiple options to use this library in your 
 * You can use the source code to import this library into Android Studio and link to your application.
 * If using Android Studio, you can use *aar* package format and reference the binaries.
 
-### Option 1: Source Zip
-
-To download a copy of the source code, click "Download ZIP" on the right side of the page or click [here](https://github.com/AzureAD/azure-activedirectory-library-for-android/archive/v1.1.5.tar.gz).
-
-### Option 2: Source via Git
+### Option 1: Source via Git
 
 To get the source code of the SDK via git:
 
-    git clone git@github.com:AzureAD/azure-activedirectory-library-for-android.git
+    git clone --recurse-submodules git@github.com:AzureAD/azure-activedirectory-library-for-android.git
     cd ./azure-activedirectory-library-for-android/src
 
-### Option 3: Binaries via Gradle
+### Option 2: Binaries via Gradle
 
 You can get the binaries from Maven central repo. AAR package can be included as follows in your project in AndroidStudio:
 
@@ -126,7 +122,7 @@ dependencies {
 }
 ```
 
-### Option 4: aar via Maven
+### Option 3: aar via Maven
 
 If you are using the m2e plugin in Eclipse, you can specify the dependency in your pom.xml file:
 
@@ -139,7 +135,7 @@ If you are using the m2e plugin in Eclipse, you can specify the dependency in yo
 </dependency>
 ```
 
-### Option 5: jar package inside libs folder
+### Option 4: jar package inside libs folder
 
 You can get the jar file from maven the repo and drop into the *libs* folder in your project. You need to copy the required resources to your project as well since the jar packages don't include them.
 


### PR DESCRIPTION
This change updates the `README` with instructions for including ADAL in your project.

The include-as-zip option has been removed because it's incredibly _easy_ to **mess up**.
Brief explanation:
- Downloading as zip via GitHub doesn't include the submodule, only an empty directory
- The submodule/branch/SHA being used by ADAL is contingent on the branch being used
- The submodule ref in `.gitmodules` may not necessarily `ref` to `HEAD`, so you'd have to navigate to the proper commit in the version tree before download **OR** `git clone` it (which is what we were trying to prevent having to do in the first place)

`git clone` avoids all of these headaches. Just do that!