### PR TITLE
Fixed a bug where the token is refreshed if Client capabilities are set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ADAL for Android gives you the ability to add support for Work Accounts to your 
 
 A Work Account is an identity you use to get work done from your organization or school. Anywhere you need to get access to your work life you'll use a Work Account. The Work Account can be tied to an Active Directory server running in your datacenter or live completely in the cloud like when you use Office 365. A Work Account will be how your users know that they are accessing their important documents and data backed my Microsoft security.
 
-## ADAL for Android 1.16.0 Released!
+## ADAL for Android 1.16.1 Released!
 
 ## Build status
 
@@ -17,7 +17,7 @@ Note: A corpnet account is required to view the VSTS build.
 
 ## Versions
 
-Current version - 1.16.0
+Current version - 1.16.1
 
 Minimum recommended version - 1.1.16
 
@@ -132,7 +132,7 @@ If you are using the m2e plugin in Eclipse, you can specify the dependency in yo
 <dependency>
     <groupId>com.microsoft.aad</groupId>
     <artifactId>adal</artifactId>
-    <version>1.16.0</version>
+    <version>1.16.1</version>
     <type>aar</type>
 </dependency>
 ```

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.7', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:0.0.7") {
+    distApi("com.microsoft.identity:common:0.0.8-RC") {
         transitive = false
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -28,6 +28,7 @@ import android.support.annotation.Nullable;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -84,6 +85,8 @@ class AuthenticationRequest implements Serializable {
     private String mAppName;
 
     private String mAppVersion;
+
+    private List<String> mClientCapabilities;
 
     /**
      * Developer can use acquireToken(with loginhint) or acquireTokenSilent(with
@@ -403,5 +406,13 @@ class AuthenticationRequest implements Serializable {
 
     public void setAppVersion(String appVersion) {
         mAppVersion = appVersion;
+    }
+
+    public List<String> getClientCapabilities() {
+        return mClientCapabilities;
+    }
+
+    public void setClientCapabilities(final List<String> clientCapabilities) {
+        this.mClientCapabilities = clientCapabilities;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -770,11 +770,20 @@ class BrokerProxy implements IBrokerProxy {
             brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_PROMPT, request.getPrompt().name());
         }
 
-        if (request.isClaimsChallengePresent()) {
-            brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_CLAIMS, request.getClaimsChallenge());
+        if (request.isClaimsChallengePresent() || request.getClientCapabilities() != null) {
+            brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_CLAIMS,
+                    AuthenticationContext.mergeClaimsWithClientCapabilities(
+                            request.getClaimsChallenge(),
+                            request.getClientCapabilities()
+                    )
+            );
         }
 
-        if (request.getForceRefresh()){
+        if (request.getForceRefresh() || request.isClaimsChallengePresent()){
+            // set force refresh to true if claims challenge is present, ad-accounts and adal-unity consumes this parameter
+            // to refresh token if claims is present on Request.
+            // Note: Even though client capabilities are sent as claims, they should not be treated as claims set to request and
+            // token should not be refreshed if they are present.
             brokerOptions.putString(AuthenticationConstants.Broker.BROKER_FORCE_REFRESH, Boolean.toString(true));
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -203,8 +203,15 @@ class Oauth2 {
 
         // Claims challenge are opaque to the sdk, we're not going to do any merging if both extra qp and claims parameter
         // contain it. Also, if developer sends it in both places, server will fail it.
-        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge())) {
-            queryParameter.appendQueryParameter(AuthenticationConstants.OAuth2.CLAIMS, mRequest.getClaimsChallenge());
+        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge())
+                || mRequest.getClientCapabilities() != null) {
+            queryParameter.appendQueryParameter(AuthenticationConstants.OAuth2.CLAIMS,
+                    URLEncoder.encode(AuthenticationContext.mergeClaimsWithClientCapabilities(
+                                    mRequest.getClaimsChallenge(),
+                                    mRequest.getClientCapabilities()
+                            ),
+                            AuthenticationConstants.ENCODING_UTF8)
+            );
         }
 
         if(!StringExtensions.isNullOrBlank(mRequest.getAppName())){
@@ -253,9 +260,13 @@ class Oauth2 {
                 AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE
         );
 
-        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge())) {
+        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge()) ||
+                mRequest.getClientCapabilities() != null) {
             message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.OAuth2.CLAIMS,
-                    StringExtensions.urlFormEncode(mRequest.getClaimsChallenge()));
+                    StringExtensions.urlFormEncode(AuthenticationContext.mergeClaimsWithClientCapabilities(
+                            mRequest.getClaimsChallenge(),
+                            mRequest.getClientCapabilities()
+                    )));
         }
 
         if (!StringExtensions.isNullOrBlank(mRequest.getAppName())) {
@@ -300,9 +311,15 @@ class Oauth2 {
                     StringExtensions.urlFormEncode(mRequest.getRedirectUri()));
         }
 
-        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge())) {
+        if (!StringExtensions.isNullOrBlank(mRequest.getClaimsChallenge()) ||
+                mRequest.getClientCapabilities() != null) {
             message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.OAuth2.CLAIMS,
-                    StringExtensions.urlFormEncode(mRequest.getClaimsChallenge()));
+                    StringExtensions.urlFormEncode(AuthenticationContext.mergeClaimsWithClientCapabilities(
+                                    mRequest.getClaimsChallenge(),
+                                    mRequest.getClientCapabilities()
+                            )
+                    )
+            );
         }
 
         if (!StringExtensions.isNullOrBlank(mRequest.getAppName())) {

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=1.16.0
+versionName=1.16.1-RC
 versionCode=1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+Version 1.16.1
+--------------
+Bugfix : Resolved ADAL/1378
+    * Fixed a bug where the token is refreshed if Client capabilities are set.
+Bugfix: Resolves COMMON/#343
+    * Fix the discrepancy on idToken claim of Account object in v1.15.1.
+
 Version 1.16.0
 --------------
 Added new acquireTokenSilent overloads to supports adding claims parameter.


### PR DESCRIPTION
Issue : https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/1378
Also updated submodule to `common-0.0.8` which has a hot fix : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/348/
Updated version to 1.16.1-RC
