### PR TITLE
Added app name , app version and client capabilities to Auth and Token requests

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -248,7 +248,7 @@ public final class AcquireTokenSilentHandlerTest {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         // Token redeem with RT fail with invalid_grant.
-        final byte[] postMessage = Util.getPoseMessage(regularRT, clientId, resource);
+        final byte[] postMessage = Util.getPostMessage(regularRT, clientId, resource);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(postMessage), Mockito.anyString()))
                 .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"), null));
@@ -309,7 +309,7 @@ public final class AcquireTokenSilentHandlerTest {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         // Token redeem with RT fail with invalid_grant.
-        final byte[] postMessage = Util.getPoseMessage(mrrt, clientId, resource);
+        final byte[] postMessage = Util.getPostMessage(mrrt, clientId, resource);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(postMessage), Mockito.anyString()))
                 .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
@@ -366,7 +366,7 @@ public final class AcquireTokenSilentHandlerTest {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         // Token redeem with RT fail with invalid_grant.
-        final byte[] postMessage = Util.getPoseMessage(mrrt, clientId, resource);
+        final byte[] postMessage = Util.getPostMessage(mrrt, clientId, resource);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(postMessage), Mockito.anyString()))
                 .thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_OK,
@@ -544,12 +544,12 @@ public final class AcquireTokenSilentHandlerTest {
         // FRT token request fails with invalid_grant
         final String anotherResource = "anotherResource";
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                Mockito.refEq(Util.getPoseMessage(frtToken, clientId, anotherResource)),
+                Mockito.refEq(Util.getPostMessage(frtToken, clientId, anotherResource)),
                 Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"), null));
 
         // retry request with MRRT succeeds
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                Mockito.refEq(Util.getPoseMessage(mrrtToken, clientId, anotherResource)),
+                Mockito.refEq(Util.getPostMessage(mrrtToken, clientId, anotherResource)),
                 Mockito.anyString())).thenReturn(new HttpWebResponse(HttpURLConnection.HTTP_OK, Util.getSuccessTokenResponse(true, false), null));
         acquireTokenSilentHandler.setWebRequestHandler(mockedWebRequestHandler);
 
@@ -565,9 +565,9 @@ public final class AcquireTokenSilentHandlerTest {
 
         // Verify post request with FRT token is executed first, followed by post request with MRRT.. 
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                Mockito.refEq(Util.getPoseMessage(frtToken, clientId, anotherResource)), Mockito.anyString());
+                Mockito.refEq(Util.getPostMessage(frtToken, clientId, anotherResource)), Mockito.anyString());
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                Mockito.refEq(Util.getPoseMessage(mrrtToken, clientId, anotherResource)), Mockito.anyString());
+                Mockito.refEq(Util.getPostMessage(mrrtToken, clientId, anotherResource)), Mockito.anyString());
 
 
         clearCache(mockCache);
@@ -612,14 +612,14 @@ public final class AcquireTokenSilentHandlerTest {
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         //FRT request fails with invalid_grant
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(frtToken, clientId, resource)),
                 Mockito.anyString())).thenReturn(new HttpWebResponse(
                 HttpURLConnection.HTTP_BAD_REQUEST, Util.getErrorResponseBody("invalid_grant"),
                 null));
 
         // MRT request also fails
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(mrrtToken, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
                         Util.getErrorResponseBody("invalid_request"), null));
@@ -636,11 +636,11 @@ public final class AcquireTokenSilentHandlerTest {
         // Verify post request with MRRT token is executed first, followed by post request with FRT. 
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(
+                AdditionalMatchers.aryEq(Util.getPostMessage(
                         frtToken, clientId, resource)), Mockito.anyString());
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(mrrtToken, clientId, resource)),
                 Mockito.anyString());
 
         // Verify cache entry
@@ -691,14 +691,14 @@ public final class AcquireTokenSilentHandlerTest {
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         // MRRT request fails with invalid_grant
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtToken, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(mrrtToken, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_BAD_REQUEST,
                         Util.getErrorResponseBody("invalid_grant"), null));
 
         // FRT request succeed
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(frtToken, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_OK,
                         Util.getSuccessTokenResponse(true, true), null));
@@ -718,10 +718,10 @@ public final class AcquireTokenSilentHandlerTest {
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(
-                        Util.getPoseMessage(mrrtToken, clientId, resource)), Mockito.anyString());
+                        Util.getPostMessage(mrrtToken, clientId, resource)), Mockito.anyString());
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(frtToken, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(frtToken, clientId, resource)),
                 Mockito.anyString());
 
         // Verify cache entry, FRT return token back, should store entries with user in cache.
@@ -955,7 +955,7 @@ public final class AcquireTokenSilentHandlerTest {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(rtForPreferredCache, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(rtForPreferredCache, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_OK,
                         Util.getSuccessTokenResponse(false, false), null));
@@ -973,7 +973,7 @@ public final class AcquireTokenSilentHandlerTest {
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(
-                        Util.getPoseMessage(rtForPreferredCache, clientId, resource)), Mockito.anyString());
+                        Util.getPostMessage(rtForPreferredCache, clientId, resource)), Mockito.anyString());
 
         // verify token items
         assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForRTEntry(preferredCacheAuthority, resource, clientId, TEST_IDTOKEN_USERID)));
@@ -1015,7 +1015,7 @@ public final class AcquireTokenSilentHandlerTest {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(mrrtForPreferredCache, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(mrrtForPreferredCache, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_OK,
                         Util.getSuccessTokenResponse(false, false), null));
@@ -1033,7 +1033,7 @@ public final class AcquireTokenSilentHandlerTest {
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(
-                        Util.getPoseMessage(mrrtForPreferredCache, clientId, resource)), Mockito.anyString());
+                        Util.getPostMessage(mrrtForPreferredCache, clientId, resource)), Mockito.anyString());
 
         // verify token items
         assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForMRRT(preferredCacheAuthority, clientId, TEST_IDTOKEN_USERID)));
