### PR TITLE
Creates build variants 'local' and 'dist'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: android
 
-jdk: 
+jdk:
   - oraclejdk8
 
 # Don't use the Travis Container-Based Infrastructure
@@ -16,12 +16,14 @@ android:
     - platform-tools
     - tools
     - build-tools-27.0.3
-    - android-25
-    - android-21
+    - android-27
     - extra
     - extra-android-m2repository
     - extra-google-m2repository
     - addon-google_apis-google-21
+    ## Emulator config ##
+    # The SDK version used for the emulator
+    - android-21
     #system images
     - sys-img-armeabi-v7a-android-21
 
@@ -30,8 +32,8 @@ env:
       # This is to guaratee a clean gradle log
       - TERM=dumb
     matrix:
-      - ANDROID_SDKS=android-25 ANDROID_TARGET=android-25
-      
+      - ANDROID_SDKS=android-27 ANDROID_TARGET=android-27
+
 before_install:
   - chmod +x gradlew
 
@@ -53,4 +55,4 @@ before_script:
 
 script:
   - cd $PWD
-  - ./gradlew clean adal:assembleLocal adal:connectedLocalDebugAndroidTest -PdisablePreDex
+  - ./gradlew clean build connectedAndroidTest -PdisablePreDex

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ before_script:
 
 script:
   - cd $PWD
-  - ./gradlew clean adal:assembleAdal adal:connectedAdalDebugAndroidTest -PdisablePreDex
+  - ./gradlew clean adal:assembleLocal adal:connectedLocalDebugAndroidTest -PdisablePreDex

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ before_script:
 
 script:
   - cd $PWD
