### PR TITLE
Adal changes to support claims on Acquire Token Silent

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -349,10 +349,11 @@ public class OauthTests {
 
         // with claims challenge
         request.setClaimsChallenge("testClaims");
+        final Oauth2 oauthClaims = createOAuthInstance(request);
         assertEquals(
                 "Token request",
                 "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1&claims=testClaims",
-                oauthWithoutLoginHint.buildTokenRequestMessage("authorizationcodevalue="));
+                oauthClaims.buildTokenRequestMessage("authorizationcodevalue="));
 
     }
 
@@ -379,7 +380,10 @@ public class OauthTests {
 
         // with claims challenge
         request.setClaimsChallenge("testClaims");
-        assertTrue(oauth2.buildRefreshTokenRequestMessage("refreshToken23434=").startsWith("grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+&claims=testClaims"));
+        final Oauth2 oauthClaims = createOAuthInstance(request);
+
+        assertEquals("grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+&redirect_uri=redirect+1234567890-%2B%3D%3B%27&claims=testClaims",
+                oauthClaims.buildRefreshTokenRequestMessage("refreshToken23434="));
 
     }
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -346,6 +346,14 @@ public class OauthTests {
                 "Token request",
                 "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1",
                 oauthWithoutLoginHint.buildTokenRequestMessage("authorizationcodevalue="));
