### PR TITLE
Updates constructor call to AccountCredentialCache & submodule commit

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -26,6 +26,7 @@ import android.content.Context;
 
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.cache.ADALOAuth2TokenCache;
 import com.microsoft.identity.common.internal.cache.AccountCredentialCache;
@@ -34,6 +35,7 @@ import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
 import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Configuration;
@@ -49,6 +51,7 @@ import java.util.List;
 import static com.microsoft.aad.adal.TokenEntryType.FRT_TOKEN_ENTRY;
 import static com.microsoft.aad.adal.TokenEntryType.MRRT_TOKEN_ENTRY;
 import static com.microsoft.aad.adal.TokenEntryType.REGULAR_TOKEN_ENTRY;
+import static com.microsoft.identity.common.internal.cache.AccountCredentialCache.ACCOUNT_CREDENTIAL_SHARED_PREFERENCES;
 
 /**
  * Internal class handling the interaction with {@link AcquireTokenSilentHandler} and {@link ITokenCacheStore}.
@@ -87,8 +90,12 @@ class TokenCacheAccessor {
 
         // Set up the MsalAuth2TokenCache
         final IAccountCredentialCache accountCredentialCache = new AccountCredentialCache(
-                appContext,
-                new CacheKeyValueDelegate()
+                new CacheKeyValueDelegate(),
+                new SharedPreferencesFileManager(
+                        appContext,
+                        ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
+                        new StorageHelper(appContext)
+                )
         );
         final MsalOAuth2TokenCache msalOAuth2TokenCache =
                 new MsalOAuth2TokenCache(

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -36,6 +36,8 @@ import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
 import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Configuration;
@@ -86,7 +88,7 @@ class TokenCacheAccessor {
         mTelemetryRequestId = telemetryRequestId;
 
         //Setup common cache implementation
-        List<IShareSingleSignOnState> sharedSSOCaches = new ArrayList<IShareSingleSignOnState>();
+        List<IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken>> sharedSSOCaches = new ArrayList<>();
 
         // Set up the MsalAuth2TokenCache
         final IAccountCredentialCache accountCredentialCache = new AccountCredentialCache(

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -53,7 +53,7 @@ import java.util.List;
 import static com.microsoft.aad.adal.TokenEntryType.FRT_TOKEN_ENTRY;
 import static com.microsoft.aad.adal.TokenEntryType.MRRT_TOKEN_ENTRY;
 import static com.microsoft.aad.adal.TokenEntryType.REGULAR_TOKEN_ENTRY;
-import static com.microsoft.identity.common.internal.cache.AccountCredentialCache.ACCOUNT_CREDENTIAL_SHARED_PREFERENCES;
+import static com.microsoft.identity.common.internal.cache.AccountCredentialCache.DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES;
 
 /**
  * Internal class handling the interaction with {@link AcquireTokenSilentHandler} and {@link ITokenCacheStore}.
@@ -95,7 +95,7 @@ class TokenCacheAccessor {
                 new CacheKeyValueDelegate(),
                 new SharedPreferencesFileManager(
                         appContext,
-                        ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
+                        DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
                         new StorageHelper(appContext)
                 )
         );


### PR DESCRIPTION
This PR supports the work in [`common/#124`](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/124).

Updates `TokenCacheAccessor` to support the new constructor API for `AccountCredentialCache` and revs the submodule commit