-  - ./gradlew clean build connectedAndroidTest -PdisablePreDex
+  - ./gradlew clean adal:assembleLocal adal:connectedLocalDebugAndroidTest -PdisablePreDex

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -186,6 +186,39 @@ publishing {
             version = project.version
 
             pom.withXml {
+                // Custom values
+
+                // Name
+                asNode().appendNode('name', 'adal')
+
+                // Description
+                asNode().appendNode(
+                        'description',
+                        'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+                )
+
+                // URL
+                asNode().appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android')
+
+                // Inception Year
+                asNode().appendNode('inceptionYear', '2014')
+
+                // Licenses
+                asNode().appendNode('licenses').appendNode('license').appendNode('name', 'MIT License')
+
+                // Developers
+                def developerNode = asNode().appendNode('developers').appendNode('developer')
+                developerNode.appendNode('id', 'microsoft')
+                developerNode.appendNode('name', 'Microsoft')
+
+                // SCM
+                asNode().appendNode('scm').appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master')
+
+                // Properties
+                def propertiesNode = asNode().appendNode('properties')
+                propertiesNode.appendNode('branch', 'master')
+                propertiesNode.appendNode('version', project.version)
+
                 def dependenciesNode = asNode().appendNode('dependencies')
 
                 def deps = configurations.implementation.allDependencies.asList()

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'com.android.library'
-// Add JaCoCo for coverage metrics
-apply plugin: 'jacoco'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
@@ -146,26 +144,6 @@ dependencies {
     // Javadoc Dependencies
     javadocDeps "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
     javadocDeps "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
-}
-
-task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-
-    jacocoClasspath = configurations['jacocoAnt']
-
-    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*', '**/AuthenticationConstants*.*', '**/IBrokerAccountService*.*', '**/EventStrings.class']
-    def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
-    def mainSrc = "${project.projectDir}/src/main/java"
-
-    sourceDirectories = files([mainSrc])
-    classDirectories = files([debugTree])
-    executionData = fileTree(dir: "$buildDir", includes: [
-            "jacoco/testDebugUnitTest.exec",
-            "outputs/code-coverage/connected/*coverage.ec"
-    ])
 }
 
 task sourcesJar(type: Jar) {

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -59,10 +59,17 @@ android {
     flavorDimensions "main"
 
     productFlavors {
-        adal{
-
+        // The 'local' productFlavor sources common from mavenLocal and is intended to be used
+        // during development.
+        local {
+            dimension "main"
+            versionNameSuffix "-local"
         }
-        adalR{
+
+        // The 'dist' productFlavor sources common from a central repository and is intended
+        // to be used for releases.
+        dist {
+            dimension "main"
         }
     }
 
@@ -103,40 +110,31 @@ android {
 }
 
 dependencies {
-    // Compile Dependencies
-    adalImplementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
-    adalImplementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
-    adalImplementation "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
-    adalImplementation "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
-    adalCompileOnly 'com.google.code.findbugs:annotations:3.0.1', {
+    // Dependencies required only at compile time
+    compileOnly 'com.google.code.findbugs:annotations:3.0.1', {
         // Need to exclude these, or build is broken by:
         //   com.android.dex.DexException: Multiple dex files define Ljavax/annotation/CheckForNull
         exclude module: 'jsr305'
         exclude module: 'jcip-annotations'
-    }
-    adalRImplementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
-    adalRImplementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
-    adalRImplementation "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
-    adalRImplementation "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
-    adalRCompileOnly 'com.google.code.findbugs:annotations:3.0.1', {
-        // Need to exclude these, or build is broken by:
-        //   com.android.dex.DexException: Multiple dex files define Ljavax/annotation/CheckForNull
-        exclude module: 'jsr305'
-        exclude module: 'jcip-annotations'
-    }
-    adalApi(project(":common")){
-        exclude group: 'com.google.code.gson', module: 'gson'
-        exclude group: 'com.android.support', module: 'appcompat-v7'
-        exclude group: 'com.nimbusds', module: 'nimbus-jose-jwt'
-        exclude group: 'org.mockito', module: 'mockito-core'
-        exclude group: 'com.google.dexmaker', module: 'dexmaker-mockito'
-        exclude group: 'org.powermock', module: 'powermock-module-junit4'
-        exclude group: 'org.powermock', module: 'powermock-module-junit4-rule'
-        exclude group: 'org.powermock', module: 'powermock-api-mockito'
-        exclude group: 'org.powermock', module: 'powermock-classloading-xstream'
     }
 
-    adalRImplementation "com.microsoft.identity:common:0.0.1"
+    // Dependencies
+    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
+    implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
+    implementation "com.android.support:support-annotations:$rootProject.ext.supportLibraryVersion"
+    implementation "com.android.support:support-v4:$rootProject.ext.supportLibraryVersion"
+
+    // 'local' flavor dependencies
+    localImplementation(project(":common")) {
+        transitive = false
+    }
+
+    // 'dist' flavor dependencies
+    //distImplementation "com.microsoft.identity:common:0.0.1"
+    // TODO delete below, uncomment above...
+    distImplementation(project(":common")) {
+        transitive = false
+    }
 
     // Android Instrumented Test Dependencies
     androidTestImplementation "com.android.support.test:runner:$rootProject.ext.runnerVersion"
@@ -172,7 +170,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
     ])
 }
 
-task createPom  {
+task createPom {
     pom {
         project {
             groupId 'com.microsoft.aad'
@@ -250,8 +248,11 @@ publishing {
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
 
+                def deps = configurations.implementation.allDependencies.asList()
+                deps.addAll(configurations.distImplementation.allDependencies.asList())
+
                 //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                configurations.adalRImplementation.allDependencies.each {
+                deps.each {
                     if (it.group != null && it.name != null) {
                         def dependencyNode = dependenciesNode.appendNode('dependency')
                         dependencyNode.appendNode('groupId', it.group)
@@ -315,7 +316,7 @@ task findbugs(type: FindBugs) {
     description 'Run findbugs'
     group 'verification'
 
-    classes = fileTree("$project.buildDir/intermediates/classes/adal/debug/")
+    classes = fileTree("$project.buildDir/intermediates/classes/local/debug/")
     source = fileTree('src/main/java')
     classpath = files()
     effort = 'max'

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -127,9 +127,10 @@ dependencies {
     }
 
     // 'dist' flavor dependencies
-    //distImplementation "com.microsoft.identity:common:0.0.1"
-    // TODO comment below, uncomment above...
-    localImplementation(project(":common")) {
+    // Once common is deployed to maven, uncomment the below line...
+    // distImplementation "com.microsoft.identity:common:0.0.1"
+    // and delete the 3 following lines....
+    distImplementation(project(":common")) {
         transitive = false
     }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.library'
 // Add JaCoCo for coverage metrics
 apply plugin: 'jacoco'
-// This plugin publishes adal in to the local maven repo
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
@@ -27,7 +25,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.github.dcendents:android-maven-gradle-plugin:$rootProject.ext.androidMavenGradlePluginVersion"
     }
 }
 
@@ -131,8 +128,8 @@ dependencies {
 
     // 'dist' flavor dependencies
     //distImplementation "com.microsoft.identity:common:0.0.1"
-    // TODO delete below, uncomment above...
-    distImplementation(project(":common")) {
+    // TODO comment below, uncomment above...
+    localImplementation(project(":common")) {
         transitive = false
     }
 
@@ -170,44 +167,6 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
     ])
 }
 
-task createPom {
-    pom {
-        project {
-            groupId 'com.microsoft.aad'
-            artifactId 'adal'
-            version = project.version
-            packaging 'aar'
-            name 'adal'
-
-            description 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-            url 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
-
-            developers {
-                developer {
-                    id 'microsoft'
-                    name 'Microsoft'
-                }
-            }
-
-            licenses {
-                license {
-                    name 'MIT License'
-                }
-            }
-            inceptionYear '2014'
-
-            properties {
-                branch 'master'
-                adalVersion = project.version
-            }
-
-            scm {
-                url "https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master"
-            }
-        }
-    }.writeTo("${archivesBaseName}-${version}.pom")
-}
-
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
@@ -220,6 +179,7 @@ task javadoc(type: Javadoc) {
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     classpath += configurations.javadocDeps
     exclude '**/*.aidl'
+
     if (JavaVersion.current().isJava8Compatible()) {
         allprojects {
             tasks.withType(Javadoc) {
@@ -227,6 +187,7 @@ task javadoc(type: Javadoc) {
             }
         }
     }
+
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
 }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -307,7 +307,7 @@ task checkstyle(type: Checkstyle) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
-        task.dependsOn 'checkstyle', 'pmd', 'lint', 'createPom'
+        task.dependsOn 'checkstyle', 'pmd', 'lint'
         task.finalizedBy 'findbugs'
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockWebRequestHandler.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockWebRequestHandler.java
@@ -105,4 +105,9 @@ class MockWebRequestHandler implements IWebRequestHandler {
     public void setRequestCorrelationId(UUID correlationId) {
         mCorrelationId = correlationId;
     }
+
+    @Override
+    public void setClientVersion(String clientVersion) {
+        // Wire up if needed.
+    }
 }

--- a/automationtestapp/build.gradle
+++ b/automationtestapp/build.gradle
@@ -28,13 +28,13 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
-    signingConfigs{
-      debug {
-              storeFile file('debug/debug.keystore')
-              storePassword "android"
-              keyAlias "androiddebugkey"
-              keyPassword "android"
-      }
+    signingConfigs {
+        debug {
+            storeFile file('debug/debug.keystore')
+            storePassword "android"
+            keyAlias "androiddebugkey"
+            keyPassword "android"
+        }
     }
 
     defaultConfig {
@@ -60,10 +60,10 @@ android {
     flavorDimensions "main"
 
     productFlavors {
-        adal{
-            applicationIdSuffix ".adal"
-            versionNameSuffix "-adalD"
-            resValue("string", "application_name", "adal")
+        local {
+            applicationIdSuffix ".local"
+            versionNameSuffix "-local"
+            resValue("string", "application_name", "adal-local")
         }
         /*
         //Leaving out MSAL support until i look into dynamically linking
@@ -73,10 +73,10 @@ android {
             resValue("string", "application_name", "msalR")
         }
         */
-        adalR{
-            applicationIdSuffix ".adalR"
-            versionNameSuffix "-adalR"
-            resValue("string", "application_name", "adalR")
+        dist {
+            applicationIdSuffix ".dist"
+            versionNameSuffix "-dist"
+            resValue("string", "application_name", "adal-dist")
         }
     }
 
@@ -90,9 +90,9 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
 
-    adalImplementation project(':adal')
-    //msalRImplementation group: 'com.microsoft.identity.client', name: 'msal', version: "$rootProject.ext.msal"
-    adalRImplementation group: 'com.microsoft.aad', name: 'adal', version: "$rootProject.ext.adalLegacy"
+    localImplementation project(':adal')
+    //distImplementation group: 'com.microsoft.identity.client', name: 'msal', version: "$rootProject.ext.msal"
+    distImplementation group: 'com.microsoft.aad', name: 'adal', version: "$rootProject.ext.adalLegacy"
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     androidTestImplementation "junit:junit:$rootProject.ext.junitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$rootProject.ext.gradleVersion"
-        classpath "com.github.dcendents:android-maven-gradle-plugin:$rootProject.ext.androidMavenGradlePluginVersion"
         classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
     }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,21 +3,20 @@ ext {
     // SDK
     minSdkVersion = 14
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 25
-    compileSdkVersion = 25
+    targetSdkVersion = 27
+    compileSdkVersion = 27
 
     // Plugins
-    gradleVersion = "3.1.2"
+    gradleVersion = "3.1.3"
 
     // Libraries
-    supportLibraryVersion = "25.4.0"
+    supportLibraryVersion = "27.1.1"
     junitVersion = "4.12"
     mockitoCoreVersion = "2.18.3"
     mockitoAndroidVersion = "2.18.3"
     runnerVersion = "1.0.1"
-    gsonVersion = "2.8.1"
+    gsonVersion = "2.8.4"
     rulesVersion = "1.0.0"
     adalLegacy = "1.14.0"
     msal = "0.1.1"
-
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,7 +8,7 @@ ext {
 
     // Plugins
     gradleVersion = "3.1.2"
-    androidMavenGradlePluginVersion = "1.4.1"
+    androidMavenGradlePluginVersion = "2.1"
 
     // Libraries
     supportLibraryVersion = "25.4.0"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,7 +8,6 @@ ext {
 
     // Plugins
     gradleVersion = "3.1.2"
-    androidMavenGradlePluginVersion = "2.1"
 
     // Libraries
     supportLibraryVersion = "25.4.0"

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -13,7 +13,7 @@ android {
 
     productFlavors {
         main {
-            matchingFallbacks = ['adal', 'adalR']
+            matchingFallbacks = ['local', 'dist']
         }
     }
 


### PR DESCRIPTION
Spiritually similar to #1231, but uses different names and removes the 3rd party library dependency.

To run, execute:
`$> ./gradlew generatePomFileForAdalPublication`

Generates the following `pom`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.microsoft.aad</groupId>
  <artifactId>adal</artifactId>
  <version>1.14.0</version>
  <packaging>aar</packaging>
  <dependencies>
    <dependency>
      <groupId>com.android.support</groupId>
      <artifactId>appcompat-v7</artifactId>
      <version>25.4.0</version>
    </dependency>
    <dependency>
      <groupId>com.google.code.gson</groupId>
      <artifactId>gson</artifactId>
      <version>2.8.1</version>
    </dependency>
    <dependency>
      <groupId>com.android.support</groupId>
      <artifactId>support-annotations</artifactId>
      <version>25.4.0</version>
    </dependency>
    <dependency>
      <groupId>com.android.support</groupId>
      <artifactId>support-v4</artifactId>
      <version>25.4.0</version>
    </dependency>
    <dependency>
      <groupId>com.microsoft.identity</groupId>
      <artifactId>common</artifactId>
      <version>0.0.1</version>
    </dependency>
  </dependencies>
</project>
```

Relates to https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1033

Reverts https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1218

https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/165 must merge first (submodule)