### PR TITLE
Issuer null fix

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -28,13 +28,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.HandlerThread;
 import android.os.Looper;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
@@ -239,6 +240,7 @@ class AcquireTokenRequest {
                 } catch (final AuthenticationException authenticationException) {
                     // Ignore the failure, save in the map as a failed instance discovery to avoid it being looked up another times in the same process
                     AuthorityValidationMetadataCache.updateInstanceDiscoveryMap(authorityUrl.getHost(), new InstanceDiscoveryMetadata(false));
+                    AzureActiveDirectory.putCloud(authorityUrl.getHost(), new AzureActiveDirectoryCloud(false));
                     Logger.v(TAG + methodName, "Fail to get authority validation metadata back. Ignore the failure since authority validation is turned off.");
                 }
             }


### PR DESCRIPTION
Resolves the following stacktrace - `null AzureActiveDirectory` cloud instance 

```java
        java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.isValidated()' on a null object reference
                com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Strategy.getIssuerCacheIdentifier(AzureActiveDirectoryOAuth2Strategy.java:78)
                com.microsoft.identity.common.internal.cache.ADALOAuth2TokenCache.saveTokens(ADALOAuth2TokenCache.java:126)
                com.microsoft.aad.adal.TokenCacheAccessor.updateTokenCacheUsingCommonCache(TokenCacheAccessor.java:346)
                com.microsoft.aad.adal.TokenCacheAccessor.updateTokenCache(TokenCacheAccessor.java:313)
                com.microsoft.aad.adal.AcquireTokenInteractiveRequest.acquireTokenWithAuthCode(AcquireTokenInteractiveRequest.java:126)
                com.microsoft.aad.adal.AcquireTokenRequest$3.run(AcquireTokenRequest.java:849)
                java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
                java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
                java.lang.Thread.run(Thread.java:818)
```