### PR TITLE
make the AuthenticationConstants in ADAL a subclass of the one in common-core

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ADALErrorTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ADALErrorTest.java
@@ -29,7 +29,7 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.support.test.runner.AndroidJUnit4;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -44,7 +44,7 @@ import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -30,7 +30,7 @@ import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.SmallTest;
 
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -31,7 +31,7 @@ import android.content.pm.Signature;
 import android.support.test.InstrumentationRegistry;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 
 import junit.framework.Assert;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationActivityUnitTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationActivityUnitTest.java
@@ -39,7 +39,7 @@ import android.webkit.WebViewClient;
 
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 
 import org.junit.Before;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -39,7 +39,7 @@ import android.test.UiThreadTest;
 import android.util.Base64;
 
 import com.google.gson.Gson;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BasicWebViewClientTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BasicWebViewClientTests.java
@@ -32,7 +32,7 @@ import android.test.UiThreadTest;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -50,8 +50,7 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.RESPONSE_ERROR_CODE;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -348,8 +347,8 @@ public class BasicWebViewClientTests {
             @Override
             public void sendResponse(int returnCode, Intent responseIntent) {
                 assertEquals(returnCode, AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR);
-                final String errString = responseIntent.getStringExtra(RESPONSE_ERROR_CODE);
-                final String intentErrMsg = responseIntent.getStringExtra(RESPONSE_ERROR_MESSAGE);
+                final String errString = responseIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE);
+                final String intentErrMsg = responseIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE);
                 assertTrue(errString.contains(String.valueOf(errCode)));
                 assertEquals(errMsg, intentErrMsg);
                 latch.countDown();
@@ -429,8 +428,8 @@ public class BasicWebViewClientTests {
             @Override
             public void sendResponse(int returnCode, Intent responseIntent) {
                 assertEquals(returnCode, AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR);
-                final String errString = responseIntent.getStringExtra(RESPONSE_ERROR_CODE);
-                final String intentErrMsg = responseIntent.getStringExtra(RESPONSE_ERROR_MESSAGE);
+                final String errString = responseIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE);
+                final String intentErrMsg = responseIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE);
                 assertTrue(errString.contains(String.valueOf(ERROR_FAILED_SSL_HANDSHAKE)));
                 assertEquals(sslError.toString(), intentErrMsg);
                 latch.countDown();

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -44,7 +44,7 @@ import android.util.Pair;
 
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import junit.framework.Assert;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -48,7 +48,7 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 
 import junit.framework.Assert;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/ChallengeResponseBuilderTests.java
@@ -27,7 +27,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import junit.framework.Assert;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
@@ -31,7 +31,7 @@ import android.content.pm.Signature;
 import android.support.test.InstrumentationRegistry;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import org.junit.Before;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/JwsBuilderTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/JwsBuilderTests.java
@@ -27,7 +27,7 @@ import android.content.Context;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import junit.framework.Assert;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockBrokerAccountService.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockBrokerAccountService.java
@@ -33,7 +33,7 @@ import android.os.IBinder;
 import android.os.RemoteException;
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.io.IOException;
 import java.util.Map;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockedIdToken.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockedIdToken.java
@@ -24,7 +24,7 @@ package com.microsoft.aad.adal;
 
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.io.UnsupportedEncodingException;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -30,8 +30,7 @@ import android.util.Base64;
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AAD;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
@@ -319,9 +318,9 @@ public class OauthTests {
         final Oauth2 oauth2 = createOAuthInstance(request);
 
         final String actualCodeRequestUrl = oauth2.getCodeRequestUrl();
-        assertTrue("Matching message", actualCodeRequestUrl.contains(AAD.ADAL_ID_PLATFORM + "=Android"));
+        assertTrue("Matching message", actualCodeRequestUrl.contains(AuthenticationConstants.AAD.ADAL_ID_PLATFORM + "=Android"));
         assertTrue("Matching message",
-                actualCodeRequestUrl.contains(AAD.ADAL_ID_VERSION + "=" + AuthenticationContext.getVersionName()));
+                actualCodeRequestUrl.contains(AuthenticationConstants.AAD.ADAL_ID_VERSION + "=" + AuthenticationContext.getVersionName()));
     }
 
     @Test

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
@@ -34,7 +34,7 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import org.junit.After;
 import org.junit.Before;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/UserInfoTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/UserInfoTests.java
