### PR TITLE
Setting Authority in ADAL Common 0.0.4 for Sovereign and PPE flows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ADAL for Android gives you the ability to add support for Work Accounts to your 
 
 A Work Account is an identity you use to get work done from your organization or school. Anywhere you need to get access to your work life you'll use a Work Account. The Work Account can be tied to an Active Directory server running in your datacenter or live completely in the cloud like when you use Office 365. A Work Account will be how your users know that they are accessing their important documents and data backed my Microsoft security.
 
-## ADAL for Android 1.15.0 Released!
+## ADAL for Android 1.15.1 Released!
 
 ## Build status
 
@@ -17,7 +17,7 @@ Note: A corpnet account is required to view the VSTS build.
 
 ## Versions
 
-Current version - 1.15.0
+Current version - 1.15.1
 
 Minimum recommended version - 1.1.16
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -33,7 +33,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.15.1-cp"
+        versionName "1.15.1-RC"
         project.archivesBaseName = "adal"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -125,7 +125,7 @@ dependencies {
     }
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:0.0.4-cp") {
+    distApi("com.microsoft.identity:common:0.0.4-RC") {
         transitive = false
     }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -33,7 +33,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.15.0"
+        versionName "1.15.1-cp"
         project.archivesBaseName = "adal"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -125,7 +125,7 @@ dependencies {
     }
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:0.0.3") {
+    distApi("com.microsoft.identity:common:0.0.4-cp") {
         transitive = false
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1422,7 +1422,7 @@ public class AuthenticationContext {
         // Package manager does not report for ADAL
         // AndroidManifest files are not merged, so it is returning hard coded
         // value
-        return "1.15.0";
+        return "1.15.1-cp";
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1422,7 +1422,7 @@ public class AuthenticationContext {
         // Package manager does not report for ADAL
         // AndroidManifest files are not merged, so it is returning hard coded
         // value
-        return "1.15.1-cp";
+        return "1.15.1-RC";
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -337,7 +337,9 @@ class TokenCacheAccessor {
         AzureActiveDirectoryTokenResponse tokenResponse = CoreAdapter.asAadTokenResponse(result);
         AzureActiveDirectoryOAuth2Configuration config = new AzureActiveDirectoryOAuth2Configuration();
         config.setAuthorityHostValidationEnabled(this.isValidateAuthorityHost());
-        config.setAuthority(this.mAuthority);
+        if (null != this.mAuthority) {
+            config.setAuthorityUrl(new URL(this.mAuthority));
+        }
         AzureActiveDirectoryOAuth2Strategy strategy = ad.createOAuth2Strategy(config);
         AzureActiveDirectoryAuthorizationRequest request = new AzureActiveDirectoryAuthorizationRequest();
         request.setClientId(clientId);

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -337,6 +337,7 @@ class TokenCacheAccessor {
         AzureActiveDirectoryTokenResponse tokenResponse = CoreAdapter.asAadTokenResponse(result);
         AzureActiveDirectoryOAuth2Configuration config = new AzureActiveDirectoryOAuth2Configuration();
         config.setAuthorityHostValidationEnabled(this.isValidateAuthorityHost());
+        config.setAuthority(this.mAuthority);
         AzureActiveDirectoryOAuth2Strategy strategy = ad.createOAuth2Strategy(config);
         AzureActiveDirectoryAuthorizationRequest request = new AzureActiveDirectoryAuthorizationRequest();
         request.setClientId(clientId);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.15.1
+--------------
+Support Sovereign and PPE authority setting in Common.
+
 Version 1.15.0
 --------------
 Update Android target and build tools to 27.


### PR DESCRIPTION
Setting version to 1.15.1-RC
Setting Authority in ADAL Common 0.0.4-RC for Sovereign and PPE flows.

Issue #1310 
