### PR TITLE
Handling for Intune Policy Required errors

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
@@ -208,6 +208,11 @@ public enum ADALError {
     AUTH_FAILED_USER_MISMATCH("User returned by service does not match the one in the request"),
 
     /**
+     * Intune App Protection Policy required.
+     */
+    AUTH_FAILED_INTUNE_POLICY_REQUIRED("Intune App Protection Policy required"),
+
+    /**
      * Internet permissions are not set for the app.
      */
     DEVICE_INTERNET_IS_NOT_AVAILABLE("Internet permissions are not set for the app"),

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -39,7 +39,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -542,25 +541,23 @@ class BrokerProxy implements IBrokerProxy {
         }
     }
 
-    @NonNull
     private AuthenticationException getAuthenticationExceptionForResult(final String oauth2ErrorCode, final String oauth2ErrorDescription,
                                                                         final Bundle bundleResult) {
         final String message = "Received error from broker, errorCode: " + oauth2ErrorCode + "; ErrorDescription: " + oauth2ErrorDescription;
 
-        // check the request body for the "unauthorized_client" error and the "protection_policy_required" suberror
+        // check the response body for the "unauthorized_client" error and the "protection_policy_required" suberror
         final Serializable responseBody = bundleResult.getSerializable(AuthenticationConstants.OAuth2.HTTP_RESPONSE_BODY);
         if (null != responseBody && responseBody instanceof HashMap) {
             final HashMap<String, String> responseMap = (HashMap<String, String>) responseBody;
-            final String error = responseMap.get("error");
-            final String suberror = responseMap.get("suberror");
-            if ("unauthorized_client".compareTo(error) == 0 &&
-                    "protection_policy_required".compareTo(suberror) == 0) {
+            final String error = responseMap.get(AuthenticationConstants.OAuth2.ERROR);
+            final String suberror = responseMap.get(AuthenticationConstants.OAuth2.SUBERROR);
+            if (AuthenticationConstants.OAuth2ErrorCode.UNAUTHORIZED_CLIENT.compareTo(error) == 0 &&
+                    AuthenticationConstants.OAuth2ErrorCode.PROTECTION_POLICY_REQUIRED.compareTo(suberror) == 0) {
 
-                // TODO: update all strings to use shared constants
-                final String accountUpn = bundleResult.getString("accountupn");
-                final String accountUserId = bundleResult.getString("accountuniqueid");
-                final String tenantId = bundleResult.getString("tenantid");
-                final String authorityUrl = bundleResult.getString("authority");
+                final String accountUpn = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_NAME);
+                final String accountUserId = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID);
+                final String tenantId = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID);
+                final String authorityUrl = bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_AUTHORITY);
 
                 AuthenticationException exception = new IntuneAppProtectionPolicyRequiredException(
                         message, accountUpn, accountUserId, tenantId, authorityUrl);

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -39,6 +39,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -481,8 +482,7 @@ class BrokerProxy implements IBrokerProxy {
 
             throw new AuthenticationException(adalErrorCode, msg);
         } else if (!StringExtensions.isNullOrBlank(oauth2ErrorCode) && request.isSilent()) {
-            final AuthenticationException exception = new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED,
-                    "Received error from broker, errorCode: " + oauth2ErrorCode + "; ErrorDescription: " + oauth2ErrorDescription);
+            final AuthenticationException exception = getAuthenticationExceptionForResult(oauth2ErrorCode, oauth2ErrorDescription, bundleResult);
             final Serializable responseBody = bundleResult.getSerializable(AuthenticationConstants.OAuth2.HTTP_RESPONSE_BODY);
             final Serializable responseHeaders = bundleResult.getSerializable(AuthenticationConstants.OAuth2.HTTP_RESPONSE_HEADER);
             if (null != responseBody && responseBody instanceof HashMap) {
@@ -540,6 +540,36 @@ class BrokerProxy implements IBrokerProxy {
 
             return result;
         }
+    }
+
+    @NonNull
+    private AuthenticationException getAuthenticationExceptionForResult(final String oauth2ErrorCode, final String oauth2ErrorDescription,
+                                                                        final Bundle bundleResult) {
+        final String message = "Received error from broker, errorCode: " + oauth2ErrorCode + "; ErrorDescription: " + oauth2ErrorDescription;
+
+        // check the request body for the "unauthorized_client" error and the "protection_policy_required" suberror
+        final Serializable responseBody = bundleResult.getSerializable(AuthenticationConstants.OAuth2.HTTP_RESPONSE_BODY);
+        if (null != responseBody && responseBody instanceof HashMap) {
+            final HashMap<String, String> responseMap = (HashMap<String, String>) responseBody;
+            final String error = responseMap.get("error");
+            final String suberror = responseMap.get("suberror");
+            if ("unauthorized_client".compareTo(error) == 0 &&
+                    "protection_policy_required".compareTo(suberror) == 0) {
+
+                // TODO: update all strings to use shared constants
+                final String accountUpn = bundleResult.getString("accountupn");
+                final String accountUserId = bundleResult.getString("accountuniqueid");
+                final String tenantId = bundleResult.getString("tenantid");
+                final String authorityUrl = bundleResult.getString("authority");
+
+                AuthenticationException exception = new IntuneAppProtectionPolicyRequiredException(
+                        message, accountUpn, accountUserId, tenantId, authorityUrl);
+
+                return exception;
+            }
+        }
+
+        return new AuthenticationException(ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED, message);
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/IntuneAppProtectionPolicyRequiredException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IntuneAppProtectionPolicyRequiredException.java
@@ -25,11 +25,41 @@ package com.microsoft.aad.adal;
 
 public class IntuneAppProtectionPolicyRequiredException extends AuthenticationException {
 
+    private final String mAccountUpn;
+    private final String mAccountUserId;
+    private final String mTenantId;
+    private final String mAuthorityUrl;
+
     /**
-     * @param msg Details related to the error such as query string, request
-     *                info
+     * @param msg           Details related to the error such as query string, request
+     *                      info
+     * @param accountUpn    The UPN of the account, needed for Intune MAM enrollment.
+     * @param accountUserId The unique ID of the account, needed for Intune MAM enrollment.
+     * @param tenantId      The tenant ID, needed of Intune MAM enrollment.
+     * @param authorityUrl  The authority URL, used by Intune MAM enrollment to support
+     *                      sovereign clouds.  If null, default public cloud will be used.
      */
-    public IntuneAppProtectionPolicyRequiredException(final String msg) {
+    public IntuneAppProtectionPolicyRequiredException(final String msg, String accountUpn, String accountUserId, String tenantId, String authorityUrl) {
         super(ADALError.AUTH_FAILED_INTUNE_POLICY_REQUIRED, msg);
+        this.mAccountUpn = accountUpn;
+        this.mAccountUserId = accountUserId;
+        this.mTenantId = tenantId;
+        this.mAuthorityUrl = authorityUrl;
+    }
+
+    public String getAccountUpn() {
+        return mAccountUpn;
+    }
+
+    public String getAccountUserId() {
+        return mAccountUserId;
+    }
+
+    public String getTenantId() {
+        return mTenantId;
+    }
+
+    public String getAuthorityURL() {
+        return mAuthorityUrl;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/IntuneAppProtectionPolicyRequiredException.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IntuneAppProtectionPolicyRequiredException.java
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+public class IntuneAppProtectionPolicyRequiredException extends AuthenticationException {
+
+    /**
+     * @param msg Details related to the error such as query string, request
+     *                info
+     */
+    public IntuneAppProtectionPolicyRequiredException(final String msg) {
+        super(ADALError.AUTH_FAILED_INTUNE_POLICY_REQUIRED, msg);
+    }
+}


### PR DESCRIPTION
Detect the Intune Policy Required errors and deserialize the additional parameters necessary for Intune MAM enrollment for the client app to use to gain compliance through the MAM SDK's API.

note: this changes depends on the constants added to the common library in this PR:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/154