### PR TITLE
[1.16.2-RC1] Picks up common@0.0.9-RC1, updates changelog, increments version

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.8', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:0.0.8") {
+    distApi("com.microsoft.identity:common:0.0.9-RC1") {
         transitive = false
     }
 

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=1.16.1
+versionName=1.16.2-RC1
 versionCode=1

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ allprojects {
         buildDir = "C:/temp/${rootProject.name}/${project.name}"
     }
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     gradle.projectsEvaluated {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 1.16.2
+--------------
+- Bugfix: Resolves COMMON/#379
+    * ClientInfo must implement Serializable so that ADAL/AuthenticationResult can be serialized.
+
 Version 1.16.1
 --------------
 Bugfix : Resolved ADAL/1378


### PR DESCRIPTION
Expands: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/380
