### PR TITLE
Pass AuthenticationException to waitingRequestOnError

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -856,8 +856,7 @@ class AcquireTokenRequest {
                                                     + ' ' + Log.getStackTraceString(authenticationException),
                                             ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,
                                             null);
-                                    waitingRequestOnError(callbackHandle, waitingRequest, requestId,
-                                            null);
+                                    waitingRequestOnError(callbackHandle, waitingRequest, requestId, authenticationException);
                                 }
                             }
                         });


### PR DESCRIPTION
Need to investigate [this point](https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1032#discussion_r194083384). Reverts change in #1032 `AcquireTokenRequest#onActivityResult` to pass `null` to `waitingRequestOnError`.

A second PR is coming for potential `1.14.1` release branch