@@ -1078,7 +1078,7 @@ public final class AcquireTokenSilentHandlerTest {
         // inject mocked web request handler
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(frtForPreferredCache, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(frtForPreferredCache, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_OK,
                         Util.getSuccessTokenResponse(true, true), null));
@@ -1096,7 +1096,7 @@ public final class AcquireTokenSilentHandlerTest {
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(
-                        Util.getPoseMessage(frtForPreferredCache, clientId, resource)), Mockito.anyString());
+                        Util.getPostMessage(frtForPreferredCache, clientId, resource)), Mockito.anyString());
 
         // verify token items
         assertNotNull(mockedCache.getItem(CacheKey.createCacheKeyForFRT(preferredCacheAuthority, familyClientId, TEST_IDTOKEN_USERID)));
@@ -1146,7 +1146,7 @@ public final class AcquireTokenSilentHandlerTest {
         final IWebRequestHandler mockedWebRequestHandler = Mockito.mock(WebRequestHandler.class);
         // MRRT request fails with invalid_grant
         Mockito.when(mockedWebRequestHandler.sendPost(Mockito.any(URL.class), Mockito.<String, String>anyMap(),
-                AdditionalMatchers.aryEq(Util.getPoseMessage(rtForTestHost, clientId, resource)),
+                AdditionalMatchers.aryEq(Util.getPostMessage(rtForTestHost, clientId, resource)),
                 Mockito.anyString())).thenReturn(
                 new HttpWebResponse(HttpURLConnection.HTTP_OK,
                         Util.getSuccessTokenResponse(false, false), null));
@@ -1164,7 +1164,7 @@ public final class AcquireTokenSilentHandlerTest {
         Mockito.verify(mockedWebRequestHandler, Mockito.times(1)).sendPost(
                 Mockito.any(URL.class), Mockito.<String, String>anyMap(),
                 AdditionalMatchers.aryEq(
-                        Util.getPoseMessage(rtForTestHost, clientId, resource)), Mockito.anyString());
+                        Util.getPostMessage(rtForTestHost, clientId, resource)), Mockito.anyString());
 
         // verify token items
         final String preferredCacheLocation = "https://preferred.cache/test.onmicrosoft.com";

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -1318,6 +1318,8 @@ public final class AcquireTokenSilentHandlerTest {
                                                            final String clientId, final boolean isExtendedLifetimeEnabled) {
         AuthenticationRequest request = new AuthenticationRequest(authority, resource, clientId, UUID.randomUUID(),
                 isExtendedLifetimeEnabled);
+        request.setAppVersion("test");
+        request.setAppName("test.mock.");
 
         request.setTelemetryRequestId(UUID.randomUUID().toString());
         return request;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -2653,7 +2653,7 @@ public final class AuthenticationContextTest {
             e.printStackTrace();
         }
 
-        result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN);
+        result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN, claims.toString());
         assertNull("Error is null", result.getErrorCode());
         assertEquals("Same token as refresh token result", expectedAT,
                 result.getAccessToken());

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -566,6 +566,35 @@ public final class AuthenticationContextTest {
         assertNull("Extra query param is null", authenticationRequest2.getExtraQueryParamsAuthentication());
     }
 
+    @Test
+    public void testInvalidClaimsAcquireToken() throws InterruptedException {
+        FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+        final AuthenticationContext context = getAuthenticationContext(mockContext,
+                "https://login.windows.net/common", false, null);
+
+        List<String> capabilities = new ArrayList<>();
+        capabilities.add("CC1");
+        capabilities.add("CC2");
+        context.setClientCapabilites(capabilities);
+
+        final MockActivity testActivity = new MockActivity();
+        final CountDownLatch signal = new CountDownLatch(1);
+        String expected = "&extraParam=1";
+        MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
+        testActivity.mSignal = signal;
+
+        // 1 - Send extra param
+        context.acquireToken(testActivity.getTestActivity(), "testResource",
+                "testClientId", "testredirectUri", "test_login_hint",
+                PromptBehavior.Always, "&extraParam=1", "invalid_claims", callback);
+        signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
+        // Check response in callback result
+        assertNotNull("Error is not null", callback.getException());
+        assertEquals("NOT_A_VALID_CLAIMS_JSON", ADALError.JSON_PARSE_ERROR,
+                ((AuthenticationException) callback.getException()).getCode());
+
+    }
+
     public static AuthenticationRequest createAuthenticationRequest(final String authority, final String resource,
                                                                     final String client, final String redirect, final String loginhint, final boolean isExtendedLifetimeEnabled) {
 
@@ -944,6 +973,8 @@ public final class AuthenticationContextTest {
                 testActivity.mStartActivityRequestCode);
         clearCache(context);
     }
