### PR TITLE
Allow Broker apps to acquire token through ad-accounts

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -634,8 +634,9 @@ class AcquireTokenRequest {
             throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, "The redirectUri is null or blank.");
         }
 
-        if (inputUri.equalsIgnoreCase(AuthenticationConstants.Broker.BROKER_REDIRECT_URI))
-        {
+        if (inputUri.equalsIgnoreCase(AuthenticationConstants.Broker.BROKER_REDIRECT_URI)) {
+            // TODO: Clean this up once we migrate all Logger functions to the common one.
+            com.microsoft.identity.common.internal.logging.Logger.info(TAG + methodName, "This is a broker redirectUri. Bypass the check.");
             return;
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -634,6 +634,11 @@ class AcquireTokenRequest {
             throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, "The redirectUri is null or blank.");
         }
 
+        if (inputUri.equalsIgnoreCase(AuthenticationConstants.Broker.BROKER_REDIRECT_URI))
+        {
+            return;
+        }
+
         // verify that redirect uri passed in by developer has the correct prefix msauth://
         if (!inputUri.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX + "://")) {
             errMsg = " The valid broker redirect URI prefix: " + AuthenticationConstants.Broker.REDIRECT_PREFIX

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -108,9 +108,7 @@ class BrokerProxy implements IBrokerProxy {
 
     /**
      * Verifies the broker related app and AD-Authenticator in Account Manager
-     * ADAL directs call to AccountManager if component is valid and present. It
-     * does not direct call if the caller is from Authenticator itself.
-     *
+     * ADAL directs call to AccountManager if component is valid and present.
      */
     @Override
     public SwitchToBroker canSwitchToBroker(final String authorityUrlStr) {

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -124,8 +124,6 @@ class BrokerProxy implements IBrokerProxy {
         }
         final String packageName = mContext.getPackageName();
         boolean canSwitchToBroker = AuthenticationSettings.INSTANCE.getUseBroker()
-                && !packageName.equalsIgnoreCase(AuthenticationSettings.INSTANCE.getBrokerPackageName())
-                && !packageName.equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
                 && verifyAuthenticator(mAcctManager)
                 && !UrlExtensions.isADFSAuthority(authorityUrl);
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -110,9 +110,12 @@ class BrokerProxy implements IBrokerProxy {
      * Verifies the broker related app and AD-Authenticator in Account Manager
      * ADAL directs call to AccountManager if component is valid and present. It
      * does not direct call if the caller is from Authenticator itself.
+     *
      */
     @Override
     public SwitchToBroker canSwitchToBroker(final String authorityUrlStr) {
+        // TODO: Get CompanyPortal to verify that they can also switch to broker when acquiring token with ADAL.
+
         final String methodName = ":canSwitchToBroker";
         final URL authorityUrl;
         try {


### PR DESCRIPTION
Remove the check which prevents Broker app to acquire token through broker.

This is required for the AADNGC (Work account password less sign-in) scenarios.