@@ -28,7 +28,7 @@ import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Base64;
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import junit.framework.TestCase;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -24,7 +24,7 @@ package com.microsoft.aad.adal;
 
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/WebRequestHandlerTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/WebRequestHandlerTests.java
@@ -27,8 +27,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AAD;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
@@ -94,7 +93,7 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         final List<String> headerValues = new ArrayList<>();
         headerValues.add(testCorrelationId.toString());
         final Map<String, List<String>> headerFields = new HashMap<>();
-        headerFields.put(AAD.CLIENT_REQUEST_ID, headerValues);
+        headerFields.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, headerValues);
         Mockito.when(mockedConnection.getHeaderFields()).thenReturn(headerFields);
 
         Mockito.when(mockedConnection.getInputStream())
@@ -184,8 +183,8 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
         Util.prepareMockedUrlConnection(mockedConnection);
         Mockito.when(mockedConnection.getInputStream())
-                .thenReturn(Util.createInputStream(AAD.ADAL_ID_PLATFORM + "-Android" + "dummy string"
-                        + AAD.ADAL_ID_VERSION + "-"
+                .thenReturn(Util.createInputStream(AuthenticationConstants.AAD.ADAL_ID_PLATFORM + "-Android" + "dummy string"
+                        + AuthenticationConstants.AAD.ADAL_ID_VERSION + "-"
                         + AuthenticationContext.getVersionName()));
         Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
@@ -196,10 +195,10 @@ public final class WebRequestHandlerTests extends AndroidTestHelper {
         assertNotNull(httpResponse != null);
         assertTrue("status is 200", httpResponse.getStatusCode() == HttpURLConnection.HTTP_OK);
         String responseMsg = httpResponse.getBody();
-        assertTrue("request header check", responseMsg.contains(AAD.ADAL_ID_PLATFORM + "-Android"));
+        assertTrue("request header check", responseMsg.contains(AuthenticationConstants.AAD.ADAL_ID_PLATFORM + "-Android"));
         assertTrue(
                 "request header check",
-                responseMsg.contains(AAD.ADAL_ID_VERSION + "-"
+                responseMsg.contains(AuthenticationConstants.AAD.ADAL_ID_VERSION + "-"
                         + AuthenticationContext.getVersionName()));
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenInteractiveRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenInteractiveRequest.java
@@ -28,7 +28,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -32,7 +32,7 @@ import android.os.HandlerThread;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.Serializable;

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -25,7 +25,7 @@ package com.microsoft.aad.adal;
 import android.content.Context;
 import android.util.Log;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenWithBrokerRequest.java
@@ -26,7 +26,7 @@ package com.microsoft.aad.adal;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -52,7 +52,7 @@ import android.webkit.WebView;
 
 import com.google.gson.Gson;
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.aad.adal;
+
+/**
+ * {@link AuthenticationConstants} contains all the constant value the SDK is using.
+ */
+public final class AuthenticationConstants extends com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants {
+    /**
+     * Private constructor to prevent an utility class from being initiated.
+     */
+    private AuthenticationConstants() {
+        super();
+    }
+
+}

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -38,7 +38,7 @@ import android.util.EventLog;
 import android.util.SparseArray;
 
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.IOException;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -36,7 +36,7 @@ import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.io.UnsupportedEncodingException;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationResult.java
@@ -24,7 +24,7 @@
 package com.microsoft.aad.adal;
 
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -35,7 +35,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import com.microsoft.aad.adal.ChallengeResponseBuilder.ChallengeResponse;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.util.HashMap;

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -32,7 +32,7 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.os.RemoteException;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -41,7 +41,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
@@ -56,11 +56,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.RT_AGE;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SPE_RING;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 /**
  * Handles interactions to authenticator inside the Account Manager.
@@ -366,7 +362,7 @@ class BrokerProxy implements IBrokerProxy {
             } catch (final AuthenticatorException e) {
                 // Error code BROKER_AUTHENTICATOR_ERROR_GETAUTHTOKEN will be thrown if there was an error
                 // communicating with the authenticator or if the authenticator returned an invalid response.
-                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(INVALID_GRANT)) {
+                if (!StringExtensions.isNullOrBlank(e.getMessage()) && e.getMessage().contains(AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT)) {
                     Logger.e(TAG + methodName, AUTHENTICATOR_CANCELS_REQUEST,
                             "Acquire token failed with 'invalid grant' error, cannot proceed with silent request.",
                             ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED);
@@ -531,10 +527,10 @@ class BrokerProxy implements IBrokerProxy {
 
             // set the x-ms-clitelem data
             final TelemetryUtils.CliTelemInfo cliTelemInfo = new TelemetryUtils.CliTelemInfo();
-            cliTelemInfo.setServerErrorCode(bundleResult.getString(SERVER_ERROR));
-            cliTelemInfo.setServerSubErrorCode(bundleResult.getString(SERVER_SUBERROR));
-            cliTelemInfo.setRefreshTokenAge(bundleResult.getString(RT_AGE));
-            cliTelemInfo.setSpeRing(bundleResult.getString(SPE_RING));
+            cliTelemInfo.setServerErrorCode(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR));
+            cliTelemInfo.setServerSubErrorCode(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR));
+            cliTelemInfo.setRefreshTokenAge(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.RT_AGE));
+            cliTelemInfo.setSpeRing(bundleResult.getString(AuthenticationConstants.Broker.CliTelemInfo.SPE_RING));
             result.setCliTelemInfo(cliTelemInfo);
 
             return result;

--- a/adal/src/main/java/com/microsoft/aad/adal/ChallengeResponseBuilder.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ChallengeResponseBuilder.java
@@ -23,7 +23,7 @@
 
 package com.microsoft.aad.adal;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.UnsupportedEncodingException;

--- a/adal/src/main/java/com/microsoft/aad/adal/DRSMetadataRequestor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DRSMetadataRequestor.java
@@ -24,7 +24,7 @@
 package com.microsoft.aad.adal;
 
 import com.google.gson.JsonSyntaxException;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 
 import java.io.IOException;
@@ -37,8 +37,7 @@ import java.util.Map;
 
 import static com.microsoft.aad.adal.DRSMetadataRequestor.Type.CLOUD;
 import static com.microsoft.aad.adal.DRSMetadataRequestor.Type.ON_PREM;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.HeaderField.ACCEPT;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.MediaType.APPLICATION_JSON;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 /**
  * Delegate class capable of fetching DRS discovery metadata documents.
@@ -124,7 +123,7 @@ final class DRSMetadataRequestor extends AbstractMetadataRequestor<DRSMetadata, 
 
         // init the headers to use in the request
         final Map<String, String> headers = new HashMap<>();
-        headers.put(ACCEPT, APPLICATION_JSON);
+        headers.put(AuthenticationConstants.HeaderField.ACCEPT, AuthenticationConstants.MediaType.APPLICATION_JSON);
         if (null != getCorrelationId()) {
             headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, getCorrelationId().toString());
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Discovery.java
@@ -26,7 +26,7 @@ package com.microsoft.aad.adal;
 import android.content.Context;
 import android.net.Uri;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;

--- a/adal/src/main/java/com/microsoft/aad/adal/IdToken.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/IdToken.java
@@ -25,7 +25,7 @@ package com.microsoft.aad.adal;
 
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import org.json.JSONException;

--- a/adal/src/main/java/com/microsoft/aad/adal/JWSBuilder.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/JWSBuilder.java
@@ -28,7 +28,7 @@ import android.util.Base64;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import org.json.JSONException;

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -29,7 +29,7 @@ import android.text.TextUtils;
 import android.util.Base64;
 
 import com.microsoft.aad.adal.ChallengeResponseBuilder.ChallengeResponse;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpWebResponse;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
@@ -54,7 +54,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.microsoft.aad.adal.TelemetryUtils.CliTelemInfo;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.HeaderField.X_MS_CLITELEM;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 /**
  * Base Oauth class.
@@ -782,11 +782,11 @@ class Oauth2 {
                 }
             }
 
-            if (null != webResponse.getResponseHeaders().get(X_MS_CLITELEM) && !webResponse.getResponseHeaders().get(X_MS_CLITELEM).isEmpty()) {
+            if (null != webResponse.getResponseHeaders().get(AuthenticationConstants.HeaderField.X_MS_CLITELEM) && !webResponse.getResponseHeaders().get(AuthenticationConstants.HeaderField.X_MS_CLITELEM).isEmpty()) {
                 final CliTelemInfo cliTelemInfo =
                         TelemetryUtils.parseXMsCliTelemHeader(
                                 webResponse.getResponseHeaders()
-                                        .get(X_MS_CLITELEM).get(0)
+                                        .get(AuthenticationConstants.HeaderField.X_MS_CLITELEM).get(0)
                         );
 
                 if (null != cliTelemInfo) {
@@ -844,7 +844,7 @@ class Oauth2 {
         }
 
         if (null != webResponse.getResponseHeaders()) {
-            final List<String> xMsCliTelemValues = webResponse.getResponseHeaders().get(X_MS_CLITELEM);
+            final List<String> xMsCliTelemValues = webResponse.getResponseHeaders().get(AuthenticationConstants.HeaderField.X_MS_CLITELEM);
             if (null != xMsCliTelemValues && !xMsCliTelemValues.isEmpty()) {
                 // Only one value is expected to be present, so we'll grab the first element...
                 final String speValue = xMsCliTelemValues.get(0);

--- a/adal/src/main/java/com/microsoft/aad/adal/PackageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/PackageHelper.java
@@ -36,7 +36,7 @@ import android.content.pm.Signature;
 import android.os.Bundle;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.UnsupportedEncodingException;

--- a/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
@@ -30,7 +30,7 @@ import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/adal/src/main/java/com/microsoft/aad/adal/StringExtensions.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/StringExtensions.java
@@ -26,7 +26,7 @@ package com.microsoft.aad.adal;
 import android.net.Uri;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -25,7 +25,7 @@ package com.microsoft.aad.adal;
 import android.content.Context;
 
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.cache.ADALOAuth2TokenCache;

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheItemSerializationAdapater.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheItemSerializationAdapater.java
@@ -31,7 +31,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2;
+import com.microsoft.aad.adal.AuthenticationConstants;
 
 import java.lang.reflect.Type;
 
@@ -49,10 +49,10 @@ public final class TokenCacheItemSerializationAdapater
     @Override
     public JsonElement serialize(TokenCacheItem tokenCacheItem, Type type, JsonSerializationContext context) {
         JsonObject jsonObj = new JsonObject();
-        jsonObj.add(OAuth2.AUTHORITY, new JsonPrimitive(tokenCacheItem.getAuthority()));
-        jsonObj.add(OAuth2.REFRESH_TOKEN, new JsonPrimitive(tokenCacheItem.getRefreshToken()));
-        jsonObj.add(OAuth2.ID_TOKEN, new JsonPrimitive(tokenCacheItem.getRawIdToken()));
-        jsonObj.add(OAuth2.ADAL_CLIENT_FAMILY_ID, new JsonPrimitive(tokenCacheItem.getFamilyClientId()));
+        jsonObj.add(AuthenticationConstants.OAuth2.AUTHORITY, new JsonPrimitive(tokenCacheItem.getAuthority()));
+        jsonObj.add(AuthenticationConstants.OAuth2.REFRESH_TOKEN, new JsonPrimitive(tokenCacheItem.getRefreshToken()));
+        jsonObj.add(AuthenticationConstants.OAuth2.ID_TOKEN, new JsonPrimitive(tokenCacheItem.getRawIdToken()));
+        jsonObj.add(AuthenticationConstants.OAuth2.ADAL_CLIENT_FAMILY_ID, new JsonPrimitive(tokenCacheItem.getFamilyClientId()));
         return jsonObj;
     }
 
@@ -60,12 +60,12 @@ public final class TokenCacheItemSerializationAdapater
     public TokenCacheItem deserialize(JsonElement json, Type type, JsonDeserializationContext context)
             throws JsonParseException {
         final JsonObject srcJsonObj = json.getAsJsonObject();
-        throwIfParameterMissing(srcJsonObj, OAuth2.AUTHORITY);
-        throwIfParameterMissing(srcJsonObj, OAuth2.ID_TOKEN);
-        throwIfParameterMissing(srcJsonObj, OAuth2.ADAL_CLIENT_FAMILY_ID);
-        throwIfParameterMissing(srcJsonObj, OAuth2.REFRESH_TOKEN);
+        throwIfParameterMissing(srcJsonObj, AuthenticationConstants.OAuth2.AUTHORITY);
+        throwIfParameterMissing(srcJsonObj, AuthenticationConstants.OAuth2.ID_TOKEN);
+        throwIfParameterMissing(srcJsonObj, AuthenticationConstants.OAuth2.ADAL_CLIENT_FAMILY_ID);
+        throwIfParameterMissing(srcJsonObj, AuthenticationConstants.OAuth2.REFRESH_TOKEN);
 
-        final String rawIdToken = srcJsonObj.get(OAuth2.ID_TOKEN).getAsString();
+        final String rawIdToken = srcJsonObj.get(AuthenticationConstants.OAuth2.ID_TOKEN).getAsString();
         final TokenCacheItem tokenCacheItem = new TokenCacheItem();
         final IdToken idToken;
         try {
@@ -76,11 +76,11 @@ public final class TokenCacheItemSerializationAdapater
         final UserInfo userInfo = new UserInfo(idToken);
         tokenCacheItem.setUserInfo(userInfo);
         tokenCacheItem.setTenantId(idToken.getTenantId());
-        tokenCacheItem.setAuthority(srcJsonObj.get(OAuth2.AUTHORITY).getAsString());
+        tokenCacheItem.setAuthority(srcJsonObj.get(AuthenticationConstants.OAuth2.AUTHORITY).getAsString());
         tokenCacheItem.setIsMultiResourceRefreshToken(true);
         tokenCacheItem.setRawIdToken(rawIdToken);
-        tokenCacheItem.setFamilyClientId(srcJsonObj.get(OAuth2.ADAL_CLIENT_FAMILY_ID).getAsString());
-        tokenCacheItem.setRefreshToken(srcJsonObj.get(OAuth2.REFRESH_TOKEN).getAsString());
+        tokenCacheItem.setFamilyClientId(srcJsonObj.get(AuthenticationConstants.OAuth2.ADAL_CLIENT_FAMILY_ID).getAsString());
+        tokenCacheItem.setRefreshToken(srcJsonObj.get(AuthenticationConstants.OAuth2.REFRESH_TOKEN).getAsString());
         return tokenCacheItem;
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/UserInfo.java
@@ -26,7 +26,7 @@ package com.microsoft.aad.adal;
 import android.net.Uri;
 import android.os.Bundle;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.Serializable;

--- a/adal/src/main/java/com/microsoft/aad/adal/WebviewHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/WebviewHelper.java
@@ -27,7 +27,7 @@ import android.content.Intent;
 import android.text.TextUtils;
 
 import com.microsoft.aad.adal.ChallengeResponseBuilder.ChallengeResponse;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.aad.adal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.Serializable;


### PR DESCRIPTION
make the AuthenticationConstants in ADAL a subclass of the one in common-core
