### PR TITLE
Adding POM task back to ADAL

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -159,7 +159,7 @@ task createPom  {
             name 'adal'
 
             description 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-            url 'https://github.com/MSOpenTech/azure-activedirectory-library-for-android'
+            url 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
 
             developers {
                 developer {
@@ -181,7 +181,7 @@ task createPom  {
             }
 
             scm {
-                url "https://github.com/MSOpenTech/azure-activedirectory-library-for-android/tree/master"
+                url "https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master"
             }
         }
     }.writeTo("${archivesBaseName}-${version}.pom")

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -149,6 +149,44 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
     ])
 }
 
+task createPom  {
+    pom {
+        project {
+            groupId 'com.microsoft.aad'
+            artifactId 'adal'
+            version = project.version
+            packaging 'aar'
+            name 'adal'
+
+            description 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+            url 'https://github.com/MSOpenTech/azure-activedirectory-library-for-android'
+
+            developers {
+                developer {
+                    id 'microsoft'
+                    name 'Microsoft'
+                }
+            }
+
+            licenses {
+                license {
+                    name 'MIT License'
+                }
+            }
+            inceptionYear '2014'
+
+            properties {
+                branch 'master'
+                adalVersion = project.version
+            }
+
+            scm {
+                url "https://github.com/MSOpenTech/azure-activedirectory-library-for-android/tree/master"
+            }
+        }
+    }.writeTo("${archivesBaseName}-${version}.pom")
+}
+
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
@@ -303,7 +341,7 @@ task checkstyle(type: Checkstyle) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
-        task.dependsOn 'checkstyle', 'pmd', 'lint'
+        task.dependsOn 'checkstyle', 'pmd', 'lint', 'createPom'
         task.finalizedBy 'findbugs'
     }
 }


### PR DESCRIPTION
Issue https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1185 

Todo : Test the POM task once common is published to maven central and added as a dependency to ADAL. Created a task here : https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1217
