### PR TITLE
Updated Adal target version to 27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ android:
     - platform-tools
     - tools
     - build-tools-27.0.3
-    - android-25
+    - android-27
     - android-21
     - extra
     - extra-android-m2repository
@@ -30,7 +30,7 @@ env:
       # This is to guaratee a clean gradle log
       - TERM=dumb
     matrix:
-      - ANDROID_SDKS=android-25 ANDROID_TARGET=android-25
+      - ANDROID_SDKS=android-27 ANDROID_TARGET=android-27
       
 before_install:
   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ android:
     - extra-android-m2repository
     - extra-google-m2repository
     - addon-google_apis-google-21
+    ## Emulator config ##
+    # The SDK version used for the emulator
+    - android-21
     #system images
     - sys-img-armeabi-v7a-android-21
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ android:
     - tools
     - build-tools-27.0.3
     - android-27
-    - android-21
     - extra
     - extra-android-m2repository
     - extra-google-m2repository

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,15 +3,15 @@ ext {
     // SDK
     minSdkVersion = 14
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 25
-    compileSdkVersion = 25
+    targetSdkVersion = 27
+    compileSdkVersion = 27
 
     // Plugins
     gradleVersion = "3.1.2"
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries
-    supportLibraryVersion = "25.4.0"
+    supportLibraryVersion = "27.1.1"
     junitVersion = "4.12"
     mockitoCoreVersion = "2.18.3"
     mockitoAndroidVersion = "2.18.3"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -7,7 +7,7 @@ ext {
     compileSdkVersion = 27
 
     // Plugins
-    gradleVersion = "3.1.2"
+    gradleVersion = "3.1.3"
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries
@@ -16,7 +16,7 @@ ext {
     mockitoCoreVersion = "2.18.3"
     mockitoAndroidVersion = "2.18.3"
     runnerVersion = "1.0.1"
-    gsonVersion = "2.8.1"
+    gsonVersion = "2.8.4"
     rulesVersion = "1.0.0"
     adalLegacy = "1.14.0"
     msal = "0.1.1"


### PR DESCRIPTION
Per this issue : https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1191
Updated the target 27 which is the latest stable version