+
+
 
     /**
      * acquire token using refresh token. All web calls are mocked. Refresh
@@ -2622,6 +2653,92 @@ public final class AuthenticationContextTest {
             e.printStackTrace();
         }
 
+        result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN);
+        assertNull("Error is null", result.getErrorCode());
+        assertEquals("Same token as refresh token result", expectedAT,
+                result.getAccessToken());
+
+        clearCache(context);
+    }
+
+    @Test
+    public void testAcquireTokenSilentSyncClientCapabilitiesWithoutBroker() throws IOException, AuthenticationException, InterruptedException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+
+        final String clientId = "clientId";
+
+        final String tokenToTest = "accessToken=" + UUID.randomUUID();
+        final String expectedAT = "accesstoken";
+        String resource = "Resource" + UUID.randomUUID();
+        ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        mockCache.removeAll();
+
+        TestCacheItem newItem = new TestCacheItem();
+        newItem.setToken(tokenToTest);
+        newItem.setRefreshToken("refreshTokenNormal");
+        newItem.setAuthority(VALID_AUTHORITY);
+        newItem.setResource(resource);
+        newItem.setClientId(clientId);
+        newItem.setUserId(TEST_IDTOKEN_USERID);
+        newItem.setName("name");
+        newItem.setFamilyName("familyName");
+        newItem.setDisplayId(TEST_IDTOKEN_UPN);
+        newItem.setTenantId("tenantId");
+        newItem.setMultiResource(false);
+
+        addItemToCache(mockCache, newItem);
+
+        newItem = new TestCacheItem();
+        newItem.setToken("");
+        newItem.setRefreshToken("refreshTokenMultiResource");
+        newItem.setAuthority(VALID_AUTHORITY);
+        newItem.setResource(resource);
+        newItem.setClientId(clientId);
+        newItem.setUserId(TEST_IDTOKEN_USERID);
+        newItem.setName("name");
+        newItem.setFamilyName("familyName");
+        newItem.setDisplayId(TEST_IDTOKEN_UPN);
+        newItem.setTenantId("tenantId");
+        newItem.setMultiResource(true);
+
+        addItemToCache(mockCache, newItem);
+        // only one MRRT for same user, client, authority
+        final AuthenticationContext context = new AuthenticationContext(mockContext,
+                VALID_AUTHORITY, false, mockCache);
+
+        final String response = "{\"access_token\":\"accesstoken"
+                + "\",\"token_type\":\"Bearer\",\"expires_in\":\"29344\",\"expires_on\":\"1368768616\","
+                + "\"resource\":\"" + resource + "\","
+                + "\"refresh_token\":\""
+                + "refreshToken" + "\",\"scope\":\"*\",\"id_token\":\"" + TEST_IDTOKEN + "\", \"client_info\":\"" + Util.TEST_CLIENT_INFO + "\"}";
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response),
+                Util.createInputStream(response));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        // 1st token request, read from cache.
+        AuthenticationResult result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN);
+        assertNull("Error is null", result.getErrorCode());
+        assertEquals("Same token in response as in cache", tokenToTest,
+                result.getAccessToken());
+
+        List<String> capabilities = new ArrayList<>();
+        capabilities.add("CC1");
+        capabilities.add("CC2");
+        context.setClientCapabilites(capabilities);
+
+        JSONObject email = new JSONObject();
+        JSONObject claims = new JSONObject();
+        try {
+            email.put("email", null);
+            claims.put("id_token", email);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
         // 2nd token request with claims with correct claims
         result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN, claims.toString());
         assertNull("Error is null", result.getErrorCode());
@@ -2629,6 +2746,131 @@ public final class AuthenticationContextTest {
                 result.getAccessToken());
 
         clearCache(context);
+    }
+
+    @Test
+    public void testAcquireTokenSilentSyncClientCapabilitiesAndClaims() throws IOException, AuthenticationException, InterruptedException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+
+        final String clientId = "clientId";
+
+        final String tokenToTest = "accessToken=" + UUID.randomUUID();
+        final String expectedAT = "accesstoken";
+        String resource = "Resource" + UUID.randomUUID();
+        ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        mockCache.removeAll();
+
+        TestCacheItem newItem = new TestCacheItem();
+        newItem.setToken(tokenToTest);
+        newItem.setRefreshToken("refreshTokenNormal");
+        newItem.setAuthority(VALID_AUTHORITY);
+        newItem.setResource(resource);
+        newItem.setClientId(clientId);
+        newItem.setUserId(TEST_IDTOKEN_USERID);
+        newItem.setName("name");
+        newItem.setFamilyName("familyName");
+        newItem.setDisplayId(TEST_IDTOKEN_UPN);
+        newItem.setTenantId("tenantId");
+        newItem.setMultiResource(false);
+
+        addItemToCache(mockCache, newItem);
+
+        newItem = new TestCacheItem();
+        newItem.setToken("");
+        newItem.setRefreshToken("refreshTokenMultiResource");
+        newItem.setAuthority(VALID_AUTHORITY);
+        newItem.setResource(resource);
+        newItem.setClientId(clientId);
+        newItem.setUserId(TEST_IDTOKEN_USERID);
+        newItem.setName("name");
+        newItem.setFamilyName("familyName");
+        newItem.setDisplayId(TEST_IDTOKEN_UPN);
+        newItem.setTenantId("tenantId");
+        newItem.setMultiResource(true);
+
+        addItemToCache(mockCache, newItem);
+        // only one MRRT for same user, client, authority
+        final AuthenticationContext context = new AuthenticationContext(mockContext,
+                VALID_AUTHORITY, false, mockCache);
+
+        final String response = "{\"access_token\":\"accesstoken"
+                + "\",\"token_type\":\"Bearer\",\"expires_in\":\"29344\",\"expires_on\":\"1368768616\","
+                + "\"resource\":\"" + resource + "\","
+                + "\"refresh_token\":\""
+                + "refreshToken" + "\",\"scope\":\"*\",\"id_token\":\"" + TEST_IDTOKEN + "\", \"client_info\":\"" + Util.TEST_CLIENT_INFO + "\"}";
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response),
+                Util.createInputStream(response));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        // 1st token request, read from cache.
+        AuthenticationResult result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN);
+        assertNull("Error is null", result.getErrorCode());
+        assertEquals("Same token in response as in cache", tokenToTest,
+                result.getAccessToken());
+
+
+        List<String> capabilities = new ArrayList<>();
+        capabilities.add("CC1");
+        capabilities.add("CC2");
+        context.setClientCapabilites(capabilities);
+
+
+
+        // 2nd token request with claims with correct claims
+        result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN);
+        assertNull("Error is null", result.getErrorCode());
+        assertEquals("Same token as refresh token result", expectedAT,
+                result.getAccessToken());
+
+        clearCache(context);
+    }
+
+
+    @Test(expected = AuthenticationException.class)
+    public void testInvalidClaimsAcquireTokenSilent() throws AuthenticationException, InterruptedException {
+        final FileMockContext mockContext = new FileMockContext(InstrumentationRegistry.getContext());
+
+        final String clientId = "clientId";
+
+        final String tokenToTest = "accessToken=" + UUID.randomUUID();
+        String resource = "Resource" + UUID.randomUUID();
+        ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
+        mockCache.removeAll();
+
+        TestCacheItem newItem = new TestCacheItem();
+        newItem.setToken(tokenToTest);
+        newItem.setRefreshToken("refreshTokenNormal");
+        newItem.setAuthority(VALID_AUTHORITY);
+        newItem.setResource(resource);
+        newItem.setClientId(clientId);
+        newItem.setUserId(TEST_IDTOKEN_USERID);
+        newItem.setName("name");
+        newItem.setFamilyName("familyName");
+        newItem.setDisplayId(TEST_IDTOKEN_UPN);
+        newItem.setTenantId("tenantId");
+        newItem.setMultiResource(false);
+
+        addItemToCache(mockCache, newItem);
+
+        final AuthenticationContext context = new AuthenticationContext(mockContext,
+                VALID_AUTHORITY, false, mockCache);
+
+        // 1st token request, read from cache.
+        AuthenticationResult result = context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN);
+        assertNull("Error is null", result.getErrorCode());
+        assertEquals("Same token in response as in cache", tokenToTest,
+                result.getAccessToken());
+
+        List<String> capabilities = new ArrayList<>();
+        capabilities.add("CC1");
+        capabilities.add("CC2");
+        context.setClientCapabilites(capabilities);
+
+        context.acquireTokenSilentSync(resource, clientId, TEST_IDTOKEN_UPN, "invalid_claims");
     }
 
     @Test

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/OauthTests.java
@@ -272,6 +272,11 @@ public class OauthTests {
         final Oauth2 oAuthxtraQPContainHasChrome = createOAuthInstance(extraQPContainHasChrome);
         final String actualCodeRequestQPHasChrome = oAuthxtraQPContainHasChrome.getCodeRequestUrl();
         assertTrue("Prompt", actualCodeRequestQPHasChrome.contains("&prompt=login&extra=1&haschrome=1"));
+
+        request.setAppName("test.mock.");
+        request.setAppVersion("test");
+        final Oauth2  oAuthWithAppInfo = createOAuthInstance(request);
+        assertTrue("App Info", oAuthWithAppInfo.getCodeRequestUrl().contains("&x-app-name=test.mock.&x-app-ver=test"));
     }
 
     @Test
@@ -347,12 +352,21 @@ public class OauthTests {
                 "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1",
                 oauthWithoutLoginHint.buildTokenRequestMessage("authorizationcodevalue="));
 
+        request.setAppName("test.mock.");
+        request.setAppVersion("test");
+
+        final Oauth2 oauthAppInfo = createOAuthInstance(request);
+        assertEquals(
+                "Token request",
+                "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1&x-app-name=test.mock.&x-app-ver=test",
+                oauthAppInfo.buildTokenRequestMessage("authorizationcodevalue="));
+
         // with claims challenge
         request.setClaimsChallenge("testClaims");
         final Oauth2 oauthClaims = createOAuthInstance(request);
         assertEquals(
                 "Token request",
-                "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1&claims=testClaims",
+                "grant_type=authorization_code&code=authorizationcodevalue%3D&client_id=client+1234567890-%2B%3D%3B%27&redirect_uri=redirect+1234567890-%2B%3D%3B%27&client_info=1&claims=testClaims&x-app-name=test.mock.&x-app-ver=test",
                 oauthClaims.buildTokenRequestMessage("authorizationcodevalue="));
 
     }
@@ -378,11 +392,18 @@ public class OauthTests {
         final Oauth2 oauthWithoutResource = createOAuthInstance(requestWithoutResource);
         assertTrue(oauthWithoutResource.buildRefreshTokenRequestMessage("refreshToken234343455=").startsWith("grant_type=refresh_token&refresh_token=refreshToken234343455%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1"));
 
+        request.setAppName("test.mock.");
+        request.setAppVersion("test");
+
+        final Oauth2 oauthAppInfo = createOAuthInstance(request);
+        assertEquals("grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+&redirect_uri=redirect+1234567890-%2B%3D%3B%27&x-app-name=test.mock.&x-app-ver=test",
+                oauthAppInfo.buildRefreshTokenRequestMessage("refreshToken23434="));
+
         // with claims challenge
         request.setClaimsChallenge("testClaims");
         final Oauth2 oauthClaims = createOAuthInstance(request);
 
-        assertEquals("grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+&redirect_uri=redirect+1234567890-%2B%3D%3B%27&claims=testClaims",
+        assertEquals("grant_type=refresh_token&refresh_token=refreshToken23434%3D&client_id=client+1234567890-%2B%3D%3B%27&client_info=1&resource=resource%2520+&redirect_uri=redirect+1234567890-%2B%3D%3B%27&claims=testClaims&x-app-name=test.mock.&x-app-ver=test",
                 oauthClaims.buildRefreshTokenRequestMessage("refreshToken23434="));
 
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -162,12 +162,16 @@ final class Util {
 
     static byte[] getPoseMessage(final String refreshToken, final String clientId, final String resource)
             throws UnsupportedEncodingException {
-        return String.format("%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
+        String string = String.format("%s=%s&%s=%s&%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
                 AuthenticationConstants.OAuth2.GRANT_TYPE, urlFormEncode(AuthenticationConstants.OAuth2.REFRESH_TOKEN),
                 AuthenticationConstants.OAuth2.REFRESH_TOKEN, urlFormEncode(refreshToken),
                 AuthenticationConstants.OAuth2.CLIENT_ID, urlFormEncode(clientId),
                 AuthenticationConstants.OAuth2.CLIENT_INFO, urlFormEncode(AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE),
-                AuthenticationConstants.AAD.RESOURCE, urlFormEncode(resource)).getBytes();
+                AuthenticationConstants.AAD.RESOURCE, urlFormEncode(resource),
+                AuthenticationConstants.AAD.APP_PACKAGE_NAME, urlFormEncode("test.mock."),
+                AuthenticationConstants.AAD.APP_VERSION, urlFormEncode("test"));
+
+        return string.getBytes();
     }
 
     static String urlFormEncode(String source) throws UnsupportedEncodingException {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/Util.java
@@ -160,7 +160,7 @@ final class Util {
         return jsonObject.toString();
     }
 
-    static byte[] getPoseMessage(final String refreshToken, final String clientId, final String resource)
+    static byte[] getPostMessage(final String refreshToken, final String clientId, final String resource)
             throws UnsupportedEncodingException {
         String string = String.format("%s=%s&%s=%s&%s=%s&%s=%s&%s=%s&%s=%s&%s=%s",
                 AuthenticationConstants.OAuth2.GRANT_TYPE, urlFormEncode(AuthenticationConstants.OAuth2.REFRESH_TOKEN),

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -273,7 +273,7 @@ public class AuthenticationContext {
                              AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, PromptBehavior.Auto, null,
-                null , callback, EventStrings.ACQUIRE_TOKEN_1, wrapActivity(activity));
+                null , callback, EventStrings.ACQUIRE_TOKEN_1, wrapActivity(activity), false);
     }
 
     /**
@@ -302,7 +302,7 @@ public class AuthenticationContext {
                              AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, PromptBehavior.Auto, extraQueryParameters,
-                null, callback,  EventStrings.ACQUIRE_TOKEN_2, wrapActivity(activity));
+                null, callback,  EventStrings.ACQUIRE_TOKEN_2, wrapActivity(activity), false);
     }
 
     /**
@@ -328,7 +328,7 @@ public class AuthenticationContext {
                              AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, null, prompt, null,
-                null, callback, EventStrings.ACQUIRE_TOKEN_3, wrapActivity(activity));
+                null, callback, EventStrings.ACQUIRE_TOKEN_3, wrapActivity(activity), false);
     }
 
     /**
@@ -353,7 +353,7 @@ public class AuthenticationContext {
                              @Nullable String redirectUri, @Nullable PromptBehavior prompt, @Nullable String extraQueryParameters,
                              AuthenticationCallback<AuthenticationResult> callback) {
         acquireToken(resource, clientId, redirectUri, null, prompt, extraQueryParameters,
-                null, callback, EventStrings.ACQUIRE_TOKEN_4, wrapActivity(activity));
+                null, callback, EventStrings.ACQUIRE_TOKEN_4, wrapActivity(activity), false);
     }
 
     /**
@@ -381,7 +381,7 @@ public class AuthenticationContext {
                              @Nullable String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                null, callback, EventStrings.ACQUIRE_TOKEN_5, wrapActivity(activity));
+                null, callback, EventStrings.ACQUIRE_TOKEN_5, wrapActivity(activity), false);
     }
 
     /**
@@ -407,7 +407,7 @@ public class AuthenticationContext {
                              @Nullable final String claims, final AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                claims, callback, EventStrings.ACQUIRE_TOKEN_8, wrapActivity(activity));
+                claims, callback, EventStrings.ACQUIRE_TOKEN_8, wrapActivity(activity), false);
     }
 
     /**
@@ -434,7 +434,7 @@ public class AuthenticationContext {
                              @Nullable String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                null, callback, EventStrings.ACQUIRE_TOKEN_6, fragment);
+                null, callback, EventStrings.ACQUIRE_TOKEN_6, fragment, false);
 
     }
 
@@ -461,7 +461,7 @@ public class AuthenticationContext {
                              @Nullable final String claims, final AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                claims, callback, EventStrings.ACQUIRE_TOKEN_9, fragment);
+                claims, callback, EventStrings.ACQUIRE_TOKEN_9, fragment, false);
     }
 
     /**
@@ -491,7 +491,7 @@ public class AuthenticationContext {
                              AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                null, callback, EventStrings.ACQUIRE_TOKEN_7, null);
+                null, callback, EventStrings.ACQUIRE_TOKEN_7, null, true);
     }
 
     /**
@@ -523,7 +523,7 @@ public class AuthenticationContext {
                              @Nullable final String claims, final AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                claims, callback, EventStrings.ACQUIRE_TOKEN_10, null);
+                claims, callback, EventStrings.ACQUIRE_TOKEN_10, null, false);
 
     }
 
@@ -531,7 +531,7 @@ public class AuthenticationContext {
                               @Nullable final String loginHint, @Nullable final PromptBehavior prompt,
                               @Nullable String extraQueryParameters, @Nullable final String claims,
                               final AuthenticationCallback<AuthenticationResult> callback, String apiEventString,
-                              final IWindowComponent fragment){
+                              final IWindowComponent fragment, final boolean useDialog){
 
         throwIfClaimsInBothExtraQpAndClaimsParameter(claims, extraQueryParameters);
 
@@ -554,12 +554,12 @@ public class AuthenticationContext {
             request.setTelemetryRequestId(requestId);
             setAppInfoToRequest(request);
 
-            if(!TextUtils.isEmpty(loginHint)) {
+            if(!StringExtensions.isNullOrBlank(loginHint)) {
                 apiEvent.setLoginHint(loginHint);
                 request.setUserIdentifierType(UserIdentifierType.LoginHint);
             }
 
-            createAcquireTokenRequest(apiEvent).acquireToken(fragment, false, request, callback);
+            createAcquireTokenRequest(apiEvent).acquireToken(fragment, useDialog, request, callback);
         }
 
     }
@@ -1157,22 +1157,77 @@ public class AuthenticationContext {
         };
     }
 
-    private String mergeClaimsWithClientCapabilities(String claims) throws JSONException {
+    /**
+     * Util method to merge
+     * @param claims input claims passed on acquireToken call
+     * @return merged claims with capabilities
+     * @throws JSONException if input claims is an invalid JSON
+     *
+     * Sample input claim :
+     *      {
+                "userinfo":
+                {
+                    "given_name": {"essential": true},
+                    "email": {"essential": true},
+                },
+                "id_token":
+                {
+                    "auth_time": {"essential": true},
+                }
+            }
+
+     Sample capabilities list : [CP1, CP2 CP3]
+
+     Output merged claims :
+        {
+            "userinfo": {
+                "given_name": {
+                    "essential": true
+                },
+                "email": {
+                    "essential": true
+                }
+            },
+            "id_token": {
+                "auth_time": {
+                    "essential": true
+                }
+            },
+            "access_token": {
+                "xms_cc": {
+                    "values": ["CP1", "CP2"]
+                }
+            }
+        }
+     */
+    String mergeClaimsWithClientCapabilities(final String claims) throws JSONException {
         if (mClientCapabilites == null || mClientCapabilites.isEmpty()) {
             return claims;
         }
-        String claimsResult = null;
-        JSONArray capabilitiesArray = new JSONArray();
+        String claimsResult;
+        final JSONArray capabilitiesArray = new JSONArray();
 
         for (String capability : mClientCapabilites) {
             capabilitiesArray.put(capability);
         }
 
-        JSONObject capabilities = new JSONObject();
-        capabilities.put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITIES_CLAIMS_LIST, capabilitiesArray);
+        final JSONObject capabilities = new JSONObject();
+        final JSONObject values = new JSONObject();
+        values.put("values", capabilitiesArray);
+        capabilities.put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITIES_CLAIMS_LIST, values);
 
         if (!TextUtils.isEmpty(claims)) {
-            claimsResult = new JSONObject(claims).put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITY_ACCESS_TOKEN, capabilities).toString();
+            final JSONObject claimsJson = new JSONObject(claims);
+
+            if (claimsJson.has(AuthenticationConstants.OAuth2.CLIENT_CAPABILITY_ACCESS_TOKEN)) {
+                final JSONObject accessTokenClaim = claimsJson.getJSONObject(AuthenticationConstants.OAuth2.CLIENT_CAPABILITY_ACCESS_TOKEN);
+                accessTokenClaim.put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITIES_CLAIMS_LIST, values);
+                claimsJson.put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITY_ACCESS_TOKEN, accessTokenClaim);
+            } else {
+                claimsJson.put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITY_ACCESS_TOKEN, capabilities);
+            }
+            claimsResult = claimsJson.toString();
+
         } else {
             JSONObject claimsObject = new JSONObject();
             claimsObject.put(AuthenticationConstants.OAuth2.CLIENT_CAPABILITY_ACCESS_TOKEN, capabilities);
@@ -1461,7 +1516,7 @@ public class AuthenticationContext {
     }
 
     public void setClientCapabilites(List<String> clientCapabilites){
-        this.mClientCapabilites = clientCapabilites;
+        mClientCapabilites = clientCapabilites;
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -28,12 +28,14 @@ import android.accounts.OperationCanceledException;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Looper;
 import android.os.NetworkOnMainThreadException;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
+import android.text.TextUtils;
 import android.util.SparseArray;
 
 import com.googleblog.android_developers.PRNGFixes;
@@ -264,20 +266,8 @@ public class AuthenticationContext {
                              @Nullable String redirectUri, @Nullable String loginHint,
                              AuthenticationCallback<AuthenticationResult> callback) {
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_1);
-            apiEvent.setLoginHint(loginHint);
-            redirectUri = getRedirectUri(redirectUri);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, PromptBehavior.Auto, null,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(wrapActivity(activity), false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, loginHint, PromptBehavior.Auto, null,
+                null , callback, EventStrings.ACQUIRE_TOKEN_1, wrapActivity(activity));
     }
 
     /**
@@ -305,20 +295,8 @@ public class AuthenticationContext {
                              @Nullable String redirectUri, @Nullable String loginHint, @Nullable String extraQueryParameters,
                              AuthenticationCallback<AuthenticationResult> callback) {
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_2);
-            apiEvent.setLoginHint(loginHint);
-            redirectUri = getRedirectUri(redirectUri);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, PromptBehavior.Auto, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(wrapActivity(activity), false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, loginHint, PromptBehavior.Auto, extraQueryParameters,
+                null, callback,  EventStrings.ACQUIRE_TOKEN_2, wrapActivity(activity));
     }
 
     /**
@@ -342,21 +320,9 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
                              @Nullable String redirectUri, @Nullable PromptBehavior prompt,
                              AuthenticationCallback<AuthenticationResult> callback) {
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(null, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
 
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_3);
-            apiEvent.setPromptBehavior(prompt);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, null, prompt, null, getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-
-            request.setTelemetryRequestId(requestId);
-
-            createAcquireTokenRequest(apiEvent).acquireToken(wrapActivity(activity), false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, null, prompt, null,
+                null, callback, EventStrings.ACQUIRE_TOKEN_3, wrapActivity(activity));
     }
 
     /**
@@ -380,22 +346,8 @@ public class AuthenticationContext {
     public void acquireToken(Activity activity, String resource, String clientId,
                              @Nullable String redirectUri, @Nullable PromptBehavior prompt, @Nullable String extraQueryParameters,
                              AuthenticationCallback<AuthenticationResult> callback) {
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(null, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
-
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_4);
-            apiEvent.setPromptBehavior(prompt);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, null, prompt, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-
-            request.setTelemetryRequestId(requestId);
-
-            createAcquireTokenRequest(apiEvent).acquireToken(wrapActivity(activity), false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, null, prompt, extraQueryParameters,
+                null, callback, EventStrings.ACQUIRE_TOKEN_4, wrapActivity(activity));
     }
 
     /**
@@ -422,21 +374,8 @@ public class AuthenticationContext {
                              @Nullable String redirectUri, @Nullable String loginHint, @Nullable PromptBehavior prompt,
                              @Nullable String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_5);
-            apiEvent.setPromptBehavior(prompt);
-            apiEvent.setLoginHint(loginHint);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(wrapActivity(activity), false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                null, callback, EventStrings.ACQUIRE_TOKEN_5, wrapActivity(activity));
     }
 
     /**
@@ -460,23 +399,9 @@ public class AuthenticationContext {
     public void acquireToken(final Activity activity, final String resource, final String clientId, @Nullable String redirectUri,
                              @Nullable final String loginHint, @Nullable final PromptBehavior prompt, @Nullable String extraQueryParameters,
                              @Nullable final String claims, final AuthenticationCallback<AuthenticationResult> callback) {
-        throwIfClaimsInBothExtraQpAndClaimsParameter(claims, extraQueryParameters);
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_8);
-            apiEvent.setPromptBehavior(prompt);
-            apiEvent.setLoginHint(loginHint);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), claims);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(wrapActivity(activity), false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                claims, callback, EventStrings.ACQUIRE_TOKEN_8, wrapActivity(activity));
     }
 
     /**
@@ -502,21 +427,9 @@ public class AuthenticationContext {
                              @Nullable String redirectUri, @Nullable String loginHint, @Nullable PromptBehavior prompt,
                              @Nullable String extraQueryParameters, AuthenticationCallback<AuthenticationResult> callback) {
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_6);
-            apiEvent.setPromptBehavior(prompt);
-            apiEvent.setLoginHint(loginHint);
+        acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                null, callback, EventStrings.ACQUIRE_TOKEN_6, fragment);
 
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(fragment, false, request, callback);
-        }
     }
 
     /**
@@ -540,23 +453,9 @@ public class AuthenticationContext {
     public void acquireToken(final IWindowComponent fragment, final String resource, final String clientId, @Nullable String redirectUri,
                              @Nullable final String loginHint, @Nullable final PromptBehavior prompt, @Nullable String extraQueryParameters,
                              @Nullable final String claims, final AuthenticationCallback<AuthenticationResult> callback) {
-        throwIfClaimsInBothExtraQpAndClaimsParameter(claims, extraQueryParameters);
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_9);
-            apiEvent.setPromptBehavior(prompt);
-            apiEvent.setLoginHint(loginHint);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), claims);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(fragment, false, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                claims, callback, EventStrings.ACQUIRE_TOKEN_9, fragment);
     }
 
     /**
@@ -585,22 +484,8 @@ public class AuthenticationContext {
                              @Nullable String loginHint, @Nullable PromptBehavior prompt, @Nullable String extraQueryParameters,
                              AuthenticationCallback<AuthenticationResult> callback) {
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
-            redirectUri = getRedirectUri(redirectUri);
-            final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_7);
-            apiEvent.setPromptBehavior(prompt);
-            apiEvent.setLoginHint(loginHint);
-
-            final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
-                    clientId, redirectUri, loginHint, prompt, extraQueryParameters,
-                    getRequestCorrelationId(), getExtendedLifetimeEnabled(), null);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
-            request.setTelemetryRequestId(requestId);
-
-            createAcquireTokenRequest(apiEvent).acquireToken(null, true, request, callback);
-        }
+        acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                null, callback, EventStrings.ACQUIRE_TOKEN_7, null);
     }
 
     /**
@@ -630,23 +515,40 @@ public class AuthenticationContext {
     public void acquireToken(final String resource, final String clientId, @Nullable String redirectUri,
                              @Nullable final String loginHint, @Nullable final PromptBehavior prompt, @Nullable String extraQueryParameters,
                              @Nullable final String claims, final AuthenticationCallback<AuthenticationResult> callback) {
+
+        acquireToken(resource, clientId, redirectUri, loginHint, prompt, extraQueryParameters,
+                claims, callback, EventStrings.ACQUIRE_TOKEN_10, null);
+
+    }
+
+    private void acquireToken(final String resource, final String clientId, @Nullable String redirectUri,
+                              @Nullable final String loginHint, @Nullable final PromptBehavior prompt,
+                              @Nullable String extraQueryParameters, @Nullable final String claims,
+                              final AuthenticationCallback<AuthenticationResult> callback, String apiEventString,
+                              final IWindowComponent fragment){
+
         throwIfClaimsInBothExtraQpAndClaimsParameter(claims, extraQueryParameters);
 
-        if (checkPreRequirements(resource, clientId, callback)
-                && checkADFSValidationRequirements(loginHint, callback)) {
+        if (checkPreRequirements(resource, clientId, callback) && checkADFSValidationRequirements(loginHint, callback)) {
             redirectUri = getRedirectUri(redirectUri);
             final String requestId = Telemetry.registerNewRequest();
-            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, EventStrings.ACQUIRE_TOKEN_10);
+            final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, apiEventString);
             apiEvent.setPromptBehavior(prompt);
-            apiEvent.setLoginHint(loginHint);
 
             final AuthenticationRequest request = new AuthenticationRequest(mAuthority, resource,
                     clientId, redirectUri, loginHint, prompt, extraQueryParameters,
                     getRequestCorrelationId(), getExtendedLifetimeEnabled(), claims);
-            request.setUserIdentifierType(UserIdentifierType.LoginHint);
             request.setTelemetryRequestId(requestId);
-            createAcquireTokenRequest(apiEvent).acquireToken(null, false, request, callback);
+            setAppInfoToRequest(request);
+
+            if(!TextUtils.isEmpty(loginHint)) {
+                apiEvent.setLoginHint(loginHint);
+                request.setUserIdentifierType(UserIdentifierType.LoginHint);
+            }
+
+            createAcquireTokenRequest(apiEvent).acquireToken(fragment, false, request, callback);
         }
+
     }
 
     /**
@@ -746,6 +648,7 @@ public class AuthenticationContext {
         request.setPrompt(PromptBehavior.Auto);
         request.setUserIdentifierType(UserIdentifierType.UniqueId);
         request.setTelemetryRequestId(requestId);
+        setAppInfoToRequest(request);
 
         final Looper currentLooper = Looper.myLooper();
         if (currentLooper != null && currentLooper == mContext.getMainLooper()) {
@@ -839,6 +742,7 @@ public class AuthenticationContext {
         request.setUserIdentifierType(UserIdentifierType.UniqueId);
 
         request.setTelemetryRequestId(requestId);
+        setAppInfoToRequest(request);
 
 
         createAcquireTokenRequest(apiEvent).acquireToken(null, false, request,
@@ -965,6 +869,7 @@ public class AuthenticationContext {
         request.setSilent(true);
         request.setPrompt(PromptBehavior.Auto);
         request.setUserIdentifierType(UserIdentifierType.UniqueId);
+        setAppInfoToRequest(request);
 
         request.setTelemetryRequestId(requestId);
 
@@ -1193,6 +1098,17 @@ public class AuthenticationContext {
     public void setRequestCorrelationId(final UUID requestCorrelationId) {
         this.mRequestCorrelationId = requestCorrelationId;
         Logger.setCorrelationId(requestCorrelationId);
+    }
+
+    private void setAppInfoToRequest(AuthenticationRequest request){
+        String packageName = mContext.getPackageName();
+        request.setAppName(packageName);
+        try {
+            PackageInfo packageInfo = mContext.getPackageManager().getPackageInfo(packageName, 0);
+            request.setAppVersion(packageInfo.versionName);
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
     }
 
     private IWindowComponent wrapActivity(final Activity activity) {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -81,6 +81,10 @@ class AuthenticationRequest implements Serializable {
 
     private boolean mSkipCache = false;
 
+    private String mAppName;
+
+    private String mAppVersion;
+
     /**
      * Developer can use acquireToken(with loginhint) or acquireTokenSilent(with
      * userid), so this sets the type of the request.
@@ -383,5 +387,21 @@ class AuthenticationRequest implements Serializable {
 
     public void setForceRefresh(boolean forceRefresh){
         mForceRefresh = forceRefresh;
+    }
+
+    public String getAppName() {
+        return mAppName;
+    }
+
+    public void setAppName(String appName) {
+        mAppName = appName;
+    }
+
+    public String getAppVersion() {
+        return mAppVersion;
+    }
+
+    public void setAppVersion(String appVersion) {
+        mAppVersion = appVersion;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -207,6 +207,14 @@ class Oauth2 {
             queryParameter.appendQueryParameter(AuthenticationConstants.OAuth2.CLAIMS, mRequest.getClaimsChallenge());
         }
 
+        if(!StringExtensions.isNullOrBlank(mRequest.getAppName())){
+            queryParameter.appendQueryParameter(AuthenticationConstants.AAD.APP_PACKAGE_NAME, mRequest.getAppName());
+        }
+
+        if(!StringExtensions.isNullOrBlank(mRequest.getAppVersion())){
+            queryParameter.appendQueryParameter(AuthenticationConstants.AAD.APP_VERSION, mRequest.getAppVersion());
+        }
+
         String requestUrl = queryParameter.build().getQuery();
         if (!StringExtensions.isNullOrBlank(extraQP)) {
             String parsedQP = extraQP;
@@ -250,6 +258,15 @@ class Oauth2 {
                     StringExtensions.urlFormEncode(mRequest.getClaimsChallenge()));
         }
 
+        if (!StringExtensions.isNullOrBlank(mRequest.getAppName())) {
+            message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.AAD.APP_PACKAGE_NAME,
+                    StringExtensions.urlFormEncode(mRequest.getAppName()));
+        }
+
+        if (!StringExtensions.isNullOrBlank(mRequest.getAppVersion())) {
+            message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.AAD.APP_VERSION,
+                    StringExtensions.urlFormEncode(mRequest.getAppVersion()));
+        }
         return message;
 
     }
@@ -288,6 +305,15 @@ class Oauth2 {
                     StringExtensions.urlFormEncode(mRequest.getClaimsChallenge()));
         }
 
+        if (!StringExtensions.isNullOrBlank(mRequest.getAppName())) {
+            message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.AAD.APP_PACKAGE_NAME,
+                    StringExtensions.urlFormEncode(mRequest.getAppName()));
+        }
+
+        if (!StringExtensions.isNullOrBlank(mRequest.getAppVersion())) {
+            message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.AAD.APP_VERSION,
+                    StringExtensions.urlFormEncode(mRequest.getAppVersion()));
+        }
         return message;
     }
 


### PR DESCRIPTION
- Added app name and app version : [API proprosal  ](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/542?_a=files&path=%2FClientAppNameVersion%2Foverview.md)
- Refactored acquireToken overloads to remove duplicate code.
- Updated  unit tests to validate these new query params

- Added client capabilities support : [API proposal](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/533?_a=files&path=%2FClientCapabilities%2Foverview.md)
- Added unit tests to validate client capabilities support.

Todo: 

- Confirm the final format of client capabilities and test with server Test Slice 
- Add sanity checks based on Authenticator and company portal versions to apply these changes only to updated app versions
- Update submodule once https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/280 merges