+
+        // with claims challenge
+        request.setClaimsChallenge("testClaims");
+        assertEquals(
+                "Token request",
+                "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1&claims=testClaims",
+                oauthWithoutLoginHint.buildTokenRequestMessage("authorizationcodevalue="));
+
     }
 
     /**
@@ -368,6 +376,11 @@ public class OauthTests {
 
         final Oauth2 oauthWithoutResource = createOAuthInstance(requestWithoutResource);
         assertTrue(oauthWithoutResource.buildRefreshTokenRequestMessage("refreshToken234343455=").startsWith("grant_type=refresh_token&refresh_token=refreshToken234343455%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1"));
+
+        // with claims challenge
+        request.setClaimsChallenge("testClaims");
+        assertTrue(oauth2.buildRefreshTokenRequestMessage("refreshToken23434=").startsWith("grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+&claims=testClaims"));
+
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -411,8 +411,7 @@ class AcquireTokenRequest {
     }
 
     private boolean shouldTrySilentFlow(final AuthenticationRequest authenticationRequest) {
-        return !authenticationRequest.isClaimsChallengePresent()
-                && authenticationRequest.getPrompt() == PromptBehavior.Auto
+        return  authenticationRequest.getPrompt() == PromptBehavior.Auto
                 || authenticationRequest.isSilent();
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -426,7 +426,7 @@ class AcquireTokenRequest {
         final boolean requestEligibleForBroker = mBrokerProxy.verifyBrokerForSilentRequest(authenticationRequest);
 
         //1. if forceRefresh == true OR claimsChallenge is not null AND the request is eligible for the broker
-        if((authenticationRequest.getForceRefresh() || authenticationRequest.isClaimsChallengePresent() && requestEligibleForBroker)){
+        if((authenticationRequest.getForceRefresh() || authenticationRequest.isClaimsChallengePresent()) && requestEligibleForBroker){
             return tryAcquireTokenSilentWithBroker(authenticationRequest);
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -426,8 +426,8 @@ class AcquireTokenRequest {
 
         final boolean requestEligibleForBroker = mBrokerProxy.verifyBrokerForSilentRequest(authenticationRequest);
 
-        //1. if forceRefresh == true AND the request is eligible for the broker
-        if(authenticationRequest.getForceRefresh() && requestEligibleForBroker){
+        //1. if forceRefresh == true OR claimsChallenge is not null AND the request is eligible for the broker
+        if((authenticationRequest.getForceRefresh() || authenticationRequest.isClaimsChallengePresent() && requestEligibleForBroker)){
             return tryAcquireTokenSilentWithBroker(authenticationRequest);
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -107,8 +107,8 @@ class AcquireTokenSilentHandler {
         // Check for if there is valid access token item in the cache.
         final TokenCacheItem accessTokenItem = mTokenCacheAccessor.getATFromCache(mAuthRequest.getResource(),
                 mAuthRequest.getClientId(), mAuthRequest.getUserFromRequest());
-        // If accessToken is null or if the user requested force refresh then get a new access token using local refresh tokens
-        if (accessTokenItem == null || mAuthRequest.getForceRefresh()) {
+        // If accessToken is null or if the user requested force refresh or if claims challenge is present then get a new access token using local refresh tokens
+        if (accessTokenItem == null || mAuthRequest.getForceRefresh() || mAuthRequest.isClaimsChallengePresent()) {
             Logger.v(TAG + methodName, "No valid access token exists, try with refresh token.");
             return tryRT();
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -669,7 +669,32 @@ public class AuthenticationContext {
      */
     public AuthenticationResult acquireTokenSilentSync(String resource, String clientId, String userId)
             throws AuthenticationException, InterruptedException {
-        return acquireTokenSilentSync(resource, clientId, userId, false, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC);
+        return acquireTokenSilentSync(resource, clientId, userId, false, null, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC);
+    }
+
+    /**
+     * This is sync function. It will first look at the cache and automatically
+     * checks for the token expiration. Additionally, if no suitable access
+     * token is found in the cache, but refresh token is available, the function
+     * will use the refresh token automatically. This method will not show UI
+     * for the user. If prompt is needed, the method will return an exception
+     *
+     * @param resource required resource identifier.
+     * @param clientId required client identifier.
+     * @param userId   UserID obtained from
+     *                 {@link AuthenticationResult #getUserInfo()}
+     * @param claims   The claims challenge returned from middle tier service, will be added as query string
+     *                 to authorize endpoint.
+     * @return A {@link Future} object representing the
+     * {@link AuthenticationResult} of the call. It contains Access
+     * Token,the Access Token's expiration time, Refresh token, and
+     * {@link UserInfo}.
+     * @throws AuthenticationException If silent request fails to get the token back.
+     * @throws InterruptedException    If the main thread is interrupted before or during the activity.
+     */
+    public AuthenticationResult acquireTokenSilentSync(String resource, String clientId, String userId, String claims)
+            throws AuthenticationException, InterruptedException {
+        return acquireTokenSilentSync(resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC);
     }
 
     /**
@@ -693,10 +718,15 @@ public class AuthenticationContext {
      */
     public AuthenticationResult acquireTokenSilentSync(String resource, String clientId, String userId, boolean forceRefresh)
             throws AuthenticationException, InterruptedException {
-        return acquireTokenSilentSync(resource, clientId, userId, forceRefresh, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC_FORCE_REFRESH);
+        return acquireTokenSilentSync(resource, clientId, userId, forceRefresh, null, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC_FORCE_REFRESH);
     }
 
-    private AuthenticationResult acquireTokenSilentSync(final String resource, final String clientId, final String userId, final boolean forceRefresh, final String apiEventString)
+    private AuthenticationResult acquireTokenSilentSync(final String resource,
+                                                        final String clientId,
+                                                        final String userId,
+                                                        final boolean forceRefresh,
+                                                        final String claims,
+                                                        final String apiEventString)
             throws AuthenticationException, InterruptedException {
 
         final String methodName = ":acquireTokenSilentSync";
@@ -862,7 +892,7 @@ public class AuthenticationContext {
                                         String clientId,
                                         String userId,
                                         AuthenticationCallback<AuthenticationResult> callback) {
-        acquireTokenSilentAsync(resource, clientId, userId, false, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC, callback);
+        acquireTokenSilentAsync(resource, clientId, userId, false, null, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC, callback);
     }
 
     /**
@@ -885,7 +915,7 @@ public class AuthenticationContext {
                                         String userId,
                                         boolean forceRefresh,
                                         AuthenticationCallback<AuthenticationResult> callback) {
-        acquireTokenSilentAsync(resource, clientId, userId, forceRefresh, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC_FORCE_REFRESH, callback);
+        acquireTokenSilentAsync(resource, clientId, userId, forceRefresh, null, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC_FORCE_REFRESH, callback);
     }
 
     /**
@@ -899,8 +929,8 @@ public class AuthenticationContext {
      * @param clientId required client identifier.
      * @param userId   UserId obtained from {@link UserInfo} inside
      *                 {@link AuthenticationResult}
-     * @param claims   Optional. The claims challenge returned from middle tier service, will be added as query string
-     *                           to authorize endpoint.
+     * @param claims   The claims challenge returned from middle tier service, will be added as query string
+     *                 to authorize endpoint.
      * @param callback required {@link AuthenticationCallback} object for async
      *                 call.
      */
@@ -909,13 +939,14 @@ public class AuthenticationContext {
                                         String userId,
                                         String claims,
                                         AuthenticationCallback<AuthenticationResult> callback) {
-        acquireTokenSilentAsync(resource, clientId, userId, false, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC, callback);
+        acquireTokenSilentAsync(resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC, callback);
     }
 
     private void acquireTokenSilentAsync(final String resource,
                                         final String clientId,
                                         final String userId,
                                         final boolean forceRefresh,
+                                        final String claims,
                                         final String apiEventString,
                                         final AuthenticationCallback<AuthenticationResult> callback) {
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -694,7 +694,7 @@ public class AuthenticationContext {
      */
     public AuthenticationResult acquireTokenSilentSync(String resource, String clientId, String userId, String claims)
             throws AuthenticationException, InterruptedException {
-        return acquireTokenSilentSync(resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC);
+        return acquireTokenSilentSync(resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_SILENT_SYNC_CLAIMS_CHALLENGE);
     }
 
     /**
@@ -939,7 +939,7 @@ public class AuthenticationContext {
                                         String userId,
                                         String claims,
                                         AuthenticationCallback<AuthenticationResult> callback) {
-        acquireTokenSilentAsync(resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC, callback);
+        acquireTokenSilentAsync(resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC_CLAIMS_CHALLENGE, callback);
     }
 
     private void acquireTokenSilentAsync(final String resource,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -880,6 +880,30 @@ public class AuthenticationContext {
         acquireTokenSilentAsync(resource, clientId, userId, forceRefresh, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC_FORCE_REFRESH, callback);
     }
 
+    /**
+     * The function will first look at the cache and automatically checks for
+     * the token expiration. Additionally, if no suitable access token is found
+     * in the cache, but refresh token is available, the function will use the
+     * refresh token automatically. This method will not show UI for the user.
+     * If prompt is needed, the method will return an exception
+     *
+     * @param resource required resource identifier.
+     * @param clientId required client identifier.
+     * @param userId   UserId obtained from {@link UserInfo} inside
+     *                 {@link AuthenticationResult}
+     * @param claims   Optional. The claims challenge returned from middle tier service, will be added as query string
+     *                           to authorize endpoint.
+     * @param callback required {@link AuthenticationCallback} object for async
+     *                 call.
+     */
+    public void acquireTokenSilentAsync(String resource,
+                                        String clientId,
+                                        String userId,
+                                        String claims,
+                                        AuthenticationCallback<AuthenticationResult> callback) {
+        acquireTokenSilentAsync(resource, clientId, userId, false, EventStrings.ACQUIRE_TOKEN_SILENT_ASYNC, callback);
+    }
+
     private void acquireTokenSilentAsync(final String resource,
                                         final String clientId,
                                         final String userId,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -741,7 +741,7 @@ public class AuthenticationContext {
         apiEvent.setPromptBehavior(PromptBehavior.Auto.toString());
 
         final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh);
+                clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh, claims);
         request.setSilent(true);
         request.setPrompt(PromptBehavior.Auto);
         request.setUserIdentifierType(UserIdentifierType.UniqueId);
@@ -961,7 +961,7 @@ public class AuthenticationContext {
         apiEvent.setPromptBehavior(PromptBehavior.Auto.toString());
 
         final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh);
+                clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh, claims);
         request.setSilent(true);
         request.setPrompt(PromptBehavior.Auto);
         request.setUserIdentifierType(UserIdentifierType.UniqueId);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -160,7 +160,7 @@ class AuthenticationRequest implements Serializable {
     }
 
     AuthenticationRequest(String authority, String resource, String clientid, String userid,
-                          UUID correlationId, boolean isExtendedLifetimeEnabled, boolean forceRefresh) {
+                          UUID correlationId, boolean isExtendedLifetimeEnabled, boolean forceRefresh, String claimsChallenge) {
         mAuthority = authority;
         mResource = resource;
         mClientId = clientid;
@@ -168,6 +168,7 @@ class AuthenticationRequest implements Serializable {
         mCorrelationId = correlationId;
         mIsExtendedLifetimeEnabled = isExtendedLifetimeEnabled;
         mForceRefresh = forceRefresh;
+        mClaimsChallenge = claimsChallenge;
     }
 
     AuthenticationRequest(String authority, String resource, String clientId,

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -771,7 +771,6 @@ class BrokerProxy implements IBrokerProxy {
         }
 
         if (request.isClaimsChallengePresent()) {
-            brokerOptions.putString(AuthenticationConstants.Broker.BROKER_SKIP_CACHE, Boolean.toString(true));
             brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_CLAIMS, request.getClaimsChallenge());
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -224,7 +224,7 @@ class Oauth2 {
     public String buildTokenRequestMessage(String code) throws UnsupportedEncodingException {
         Logger.v(TAG, "Building request message for redeeming token with auth code.");
 
-        return String.format("%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
+        String message =  String.format("%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
                 AuthenticationConstants.OAuth2.GRANT_TYPE,
                 StringExtensions.urlFormEncode(AuthenticationConstants.OAuth2.AUTHORIZATION_CODE),
 
@@ -241,6 +241,14 @@ class Oauth2 {
                 AuthenticationConstants.OAuth2.CLIENT_INFO,
                 AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE
         );
+
+        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge())) {
+            message = String.format("%s&%s=%s", message, AuthenticationConstants.OAuth2.CLAIMS,
+                    StringExtensions.urlFormEncode(mRequest.getClaimsChallenge()));
+        }
+
+        return message;
+
     }
 
     public String buildRefreshTokenRequestMessage(String refreshToken)
@@ -270,6 +278,11 @@ class Oauth2 {
                 && !mRequest.getClientId().equalsIgnoreCase(AuthenticationConstants.Broker.BROKER_CLIENT_ID)) {
             message = String.format("%s&%s=%s", message, AuthenticationConstants.OAuth2.REDIRECT_URI,
                     StringExtensions.urlFormEncode(mRequest.getRedirectUri()));
+        }
+
+        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge())) {
+            message = String.format("%s&%s=%s", message, AuthenticationConstants.OAuth2.CLAIMS,
+                    StringExtensions.urlFormEncode(mRequest.getClaimsChallenge()));
         }
 
         return message;

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -172,11 +172,15 @@ final class EventStrings {
 
     static final String ACQUIRE_TOKEN_SILENT_SYNC_FORCE_REFRESH = "13";
 
+    static final String ACQUIRE_TOKEN_SILENT_SYNC_CLAIMS_CHALLENGE = "15";
+
     static final String ACQUIRE_TOKEN_SILENT = "2";
 
     static final String ACQUIRE_TOKEN_SILENT_ASYNC = "3";
 
     static final String ACQUIRE_TOKEN_SILENT_ASYNC_FORCE_REFRESH = "14";
+
+    static final String ACQUIRE_TOKEN_SILENT_ASYNC_CLAIMS_CHALLENGE = "16";
 
     static final String ACQUIRE_TOKEN_WITH_REFRESH_TOKEN = "4";
 


### PR DESCRIPTION
- Added two new API's for Acquire Token Silent calls
- Passing Claims parameter with token request as well if present
- Changes are made to Acquire Token call to use RT to get a new AT if claims parameter is present
- Unit tests to verify if the token request is constructed correctly with claims