### PR TITLE
Migrating AuthenticationActivity logging to common.Logger, lots of cleanup

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -156,16 +156,26 @@ public class AuthenticationActivity extends Activity {
         @Override
         public void onReceive(final Context context, final Intent intent) {
             final String methodName = ":onReceive";
-            Logger.v(TAG + methodName, "ActivityBroadcastReceiver onReceive");
+
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "ActivityBroadcastReceiver onReceive"
+            );
 
             if (null != intent.getAction() && intent.getAction().equalsIgnoreCase(ACTION_CANCEL)) {
-                Logger.v(TAG + methodName,
-                        "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity");
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity"
+                );
 
                 int cancelRequestId = intent.getIntExtra(REQUEST_ID, 0);
 
                 if (cancelRequestId == mWaitingRequestId) {
-                    Logger.v(TAG + methodName, "Waiting requestId is same and cancelling this activity");
+                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                            TAG + methodName,
+                            "Waiting requestId is same and cancelling this activity"
+                    );
+
                     AuthenticationActivity.this.finish();
                     // no need to send result back to activity. It is
                     // cancelled
@@ -182,24 +192,40 @@ public class AuthenticationActivity extends Activity {
     protected void onCreate(final Bundle savedInstanceState) {
         final String methodName = ":onCreate";
         super.onCreate(savedInstanceState);
-        setContentView(this.getResources().getIdentifier("activity_authentication", "layout",
-                this.getPackageName()));
+
+        setContentView(
+                this.getResources()
+                        .getIdentifier(
+                                "activity_authentication",
+                                "layout",
+                                this.getPackageName()
+                        )
+        );
+
         CookieSyncManager.createInstance(getApplicationContext());
         CookieSyncManager.getInstance().sync();
         CookieManager cookieManager = CookieManager.getInstance();
         cookieManager.setAcceptCookie(true);
 
-        Logger.v(TAG + methodName, "AuthenticationActivity was created.");
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG + methodName,
+                "AuthenticationActivity was created."
+        );
+
         // Get the message from the intent
         mAuthRequest = getAuthenticationRequestFromIntent(getIntent());
+
         if (mAuthRequest == null) {
-            Logger.d(TAG + methodName, "Intent for Authentication Activity doesn't have the request details, returning to caller");
-            Intent resultIntent = new Intent();
-            resultIntent.putExtra(RESPONSE_ERROR_CODE,
-                    WEBVIEW_INVALID_REQUEST);
-            resultIntent.putExtra(RESPONSE_ERROR_MESSAGE,
-                    "Intent does not have request details");
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                    TAG + methodName,
+                    "Intent for Authentication Activity doesn't have the request details, returning to caller"
+            );
+
+            final Intent resultIntent = new Intent();
+            resultIntent.putExtra(RESPONSE_ERROR_CODE, WEBVIEW_INVALID_REQUEST);
+            resultIntent.putExtra(RESPONSE_ERROR_MESSAGE, "Intent does not have request details");
             returnToCaller(BROWSER_CODE_ERROR, resultIntent);
+
             return;
         }
 
@@ -222,6 +248,7 @@ public class AuthenticationActivity extends Activity {
             returnError(ADALError.ARGUMENT_EXCEPTION, ACCOUNT_REDIRECT);
             return;
         }
+
         mRedirectUrl = mAuthRequest.getRedirectUri();
 
         Telemetry.getInstance().startEvent(mAuthRequest.getTelemetryRequestId(), EventStrings.UI_EVENT);
@@ -230,40 +257,69 @@ public class AuthenticationActivity extends Activity {
         mUIEvent.setCorrelationId(mAuthRequest.getCorrelationId().toString());
 
         // Create the Web View to show the page
-        mWebView = (WebView) findViewById(this.getResources().getIdentifier("webView1", "id",
-                this.getPackageName()));
+        mWebView = findViewById(
+                this.getResources()
+                        .getIdentifier(
+                                "webView1",
+                                "id",
+                                this.getPackageName()
+                        )
+        );
 
         // Disable hardware acceleration in WebView if needed
         if (!AuthenticationSettings.INSTANCE.getDisableWebViewHardwareAcceleration()) {
             mWebView.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null);
-            Logger.d(TAG + methodName, "Hardware acceleration is disabled in WebView");
+
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                    TAG + methodName,
+                    "Hardware acceleration is disabled in WebView"
+            );
         }
 
         mStartUrl = "about:blank";
+
         try {
-            Oauth2 oauth = new Oauth2(mAuthRequest);
+            final Oauth2 oauth = new Oauth2(mAuthRequest);
             mStartUrl = oauth.getCodeRequestUrl();
         } catch (UnsupportedEncodingException e) {
-            Logger.v(TAG + methodName, "Encoding format is not supported. ", e.getMessage(), null);
-            Intent resultIntent = new Intent();
-            resultIntent.putExtra(RESPONSE_REQUEST_INFO,
-                    mAuthRequest);
+            com.microsoft.identity.common.internal.logging.Logger.error(
+                    TAG + methodName,
+                    "Encoding format is not supported. ",
+                    e
+            );
+
+            final Intent resultIntent = new Intent();
+            resultIntent.putExtra(RESPONSE_REQUEST_INFO, mAuthRequest);
             returnToCaller(BROWSER_CODE_ERROR, resultIntent);
+
             return;
         }
 
         // Create the broadcast receiver for cancel
-        Logger.v(TAG + methodName, "Init broadcastReceiver with request. "
-                + "RequestId:" + mAuthRequest.getRequestId(), mAuthRequest.getLogInfo(), null);
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG + methodName,
+                "Init broadcastReceiver with request. "
+                        + "RequestId:"
+                        + mAuthRequest.getRequestId()
+        );
+
+        com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                TAG + methodName,
+                mAuthRequest.getLogInfo()
+        );
+
         mReceiver = new ActivityBroadcastReceiver();
         mReceiver.mWaitingRequestId = mAuthRequest.getRequestId();
-        LocalBroadcastManager.getInstance(this).registerReceiver(mReceiver,
-                new IntentFilter(ACTION_CANCEL));
+        LocalBroadcastManager.getInstance(this).registerReceiver(mReceiver, new IntentFilter(ACTION_CANCEL));
 
         String userAgent = mWebView.getSettings().getUserAgentString();
         mWebView.getSettings().setUserAgentString(userAgent + CLIENT_TLS_NOT_SUPPORTED);
         userAgent = mWebView.getSettings().getUserAgentString();
-        Logger.v(TAG + methodName, "", "UserAgent:" + userAgent, null);
+
+        com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                TAG + methodName,
+                "UserAgent:" + userAgent
+        );
 
         if (isBrokerRequest(getIntent())) {
             // This activity is started from calling app and running in
@@ -271,91 +327,142 @@ public class AuthenticationActivity extends Activity {
             mCallingPackage = getCallingPackage();
 
             if (mCallingPackage == null) {
-                Logger.v(TAG + methodName, "Calling package is null, startActivityForResult is not used to call this activity");
-                Intent resultIntent = new Intent();
-                resultIntent.putExtra(RESPONSE_ERROR_CODE,
-                        WEBVIEW_INVALID_REQUEST);
-                resultIntent.putExtra(RESPONSE_ERROR_MESSAGE,
-                        "startActivityForResult is not used to call this activity");
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Calling package is null, startActivityForResult is not used to call this activity"
+                );
+
+                final Intent resultIntent = new Intent();
+                resultIntent.putExtra(RESPONSE_ERROR_CODE, WEBVIEW_INVALID_REQUEST);
+                resultIntent.putExtra(RESPONSE_ERROR_MESSAGE, "startActivityForResult is not used to call this activity");
                 returnToCaller(BROWSER_CODE_ERROR, resultIntent);
+
                 return;
             }
-            Logger.i(TAG + methodName, "It is a broker request for package:" + mCallingPackage, "");
+            com.microsoft.identity.common.internal.logging.Logger.info(
+                    TAG + methodName,
+                    "It is a broker request for package:" + mCallingPackage
+            );
 
-            mAccountAuthenticatorResponse = getIntent().getParcelableExtra(
-                    AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE);
+            mAccountAuthenticatorResponse = getIntent().getParcelableExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE);
 
             if (mAccountAuthenticatorResponse != null) {
                 mAccountAuthenticatorResponse.onRequestContinued();
             }
 
-            PackageHelper info = new PackageHelper(AuthenticationActivity.this);
+            final PackageHelper info = new PackageHelper(AuthenticationActivity.this);
             mCallingPackage = getCallingPackage();
             mCallingUID = info.getUIDForPackage(mCallingPackage);
-            String signatureDigest = info.getCurrentSignatureForPackage(mCallingPackage);
+
+            final String signatureDigest = info.getCurrentSignatureForPackage(mCallingPackage);
             mStartUrl = getBrokerStartUrl(mStartUrl, mCallingPackage, signatureDigest);
 
             if (!isCallerBrokerInstaller()) {
-                Logger.v(TAG + methodName, "Caller needs to be verified using special redirectUri");
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Caller needs to be verified using special redirectUri"
+                );
+
                 mRedirectUrl = PackageHelper.getBrokerRedirectUrl(mCallingPackage, signatureDigest);
             }
 
-            Logger.v(TAG + methodName, "", "Broker redirectUrl: " + mRedirectUrl + " The calling package is: " + mCallingPackage
-                    + " Signature hash for calling package is: " + signatureDigest + " Current context package: "
-                    + getPackageName() + " Start url: " + mStartUrl, null);
+            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                    TAG + methodName,
+                    "Broker redirectUrl: " + mRedirectUrl
+                            + " The calling package is: " + mCallingPackage
+                            + " Signature hash for calling package is: " + signatureDigest
+                            + " Current context package: " + getPackageName()
+                            + " Start url: " + mStartUrl
+            );
         } else {
-            Logger.v(TAG + methodName, "Non-broker request for package " + getCallingPackage(),
-                    " Start url: " + mStartUrl, null);
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Non-broker request for package " + getCallingPackage()
+            );
+            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                    TAG + methodName,
+                    "Start url: " + mStartUrl
+            );
         }
 
         mRegisterReceiver = false;
         final String postUrl = mStartUrl;
-        Logger.i(TAG + methodName, "Device info:" + android.os.Build.VERSION.RELEASE + " " + android.os.Build.MANUFACTURER
-                + android.os.Build.MODEL, "");
+        com.microsoft.identity.common.internal.logging.Logger.infoPII(
+                TAG + methodName,
+                "Device info:" + android.os.Build.VERSION.RELEASE
+                        + " "
+                        + android.os.Build.MANUFACTURER + android.os.Build.MODEL
+        );
 
         mStorageHelper = new StorageHelper(getApplicationContext());
         setupWebView();
 
         // Also log correlation id
         if (mAuthRequest.getCorrelationId() == null) {
-            Logger.v(TAG + methodName, "Null correlation id in the request.");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Null correlation id in the request."
+            );
         } else {
-            Logger.v(TAG + methodName, "Correlation id for request sent is:"
-                    + mAuthRequest.getCorrelationId().toString());
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Correlation id for request sent is:"
+                            + mAuthRequest.getCorrelationId().toString()
+            );
         }
 
         if (savedInstanceState == null) {
             mWebView.post(new Runnable() {
+
                 @Override
                 public void run() {
                     // load blank first to avoid error for not loading webview
-                    Logger.v(TAG + methodName, "Launching webview for acquiring auth code.");
+                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                            TAG + methodName,
+                            "Launching webview for acquiring auth code."
+                    );
                     mWebView.loadUrl("about:blank");
                     mWebView.loadUrl(postUrl);
                 }
+
             });
         } else {
-            Logger.v(TAG + methodName, "Reuse webview");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Reuse webview"
+            );
         }
     }
 
     private boolean isCallerBrokerInstaller() {
         // Allow intune's signature check
         final String methodName = ":isCallerBrokerInstaller";
-        PackageHelper info = new PackageHelper(AuthenticationActivity.this);
-        String packageName = getCallingPackage();
-        if (!StringExtensions.isNullOrBlank(packageName)) {
+        final PackageHelper info = new PackageHelper(AuthenticationActivity.this);
+        final String packageName = getCallingPackage();
 
+        if (!StringExtensions.isNullOrBlank(packageName)) {
             if (packageName.equals(AuthenticationSettings.INSTANCE.getBrokerPackageName())) {
-                Logger.v(TAG + methodName, "Same package as broker.");
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Same package as broker."
+                );
+
                 return true;
             }
 
-            String signature = info.getCurrentSignatureForPackage(packageName);
-            Logger.v(TAG + methodName, "Checking broker signature. ",
-                    "Check signature for " + packageName + " signature:" + signature
-                            + " brokerSignature:"
-                            + AuthenticationSettings.INSTANCE.getBrokerSignature(), null);
+            final String signature = info.getCurrentSignatureForPackage(packageName);
+
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Checking broker signature."
+            );
+            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                    TAG + methodName,
+                    "Check signature for " + packageName
+                            + " signature:" + signature
+                            + " brokerSignature:" + AuthenticationSettings.INSTANCE.getBrokerSignature()
+            );
+
             return signature.equals(AuthenticationSettings.INSTANCE.getBrokerSignature())
                     || signature
                     .equals(AZURE_AUTHENTICATOR_APP_SIGNATURE);
@@ -386,6 +493,7 @@ public class AuthenticationActivity extends Activity {
 
         // Set focus to the view for touch event
         mWebView.setOnTouchListener(new View.OnTouchListener() {
+
             @Override
             public boolean onTouch(final View view, final MotionEvent event) {
                 int action = event.getAction();
@@ -394,6 +502,7 @@ public class AuthenticationActivity extends Activity {
                 }
                 return false;
             }
+
         });
 
         mWebView.getSettings().setLoadWithOverviewMode(true);
@@ -409,7 +518,10 @@ public class AuthenticationActivity extends Activity {
         AuthenticationRequest authRequest = null;
 
         if (isBrokerRequest(callingIntent)) {
-            Logger.v(TAG + methodName, "It is a broker request. Get request info from bundle extras.");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "It is a broker request. Get request info from bundle extras."
+            );
 
             final String authority = callingIntent.getStringExtra(ACCOUNT_AUTHORITY);
             final String resource = callingIntent.getStringExtra(ACCOUNT_RESOURCE);
@@ -431,11 +543,15 @@ public class AuthenticationActivity extends Activity {
             UUID correlationIdParsed = null;
 
             if (!StringExtensions.isNullOrBlank(correlationId)) {
+
                 try {
                     correlationIdParsed = UUID.fromString(correlationId);
-                } catch (IllegalArgumentException ex) {
-                    Logger.e(TAG + methodName, "CorrelationId is malformed: " + correlationId, "",
-                            ADALError.CORRELATION_ID_FORMAT);
+                } catch (final IllegalArgumentException ex) {
+                    com.microsoft.identity.common.internal.logging.Logger.error(
+                            TAG + methodName,
+                            "CorrelationId is malformed: " + correlationId,
+                            ex
+                    );
                 }
             }
 
@@ -467,9 +583,12 @@ public class AuthenticationActivity extends Activity {
      */
     private void returnError(final ADALError errorCode, final String argument) {
         // Set result back to account manager call
-        Logger.w(TAG, "Argument error:" + argument);
-        Intent resultIntent = new Intent();
+        com.microsoft.identity.common.internal.logging.Logger.warn(
+                TAG,
+                "Argument error:" + argument
+        );
 
+        final Intent resultIntent = new Intent();
         // TODO only send adalerror from activity side as int
         resultIntent.putExtra(RESPONSE_ERROR_CODE, errorCode.name());
         resultIntent.putExtra(RESPONSE_ERROR_MESSAGE, argument);
@@ -497,7 +616,11 @@ public class AuthenticationActivity extends Activity {
                 // This encoding issue will happen at the beginning of API call,
                 // if it is not supported on this device. ADAL uses one encoding
                 // type.
-                Logger.e(TAG, "Encoding", e);
+                com.microsoft.identity.common.internal.logging.Logger.error(
+                        TAG,
+                        "Unsupported encoding",
+                        e
+                );
             }
         }
         return loadUrl;
@@ -506,8 +629,7 @@ public class AuthenticationActivity extends Activity {
     private boolean isBrokerRequest(final Intent callingIntent) {
         // Intent should have a flag and activity is hosted inside broker
         return callingIntent != null
-                && !StringExtensions.isNullOrBlank(callingIntent
-                .getStringExtra(BROKER_REQUEST));
+                && !StringExtensions.isNullOrBlank(callingIntent.getStringExtra(BROKER_REQUEST));
     }
 
     /**
@@ -518,7 +640,11 @@ public class AuthenticationActivity extends Activity {
      */
     private void returnToCaller(final int resultCode, Intent data) {
         final String methodName = ":returnToCaller";
-        Logger.v(TAG + methodName, "Return To Caller:" + resultCode);
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG + methodName,
+                "Return To Caller:" + resultCode
+        );
+
         displaySpinner(false);
 
         if (data == null) {
@@ -526,13 +652,19 @@ public class AuthenticationActivity extends Activity {
         }
 
         if (mAuthRequest == null) {
-            Logger.w(TAG + methodName, "Request object is null", "",
-                    ADALError.ACTIVITY_REQUEST_INTENT_DATA_IS_NULL);
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                    TAG + methodName,
+                    "Request object is null"
+            );
         } else {
             // set request id related to this response to send the delegateId
-            Logger.v(TAG + methodName,
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
                     "Set request id related to response. "
-                            + "REQUEST_ID for caller returned to:" + mAuthRequest.getRequestId());
+                            + "REQUEST_ID for caller returned to:"
+                            + mAuthRequest.getRequestId()
+            );
+
             data.putExtra(REQUEST_ID, mAuthRequest.getRequestId());
         }
 
@@ -543,7 +675,11 @@ public class AuthenticationActivity extends Activity {
     @Override
     protected void onPause() {
         final String methodName = ":onPause";
-        Logger.v(TAG + methodName, "AuthenticationActivity onPause unregister receiver");
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG + methodName,
+                "AuthenticationActivity onPause unregister receiver"
+        );
+
         super.onPause();
 
         // Unregister the cancel action listener from the local broadcast
@@ -551,10 +687,14 @@ public class AuthenticationActivity extends Activity {
         if (mReceiver != null) {
             LocalBroadcastManager.getInstance(this).unregisterReceiver(mReceiver);
         }
+
         mRegisterReceiver = true;
 
         if (mSpinner != null) {
-            Logger.v(TAG + methodName, "Spinner at onPause will dismiss");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Spinner at onPause will dismiss"
+            );
             mSpinner.dismiss();
         }
 
@@ -568,13 +708,30 @@ public class AuthenticationActivity extends Activity {
         // It can come here from onCreate, onRestart or onPause.
         // Don't load url again since it will send another 2FA request
         if (mRegisterReceiver) {
-            Logger.v(TAG + methodName, "Webview onResume will register receiver. ",
-                    "StartUrl: " + mStartUrl, null);
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Webview onResume will register receiver."
+            );
+
+            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                    TAG + methodName,
+                    "StartUrl: " + mStartUrl
+            );
+
             if (mReceiver != null) {
-                Logger.v(TAG + methodName, "Webview onResume register broadcast receiver for request. "
-                        + "RequestId: " + mReceiver.mWaitingRequestId);
-                LocalBroadcastManager.getInstance(this).registerReceiver(mReceiver,
-                        new IntentFilter(ACTION_CANCEL));
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Webview onResume register broadcast receiver for request. "
+                                + "RequestId: "
+                                + mReceiver.mWaitingRequestId
+                );
+
+                LocalBroadcastManager
+                        .getInstance(this)
+                        .registerReceiver(
+                                mReceiver,
+                                new IntentFilter(ACTION_CANCEL)
+                        );
             }
         }
         mRegisterReceiver = false;
@@ -582,20 +739,34 @@ public class AuthenticationActivity extends Activity {
         // Spinner dialog to show some message while it is loading
         mSpinner = new ProgressDialog(this);
         mSpinner.requestWindowFeature(Window.FEATURE_NO_TITLE);
-        mSpinner.setMessage(this.getText(this.getResources().getIdentifier("app_loading", "string",
-                this.getPackageName())));
+        mSpinner.setMessage(
+                this.getText(
+                        this.getResources()
+                                .getIdentifier(
+                                        "app_loading",
+                                        "string",
+                                        this.getPackageName()
+                                )
+                )
+        );
     }
 
     @Override
     protected void onRestart() {
-        Logger.v(TAG, "AuthenticationActivity onRestart");
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG,
+                "AuthenticationActivity onRestart"
+        );
         super.onRestart();
         mRegisterReceiver = true;
     }
 
     @Override
     public void onBackPressed() {
-        Logger.v(TAG, "Back button is pressed");
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG,
+                "Back button is pressed"
+        );
 
         // User should be able to click back button to cancel in case pkeyauth
         // happen.
@@ -610,8 +781,11 @@ public class AuthenticationActivity extends Activity {
     }
 
     private void cancelRequest() {
-        Logger.v(TAG, "Sending intent to cancel authentication activity");
-        Intent resultIntent = new Intent();
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG,
+                "Sending intent to cancel authentication activity"
+        );
+        final Intent resultIntent = new Intent();
 
         if (mUIEvent != null) {
             mUIEvent.setUserCancel();
@@ -622,7 +796,10 @@ public class AuthenticationActivity extends Activity {
 
     private void prepareForBrokerResume() {
         final String methodName = ":prepareForBrokerResume";
-        Logger.v(TAG + methodName, "Return to caller with BROKER_REQUEST_RESUME, and waiting for result.");
+        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                TAG + methodName,
+                "Return to caller with BROKER_REQUEST_RESUME, and waiting for result."
+        );
 
         final Intent resultIntent = new Intent();
         returnToCaller(BROKER_REQUEST_RESUME, resultIntent);
@@ -640,7 +817,12 @@ public class AuthenticationActivity extends Activity {
         super.onDestroy();
 
         if (mUIEvent != null) {
-            Telemetry.getInstance().stopEvent(mAuthRequest.getTelemetryRequestId(), mUIEvent, EventStrings.UI_EVENT);
+            Telemetry.getInstance()
+                    .stopEvent(
+                            mAuthRequest.getTelemetryRequestId(),
+                            mUIEvent,
+                            EventStrings.UI_EVENT
+                    );
         }
     }
 
@@ -652,58 +834,101 @@ public class AuthenticationActivity extends Activity {
 
         public void processRedirectUrl(final WebView view, final String url) {
             final String methodName = ":processRedirectUrl";
+
             if (!isBrokerRequest(getIntent())) {
                 // It is pointing to redirect. Final url can be processed to
                 // get the code or error.
-                Logger.i(TAG + methodName, "It is not a broker request", "");
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + methodName,
+                        "It is not a broker request"
+                );
 
-                Intent resultIntent = new Intent();
+                final Intent resultIntent = new Intent();
                 resultIntent.putExtra(RESPONSE_FINAL_URL, url);
                 resultIntent.putExtra(RESPONSE_REQUEST_INFO, mAuthRequest);
                 returnToCaller(BROWSER_CODE_COMPLETE, resultIntent);
 
                 view.stopLoading();
             } else {
-                Logger.i(TAG + methodName, "It is a broker request", "");
-                displaySpinnerWithMessage(AuthenticationActivity.this
-                        .getText(AuthenticationActivity.this.getResources().getIdentifier(
-                                "broker_processing", "string", getPackageName())));
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + methodName,
+                        "It is a broker request"
+                );
+
+                displaySpinnerWithMessage(
+                        AuthenticationActivity.this.getText(
+                                AuthenticationActivity.this
+                                        .getResources()
+                                        .getIdentifier(
+                                                "broker_processing",
+                                                "string",
+                                                getPackageName()
+                                        )
+                        )
+                );
 
                 view.stopLoading();
 
                 // do async task and show spinner while exchanging code for
                 // access token
-                new TokenTask(mWebRequestHandler, mAuthRequest, mCallingPackage, mCallingUID)
-                        .execute(url);
+                new TokenTask(mWebRequestHandler, mAuthRequest, mCallingPackage, mCallingUID).execute(url);
             }
         }
 
         public boolean processInvalidUrl(final WebView view, final String url) {
             final String methodName = ":processInvalidUrl";
-            if (isBrokerRequest(getIntent())
-                    && url.startsWith(REDIRECT_PREFIX)) {
-                Logger.e(TAG + methodName,
+
+            if (isBrokerRequest(getIntent()) && url.startsWith(REDIRECT_PREFIX)) {
+                com.microsoft.identity.common.internal.logging.Logger.error(
+                        TAG + methodName,
                         "The RedirectUri is not as expected.",
+                        null
+                );
+                com.microsoft.identity.common.internal.logging.Logger.errorPII(
+                        TAG + methodName,
                         String.format("Received %s and expected %s", url, mRedirectUrl),
-                        ADALError.DEVELOPER_REDIRECTURI_INVALID);
-                returnError(ADALError.DEVELOPER_REDIRECTURI_INVALID, String.format(
-                        "The RedirectUri is not as expected. Received %s and expected %s", url,
-                        mRedirectUrl));
+                        null
+                );
+
+                returnError(
+                        ADALError.DEVELOPER_REDIRECTURI_INVALID,
+                        String.format(
+                                "The RedirectUri is not as expected. Received %s and expected %s", url,
+                                mRedirectUrl
+                        )
+                );
                 view.stopLoading();
+
                 return true;
             }
 
             if (url.toLowerCase(Locale.US).equals("about:blank")) {
-                Logger.v(TAG + methodName, "It is an blank page request");
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "It is an blank page request"
+                );
+
                 return true;
             }
 
             if (!url.toLowerCase(Locale.US).startsWith(REDIRECT_SSL_PREFIX)) {
-                Logger.e(TAG + methodName, "The webview was redirected to an unsafe URL.", "", ADALError.WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED);
-                returnError(ADALError.WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED, "The webview was redirected to an unsafe URL.");
+                final String errMsg = "The webview was redirected to an unsafe URL.";
+                com.microsoft.identity.common.internal.logging.Logger.error(
+                        TAG + methodName,
+                        errMsg,
+                        null
+                );
+
+                returnError(
+                        ADALError.WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED,
+                        errMsg
+                );
+
                 view.stopLoading();
+
                 return true;
             }
+
             return false;
         }
 
@@ -741,7 +966,10 @@ public class AuthenticationActivity extends Activity {
         public void onReceivedClientCertRequest(final WebView view,
                                                 final ClientCertRequest request) {
             final String methodName = ":onReceivedClientCertRequest";
-            Logger.v(TAG + methodName, "Webview receives client TLS request.");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Webview receives client TLS request."
+            );
 
             final Principal[] acceptableCertIssuers = request.getPrincipals();
 
@@ -750,41 +978,69 @@ public class AuthenticationActivity extends Activity {
                 for (Principal issuer : acceptableCertIssuers) {
                     if (issuer.getName().contains("CN=MS-Organization-Access")) {
                         //Checking if received acceptable issuers contain "CN=MS-Organization-Access"
-                        Logger.v(TAG + methodName, "Cancelling the TLS request, not respond to TLS challenge triggered by device authentication.");
+                        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                                TAG + methodName,
+                                "Cancelling the TLS request, not respond to TLS challenge triggered by device authentication."
+                        );
                         request.cancel();
                         return;
                     }
                 }
             }
 
-            KeyChain.choosePrivateKeyAlias(AuthenticationActivity.this, new KeyChainAliasCallback() {
+            KeyChain.choosePrivateKeyAlias(
+                    AuthenticationActivity.this,
+                    new KeyChainAliasCallback() {
 
-                @Override
-                public void alias(final String alias) {
-                    if (alias == null) {
-                        Logger.v(TAG + methodName, "No certificate chosen by user, cancelling the TLS request.");
-                        request.cancel();
-                        return;
-                    }
+                        @Override
+                        public void alias(final String alias) {
+                            if (alias == null) {
+                                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                                        TAG + methodName,
+                                        "No certificate chosen by user, cancelling the TLS request."
+                                );
+                                request.cancel();
+                                return;
+                            }
 
-                    try {
-                        final X509Certificate[] certChain = KeyChain.getCertificateChain(
-                                getApplicationContext(), alias);
-                        final PrivateKey privateKey = KeyChain.getPrivateKey(
-                                getCallingContext(), alias);
+                            try {
+                                final X509Certificate[] certChain = KeyChain.getCertificateChain(getApplicationContext(), alias);
+                                final PrivateKey privateKey = KeyChain.getPrivateKey(getCallingContext(), alias);
 
-                        Logger.v(TAG + methodName, "Certificate is chosen by user, proceed with TLS request.");
-                        request.proceed(privateKey, certChain);
-                        return;
-                    } catch (KeyChainException e) {
-                        Logger.e(TAG + methodName, "KeyChain exception", e);
-                    } catch (InterruptedException e) {
-                        Logger.e(TAG + methodName, "InterruptedException exception", e);
-                    }
+                                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                                        TAG + methodName,
+                                        "Certificate is chosen by user, proceed with TLS request."
+                                );
+                                request.proceed(privateKey, certChain);
+                                return;
+                            } catch (final KeyChainException e) {
+                                com.microsoft.identity.common.internal.logging.Logger.error(
+                                        TAG + methodName,
+                                        "Keychain exception",
+                                        null
+                                );
+                                com.microsoft.identity.common.internal.logging.Logger.errorPII(
+                                        TAG + methodName,
+                                        "Exception details:",
+                                        e
+                                );
+                            } catch (final InterruptedException e) {
+                                com.microsoft.identity.common.internal.logging.Logger.error(
+                                        TAG + methodName,
+                                        "InterruptedException exception",
+                                        e
+                                );
+                            }
 
-                    request.cancel();
-                }
-            }, request.getKeyTypes(), request.getPrincipals(), request.getHost(), request.getPort(), null);
+                            request.cancel();
+                        }
+                    },
+                    request.getKeyTypes(),
+                    request.getPrincipals(),
+                    request.getHost(),
+                    request.getPort(),
+                    null
+            );
         }
     }
 
@@ -795,10 +1051,16 @@ public class AuthenticationActivity extends Activity {
      */
     private void displaySpinner(final boolean show) {
         final String methodName = ":displaySpinner";
+
         if (!AuthenticationActivity.this.isFinishing()
                 && !AuthenticationActivity.this.isChangingConfigurations() && mSpinner != null) {
             // Used externally to verify web view processing.
-            Logger.v(TAG + methodName, "DisplaySpinner:" + show + " showing:" + mSpinner.isShowing());
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "DisplaySpinner:" + show
+                            + " showing:" + mSpinner.isShowing()
+            );
+
             if (show && !mSpinner.isShowing()) {
                 mSpinner.show();
             }
@@ -832,15 +1094,23 @@ public class AuthenticationActivity extends Activity {
         // Added here to make Authenticator work with one common code base
         if (isBrokerRequest(getIntent()) && mAccountAuthenticatorResponse != null) {
             // send the result bundle back if set, otherwise send an error.
-            Logger.v(TAG, "It is a broker request");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG,
+                    "It is a broker request"
+            );
+
             if (mAuthenticatorResultBundle == null) {
-                mAccountAuthenticatorResponse.onError(AccountManager.ERROR_CODE_CANCELED,
-                        "canceled");
+                mAccountAuthenticatorResponse.onError(
+                        AccountManager.ERROR_CODE_CANCELED,
+                        "canceled"
+                );
             } else {
                 mAccountAuthenticatorResponse.onResult(mAuthenticatorResultBundle);
             }
+
             mAccountAuthenticatorResponse = null;
         }
+
         super.finish();
     }
 
@@ -852,7 +1122,7 @@ public class AuthenticationActivity extends Activity {
      * @param result this is returned as the result of the
      *               AbstractAccountAuthenticator request
      */
-    private void setAccountAuthenticatorResult(Bundle result) {
+    private void setAccountAuthenticatorResult(final Bundle result) {
         mAuthenticatorResultBundle = result;
     }
 
@@ -888,27 +1158,53 @@ public class AuthenticationActivity extends Activity {
 
         @Override
         protected TokenTaskResult doInBackground(final String... urlItems) {
-            Oauth2 oauthRequest = new Oauth2(mRequest, mRequestHandler, mJWSBuilder);
-            TokenTaskResult result = new TokenTaskResult();
+            final Oauth2 oauthRequest = new Oauth2(mRequest, mRequestHandler, mJWSBuilder);
+            final TokenTaskResult result = new TokenTaskResult();
 
             try {
                 result.mTaskResult = oauthRequest.getToken(urlItems[0]);
-                Logger.v(TAG, "Process result returned from TokenTask. ", mRequest.getLogInfo(), null);
-            } catch (IOException | AuthenticationException exc) {
-                Logger.e(TAG, "Error in processing code to get a token. ", mRequest.getLogInfo(),
-                        ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, exc);
+                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                        TAG,
+                        "Process result returned from TokenTask. "
+                                + mRequest.getLogInfo()
+                );
+            } catch (final IOException | AuthenticationException exc) {
+                com.microsoft.identity.common.internal.logging.Logger.error(
+                        TAG,
+                        "Error in processing code to get a token.",
+                        exc
+                );
+                com.microsoft.identity.common.internal.logging.Logger.errorPII(
+                        TAG,
+                        mRequest.getLogInfo(),
+                        null
+                );
+
                 result.mTaskException = exc;
             }
 
             if (result.mTaskResult != null && result.mTaskResult.getAccessToken() != null) {
-                Logger.v(TAG, "Token task successfully returns access token.", mRequest.getLogInfo(), null);
+                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                        TAG,
+                        "Token task successfully returns access token. "
+                                + mRequest.getLogInfo()
+                );
 
                 // Record account in the AccountManager service
                 try {
                     setAccount(result);
-                } catch (GeneralSecurityException | IOException exc) {
-                    Logger.e(TAG, "Error in setting the account", mRequest.getLogInfo(),
-                            ADALError.BROKER_ACCOUNT_SAVE_FAILED, exc);
+                } catch (final GeneralSecurityException | IOException exc) {
+                    com.microsoft.identity.common.internal.logging.Logger.error(
+                            TAG,
+                            "Error in setting the account.",
+                            null
+                    );
+                    com.microsoft.identity.common.internal.logging.Logger.errorPII(
+                            TAG,
+                            mRequest.getLogInfo(),
+                            exc
+                    );
+
                     result.mTaskException = exc;
                 }
             }
@@ -920,11 +1216,24 @@ public class AuthenticationActivity extends Activity {
                 throws NoSuchAlgorithmException, UnsupportedEncodingException {
             // include UID in the key for broker to store caches for different
             // apps under same account entry
-            String digestKey = StringExtensions.createHash(USERDATA_UID_KEY + mAppCallingUID + cacheKey);
-            Logger.v(TAG, "Get broker app cache key.",
+            final String digestKey = StringExtensions.createHash(
+                    USERDATA_UID_KEY
+                            + mAppCallingUID
+                            + cacheKey
+            );
+
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG,
+                    "Get broker app cache key."
+            );
+
+            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                    TAG,
                     "Key hash is:" + digestKey
                             + " calling app UID:" + mAppCallingUID
-                            + " Key is: " + cacheKey, null);
+                            + " Key is: " + cacheKey
+            );
+
             return digestKey;
         }
 
@@ -932,8 +1241,8 @@ public class AuthenticationActivity extends Activity {
         private void appendAppUIDToAccount(final Account account)
                 throws GeneralSecurityException, IOException {
             final String methodName = ":appendAppUIDToAccount";
-            String appIdList = mAccountManager.getUserData(account,
-                    ACCOUNT_UID_CACHES);
+
+            String appIdList = mAccountManager.getUserData(account, ACCOUNT_UID_CACHES);
 
             if (appIdList == null) {
                 appIdList = "";
@@ -941,17 +1250,46 @@ public class AuthenticationActivity extends Activity {
                 try {
                     appIdList = mStorageHelper.decrypt(appIdList);
                 } catch (final GeneralSecurityException | IOException ex) {
-                    Logger.e(TAG + methodName, "appUIDList failed to decrypt", "appIdList:" + appIdList,
-                            ADALError.ENCRYPTION_FAILED, ex);
+                    com.microsoft.identity.common.internal.logging.Logger.error(
+                            TAG + methodName,
+                            "appUIDList failed to decrypt",
+                            null
+                    );
+
+                    com.microsoft.identity.common.internal.logging.Logger.errorPII(
+                            TAG + methodName,
+                            "appIdList:" + appIdList,
+                            ex
+                    );
+
                     appIdList = "";
-                    Logger.i(TAG + methodName, "Reset the appUIDlist", "");
+                    com.microsoft.identity.common.internal.logging.Logger.info(
+                            TAG + methodName,
+                            "Reset the appUIDlist"
+                    );
                 }
             }
 
-            Logger.i(TAG + methodName, "Add calling UID. ", "App UID: " + mAppCallingUID + "appIdList:" + appIdList, null);
-            if (!appIdList.contains(USERDATA_UID_KEY
-                    + mAppCallingUID)) {
-                Logger.i(TAG + methodName, "Account has new calling UID. ", "App UID: " + mAppCallingUID, null);
+            com.microsoft.identity.common.internal.logging.Logger.info(
+                    TAG + methodName,
+                    "Add calling UID."
+            );
+
+            com.microsoft.identity.common.internal.logging.Logger.infoPII(
+                    TAG + methodName,
+                    "App UID: " + mAppCallingUID
+                            + "appIdList:" + appIdList
+            );
+
+            if (!appIdList.contains(USERDATA_UID_KEY + mAppCallingUID)) {
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + methodName,
+                        "Account has new calling UID."
+                );
+                com.microsoft.identity.common.internal.logging.Logger.infoPII(
+                        TAG + methodName,
+                        "App UID: " + mAppCallingUID
+                );
 
                 final String encryptedValue = mStorageHelper.encrypt(
                         appIdList
@@ -990,11 +1328,18 @@ public class AuthenticationActivity extends Activity {
             if (userinfo == null || StringExtensions.isNullOrBlank(userinfo.getUserId())) {
                 // return userid in the userinfo and use only account name
                 // for all fields
-                Logger.i(TAG + methodName, "Set userinfo from account", "");
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + methodName,
+                        "Set userinfo from account"
+                );
+
                 result.mTaskResult.setUserInfo(new UserInfo(name, name, "", "", name));
                 mRequest.setLoginHint(name);
             } else {
-                Logger.i(TAG + methodName, "Saving userinfo to account", "");
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + methodName,
+                        "Saving userinfo to account"
+                );
                 mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_USERID, userinfo.getUserId());
                 mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_GIVEN_NAME, userinfo.getGivenName());
                 mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_FAMILY_NAME, userinfo.getFamilyName());
@@ -1003,21 +1348,38 @@ public class AuthenticationActivity extends Activity {
             }
 
             result.mAccountName = name;
-            Logger.i(TAG + methodName, "Setting account in account manager. ",
-                    "Package: " + mPackageName + " calling app UID:" + mAppCallingUID + " Account name: " + name);
+
+            com.microsoft.identity.common.internal.logging.Logger.info(
+                    TAG + methodName,
+                    "Setting account in account manager."
+            );
+
+            com.microsoft.identity.common.internal.logging.Logger.infoPII(
+                    TAG + methodName,
+                    "Package: " + mPackageName
+                            + " calling app UID:" + mAppCallingUID
+                            + " Account name: " + name
+            );
 
             // Cache logic will be changed based on latest logic
             // This is currently keeping accesstoken and MRRT separate
             // Encrypted Results are saved to AccountManager Service
             // sqllite database. Only Authenticator and similar UID can
             // access.
-            Gson gson = new Gson();
-            Logger.i(TAG + methodName, "app context:" + getApplicationContext().getPackageName()
-                    + " context:" + AuthenticationActivity.this.getPackageName()
-                    + " calling packagename:" + getCallingPackage(), "");
+            final Gson gson = new Gson();
+
+            com.microsoft.identity.common.internal.logging.Logger.infoPII(
+                    TAG + methodName,
+                    "app context:" + getApplicationContext().getPackageName()
+                            + " context:" + AuthenticationActivity.this.getPackageName()
+                            + " calling packagename:" + getCallingPackage()
+            );
 
             if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
-                Logger.i(TAG + methodName, "Calling app doesn't provide the secret key.", "");
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + methodName,
+                        "Calling app doesn't provide the secret key."
+                );
             }
 
             final TokenCacheItem item = TokenCacheItem.createRegularTokenCacheItem(
@@ -1065,7 +1427,11 @@ public class AuthenticationActivity extends Activity {
             // Record calling UID for this account so that app can get token
             // in the background call without requiring server side
             // validation
-            Logger.i(TAG + methodName, "Set calling uid:" + mAppCallingUID, "");
+            com.microsoft.identity.common.internal.logging.Logger.info(
+                    TAG + methodName,
+                    "Set calling uid:" + mAppCallingUID
+            );
+
             appendAppUIDToAccount(newAccount);
         }
 
@@ -1074,7 +1440,12 @@ public class AuthenticationActivity extends Activity {
                                   final Account cacheAccount,
                                   final int callingUID) {
             final String methodName = ":saveCacheKey";
-            Logger.v(TAG + methodName, "Get CacheKeys for account");
+
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Get CacheKeys for account"
+            );
+
             // Store cachekeys for each UID
             // Activity has access to packagename and UID, but background call
             // in getAuthToken only knows about UID
@@ -1085,22 +1456,45 @@ public class AuthenticationActivity extends Activity {
             }
 
             if (!keylist.contains(CALLER_CACHEKEY_PREFIX + key)) {
-                Logger.v(TAG + methodName, "Account does not have the cache key. Saving it to account for the caller. ",
-                        "callerUID: " + callingUID + "The key to be saved is: " + key, null);
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Account does not have the cache key. Saving it to account for the caller."
+                );
+
+                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                        TAG + methodName,
+                        "callerUID: " + callingUID
+                                + "The key to be saved is: " + key
+                );
+
                 keylist += CALLER_CACHEKEY_PREFIX + key;
                 mAccountManager.setUserData(cacheAccount, USERDATA_CALLER_CACHEKEYS + callingUID, keylist);
-                Logger.v(TAG + methodName, "Cache key saved into key list for the caller.", "keylist:" + keylist, null);
+
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Cache key saved into key list for the caller."
+                );
+                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                        TAG + methodName,
+                        "keylist:" + keylist
+                );
             }
         }
 
         @Override
         protected void onPostExecute(final TokenTaskResult result) {
-            Logger.v(TAG, "Token task returns the result");
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG,
+                    "Token task returns the result"
+            );
             displaySpinner(false);
             Intent intent = new Intent();
 
             if (result.mTaskResult == null) {
-                Logger.v(TAG, "Token task has exception");
+                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG,
+                        "Token task has exception"
+                );
 
                 returnError(
                         ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -158,7 +158,7 @@ public class AuthenticationActivity extends Activity {
             final String methodName = ":onReceive";
             Logger.v(TAG + methodName, "ActivityBroadcastReceiver onReceive");
 
-            if (intent.getAction().equalsIgnoreCase(ACTION_CANCEL)) {
+            if (null != intent.getAction() && intent.getAction().equalsIgnoreCase(ACTION_CANCEL)) {
                 Logger.v(TAG + methodName,
                         "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity");
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -865,13 +865,9 @@ public class AuthenticationActivity extends Activity {
     class TokenTask extends AsyncTask<String, String, TokenTaskResult> {
 
         private String mPackageName;
-
         private int mAppCallingUID;
-
         private AuthenticationRequest mRequest;
-
         private AccountManager mAccountManager;
-
         private IWebRequestHandler mRequestHandler;
 
         public TokenTask() {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -87,38 +87,24 @@ public class AuthenticationActivity extends Activity {
     static final int BACK_PRESSED_CANCEL_DIALOG_STEPS = -2;
 
     private static final String TAG = "AuthenticationActivity";
-
     private boolean mRegisterReceiver = false;
-
     private WebView mWebView;
-
     private String mStartUrl;
-
     private ProgressDialog mSpinner;
-
     private String mRedirectUrl;
-
     private AuthenticationRequest mAuthRequest;
 
     // Broadcast receiver for cancel
     private ActivityBroadcastReceiver mReceiver = null;
-
     private String mCallingPackage;
-
     private int mWaitingRequestId;
-
     private int mCallingUID;
-
     private AccountAuthenticatorResponse mAccountAuthenticatorResponse = null;
-
     private Bundle mAuthenticatorResultBundle = null;
-
     private final IWebRequestHandler mWebRequestHandler = new WebRequestHandler();
-
     private final JWSBuilder mJWSBuilder = new JWSBuilder();
     private boolean mPkeyAuthRedirect = false;
     private StorageHelper mStorageHelper;
-
     private UIEvent mUIEvent = null;
 
     // Broadcast receiver is needed to cancel outstanding AuthenticationActivity

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -1051,7 +1051,13 @@ public class AuthenticationActivity extends Activity {
 
                 json = gson.toJson(itemMRRT);
                 encrypted = mStorageHelper.encrypt(json);
-                key = CacheKey.createCacheKeyForMRRT(mAuthRequest.getAuthority(), mAuthRequest.getClientId(), null);
+
+                key = CacheKey.createCacheKeyForMRRT(
+                        mAuthRequest.getAuthority(),
+                        mAuthRequest.getClientId(),
+                        null
+                );
+
                 saveCacheKey(key, newAccount, mAppCallingUID);
                 mAccountManager.setUserData(newAccount, getBrokerAppCacheKey(key), encrypted);
             }
@@ -1082,9 +1088,7 @@ public class AuthenticationActivity extends Activity {
                 Logger.v(TAG + methodName, "Account does not have the cache key. Saving it to account for the caller. ",
                         "callerUID: " + callingUID + "The key to be saved is: " + key, null);
                 keylist += CALLER_CACHEKEY_PREFIX + key;
-                mAccountManager.setUserData(cacheAccount,
-                        USERDATA_CALLER_CACHEKEYS + callingUID,
-                        keylist);
+                mAccountManager.setUserData(cacheAccount, USERDATA_CALLER_CACHEKEYS + callingUID, keylist);
                 Logger.v(TAG + methodName, "Cache key saved into key list for the caller.", "keylist:" + keylist, null);
             }
         }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -408,7 +408,6 @@ public class AuthenticationActivity extends Activity {
                 try {
                     correlationIdParsed = UUID.fromString(correlationId);
                 } catch (IllegalArgumentException ex) {
-                    correlationIdParsed = null;
                     Logger.e(TAG + methodName, "CorrelationId is malformed: " + correlationId, "",
                             ADALError.CORRELATION_ID_FORMAT);
                 }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -52,7 +52,6 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.gson.Gson;
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.JWSBuilder;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
@@ -163,8 +162,7 @@ public class AuthenticationActivity extends Activity {
                 Logger.v(TAG + methodName,
                         "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity");
 
-                int cancelRequestId = intent.getIntExtra(
-                        REQUEST_ID, 0);
+                int cancelRequestId = intent.getIntExtra(REQUEST_ID, 0);
 
                 if (cancelRequestId == mWaitingRequestId) {
                     Logger.v(TAG + methodName, "Waiting requestId is same and cancelling this activity");
@@ -206,26 +204,22 @@ public class AuthenticationActivity extends Activity {
         }
 
         if (mAuthRequest.getAuthority() == null || mAuthRequest.getAuthority().isEmpty()) {
-            returnError(ADALError.ARGUMENT_EXCEPTION,
-                    ACCOUNT_AUTHORITY);
+            returnError(ADALError.ARGUMENT_EXCEPTION, ACCOUNT_AUTHORITY);
             return;
         }
 
         if (mAuthRequest.getResource() == null || mAuthRequest.getResource().isEmpty()) {
-            returnError(ADALError.ARGUMENT_EXCEPTION,
-                    ACCOUNT_RESOURCE);
+            returnError(ADALError.ARGUMENT_EXCEPTION, ACCOUNT_RESOURCE);
             return;
         }
 
         if (mAuthRequest.getClientId() == null || mAuthRequest.getClientId().isEmpty()) {
-            returnError(ADALError.ARGUMENT_EXCEPTION,
-                    ACCOUNT_CLIENTID_KEY);
+            returnError(ADALError.ARGUMENT_EXCEPTION, ACCOUNT_CLIENTID_KEY);
             return;
         }
 
         if (mAuthRequest.getRedirectUri() == null || mAuthRequest.getRedirectUri().isEmpty()) {
-            returnError(ADALError.ARGUMENT_EXCEPTION,
-                    ACCOUNT_REDIRECT);
+            returnError(ADALError.ARGUMENT_EXCEPTION, ACCOUNT_REDIRECT);
             return;
         }
         mRedirectUrl = mAuthRequest.getRedirectUri();
@@ -635,8 +629,7 @@ public class AuthenticationActivity extends Activity {
 
     private void hideKeyBoard() {
         if (mWebView != null) {
-            InputMethodManager imm = (InputMethodManager) this
-                    .getSystemService(Service.INPUT_METHOD_SERVICE);
+            InputMethodManager imm = (InputMethodManager) this.getSystemService(Service.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(mWebView.getApplicationWindowToken(), 0);
         }
     }
@@ -662,12 +655,12 @@ public class AuthenticationActivity extends Activity {
                 // It is pointing to redirect. Final url can be processed to
                 // get the code or error.
                 Logger.i(TAG + methodName, "It is not a broker request", "");
+
                 Intent resultIntent = new Intent();
                 resultIntent.putExtra(RESPONSE_FINAL_URL, url);
-                resultIntent.putExtra(RESPONSE_REQUEST_INFO,
-                        mAuthRequest);
-                returnToCaller(BROWSER_CODE_COMPLETE,
-                        resultIntent);
+                resultIntent.putExtra(RESPONSE_REQUEST_INFO, mAuthRequest);
+                returnToCaller(BROWSER_CODE_COMPLETE, resultIntent);
+
                 view.stopLoading();
             } else {
                 Logger.i(TAG + methodName, "It is a broker request", "");
@@ -1007,21 +1000,11 @@ public class AuthenticationActivity extends Activity {
                 mRequest.setLoginHint(name);
             } else {
                 Logger.i(TAG + methodName, "Saving userinfo to account", "");
-                mAccountManager.setUserData(newAccount,
-                        ACCOUNT_USERINFO_USERID,
-                        userinfo.getUserId());
-                mAccountManager.setUserData(newAccount,
-                        ACCOUNT_USERINFO_GIVEN_NAME,
-                        userinfo.getGivenName());
-                mAccountManager.setUserData(newAccount,
-                        ACCOUNT_USERINFO_FAMILY_NAME,
-                        userinfo.getFamilyName());
-                mAccountManager.setUserData(newAccount,
-                        ACCOUNT_USERINFO_IDENTITY_PROVIDER,
-                        userinfo.getIdentityProvider());
-                mAccountManager.setUserData(newAccount,
-                        ACCOUNT_USERINFO_USERID_DISPLAYABLE,
-                        userinfo.getDisplayableId());
+                mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_USERID, userinfo.getUserId());
+                mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_GIVEN_NAME, userinfo.getGivenName());
+                mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_FAMILY_NAME, userinfo.getFamilyName());
+                mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_IDENTITY_PROVIDER, userinfo.getIdentityProvider());
+                mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_USERID_DISPLAYABLE, userinfo.getDisplayableId());
             }
 
             result.mAccountName = name;
@@ -1121,70 +1104,34 @@ public class AuthenticationActivity extends Activity {
             }
 
             if (result.mTaskResult.getStatus().equals(AuthenticationStatus.Succeeded)) {
-                intent.putExtra(
-                        REQUEST_ID,
-                        mWaitingRequestId
-                );
-                intent.putExtra(
-                        ACCOUNT_ACCESS_TOKEN,
-                        result.mTaskResult.getAccessToken()
-                );
-                intent.putExtra(
-                        ACCOUNT_NAME,
-                        result.mAccountName
-                );
+                intent.putExtra(REQUEST_ID, mWaitingRequestId);
+                intent.putExtra(ACCOUNT_ACCESS_TOKEN, result.mTaskResult.getAccessToken());
+                intent.putExtra(ACCOUNT_NAME, result.mAccountName);
 
                 if (result.mTaskResult.getExpiresOn() != null) {
-                    intent.putExtra(
-                            ACCOUNT_EXPIREDATE,
-                            result.mTaskResult.getExpiresOn().getTime()
-                    );
+                    intent.putExtra(ACCOUNT_EXPIREDATE, result.mTaskResult.getExpiresOn().getTime());
                 }
 
                 if (result.mTaskResult.getTenantId() != null) {
-                    intent.putExtra(
-                            ACCOUNT_USERINFO_TENANTID,
-                            result.mTaskResult.getTenantId()
-                    );
+                    intent.putExtra(ACCOUNT_USERINFO_TENANTID, result.mTaskResult.getTenantId());
                 }
 
                 final UserInfo userinfo = result.mTaskResult.getUserInfo();
 
                 if (userinfo != null) {
-                    intent.putExtra(ACCOUNT_USERINFO_USERID,
-                            userinfo.getUserId());
-                    intent.putExtra(ACCOUNT_USERINFO_GIVEN_NAME,
-                            userinfo.getGivenName());
-                    intent.putExtra(
-                            ACCOUNT_USERINFO_FAMILY_NAME,
-                            userinfo.getFamilyName());
-                    intent.putExtra(
-                            ACCOUNT_USERINFO_IDENTITY_PROVIDER,
-                            userinfo.getIdentityProvider());
-                    intent.putExtra(
-                            ACCOUNT_USERINFO_USERID_DISPLAYABLE,
-                            userinfo.getDisplayableId());
+                    intent.putExtra(ACCOUNT_USERINFO_USERID, userinfo.getUserId());
+                    intent.putExtra(ACCOUNT_USERINFO_GIVEN_NAME, userinfo.getGivenName());
+                    intent.putExtra(ACCOUNT_USERINFO_FAMILY_NAME, userinfo.getFamilyName());
+                    intent.putExtra(ACCOUNT_USERINFO_IDENTITY_PROVIDER, userinfo.getIdentityProvider());
+                    intent.putExtra(ACCOUNT_USERINFO_USERID_DISPLAYABLE, userinfo.getDisplayableId());
                 }
 
                 if (null != result.mTaskResult.getCliTelemInfo()) {
                     final TelemetryUtils.CliTelemInfo cliTelemInfo = result.mTaskResult.getCliTelemInfo();
-
-                    intent.putExtra(
-                            SPE_RING,
-                            cliTelemInfo.getSpeRing()
-                    );
-                    intent.putExtra(
-                            RT_AGE,
-                            cliTelemInfo.getRefreshTokenAge()
-                    );
-                    intent.putExtra(
-                            SERVER_ERROR,
-                            cliTelemInfo.getServerErrorCode()
-                    );
-                    intent.putExtra(
-                            SERVER_SUBERROR,
-                            cliTelemInfo.getServerSubErrorCode()
-                    );
+                    intent.putExtra(SPE_RING, cliTelemInfo.getSpeRing());
+                    intent.putExtra(RT_AGE, cliTelemInfo.getRefreshTokenAge());
+                    intent.putExtra(SERVER_ERROR, cliTelemInfo.getServerErrorCode());
+                    intent.putExtra(SERVER_SUBERROR, cliTelemInfo.getServerSubErrorCode());
                 }
 
                 returnResult(TOKEN_BROKER_RESPONSE, intent);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -261,8 +261,7 @@ public class AuthenticationActivity extends Activity {
                 new IntentFilter(ACTION_CANCEL));
 
         String userAgent = mWebView.getSettings().getUserAgentString();
-        mWebView.getSettings().setUserAgentString(
-                userAgent + CLIENT_TLS_NOT_SUPPORTED);
+        mWebView.getSettings().setUserAgentString(userAgent + CLIENT_TLS_NOT_SUPPORTED);
         userAgent = mWebView.getSettings().getUserAgentString();
         Logger.v(TAG + methodName, "", "UserAgent:" + userAgent, null);
 
@@ -285,9 +284,11 @@ public class AuthenticationActivity extends Activity {
 
             mAccountAuthenticatorResponse = getIntent().getParcelableExtra(
                     AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE);
+
             if (mAccountAuthenticatorResponse != null) {
                 mAccountAuthenticatorResponse.onRequestContinued();
             }
+
             PackageHelper info = new PackageHelper(AuthenticationActivity.this);
             mCallingPackage = getCallingPackage();
             mCallingUID = info.getUIDForPackage(mCallingPackage);
@@ -889,6 +890,7 @@ public class AuthenticationActivity extends Activity {
         protected TokenTaskResult doInBackground(final String... urlItems) {
             Oauth2 oauthRequest = new Oauth2(mRequest, mRequestHandler, mJWSBuilder);
             TokenTaskResult result = new TokenTaskResult();
+
             try {
                 result.mTaskResult = oauthRequest.getToken(urlItems[0]);
                 Logger.v(TAG, "Process result returned from TokenTask. ", mRequest.getLogInfo(), null);
@@ -918,9 +920,7 @@ public class AuthenticationActivity extends Activity {
                 throws NoSuchAlgorithmException, UnsupportedEncodingException {
             // include UID in the key for broker to store caches for different
             // apps under same account entry
-            String digestKey = StringExtensions
-                    .createHash(USERDATA_UID_KEY + mAppCallingUID
-                            + cacheKey);
+            String digestKey = StringExtensions.createHash(USERDATA_UID_KEY + mAppCallingUID + cacheKey);
             Logger.v(TAG, "Get broker app cache key.",
                     "Key hash is:" + digestKey
                             + " calling app UID:" + mAppCallingUID
@@ -952,14 +952,14 @@ public class AuthenticationActivity extends Activity {
             if (!appIdList.contains(USERDATA_UID_KEY
                     + mAppCallingUID)) {
                 Logger.i(TAG + methodName, "Account has new calling UID. ", "App UID: " + mAppCallingUID, null);
-                String encryptedValue = mStorageHelper.encrypt(appIdList
-                        + USERDATA_UID_KEY
-                        + mAppCallingUID);
-                mAccountManager
-                        .setUserData(
-                                account,
-                                ACCOUNT_UID_CACHES,
-                                encryptedValue);
+
+                final String encryptedValue = mStorageHelper.encrypt(
+                        appIdList
+                                + USERDATA_UID_KEY
+                                + mAppCallingUID
+                );
+
+                mAccountManager.setUserData(account, ACCOUNT_UID_CACHES, encryptedValue);
             }
         }
 
@@ -971,14 +971,13 @@ public class AuthenticationActivity extends Activity {
 
             final String methodName = ":setAccount";
             // Authenticator sets the account here and stores the tokens.
-            String name = mRequest.getBrokerAccountName();
-            Account[] accountList = mAccountManager
-                    .getAccountsByType(BROKER_ACCOUNT_TYPE);
+            final String name = mRequest.getBrokerAccountName();
+            final Account[] accountList = mAccountManager.getAccountsByType(BROKER_ACCOUNT_TYPE);
 
             if (accountList.length != 1) {
                 result.mTaskResult = null;
-                result.mTaskException = new AuthenticationException(
-                        ADALError.BROKER_SINGLE_USER_EXPECTED);
+                result.mTaskException = new AuthenticationException(ADALError.BROKER_SINGLE_USER_EXPECTED);
+
                 return;
             }
 
@@ -1021,31 +1020,40 @@ public class AuthenticationActivity extends Activity {
                 Logger.i(TAG + methodName, "Calling app doesn't provide the secret key.", "");
             }
 
-            TokenCacheItem item = TokenCacheItem.createRegularTokenCacheItem(mRequest.getAuthority(), mRequest.getResource(),
-                    mRequest.getClientId(), result.mTaskResult);
+            final TokenCacheItem item = TokenCacheItem.createRegularTokenCacheItem(
+                    mRequest.getAuthority(),
+                    mRequest.getResource(),
+                    mRequest.getClientId(),
+                    result.mTaskResult
+            );
+
             String json = gson.toJson(item);
             String encrypted = mStorageHelper.encrypt(json);
 
             // Single user and cache is stored per account
-            String key = CacheKey.createCacheKeyForRTEntry(mAuthRequest.getAuthority(), mAuthRequest.getResource(),
-                    mAuthRequest.getClientId(), null);
+            String key = CacheKey.createCacheKeyForRTEntry(
+                    mAuthRequest.getAuthority(),
+                    mAuthRequest.getResource(),
+                    mAuthRequest.getClientId(),
+                    null
+            );
+
             saveCacheKey(key, newAccount, mAppCallingUID);
-            mAccountManager.setUserData(
-                    newAccount,
-                    getBrokerAppCacheKey(key),
-                    encrypted);
+            mAccountManager.setUserData(newAccount, getBrokerAppCacheKey(key), encrypted);
 
             if (result.mTaskResult.getIsMultiResourceRefreshToken()) {
                 // ADAL stores MRRT refresh token separately
-                TokenCacheItem itemMRRT = TokenCacheItem.createMRRTTokenCacheItem(mRequest.getAuthority(), mRequest.getClientId(), result.mTaskResult);
+                final TokenCacheItem itemMRRT = TokenCacheItem.createMRRTTokenCacheItem(
+                        mRequest.getAuthority(),
+                        mRequest.getClientId(),
+                        result.mTaskResult
+                );
+
                 json = gson.toJson(itemMRRT);
                 encrypted = mStorageHelper.encrypt(json);
                 key = CacheKey.createCacheKeyForMRRT(mAuthRequest.getAuthority(), mAuthRequest.getClientId(), null);
                 saveCacheKey(key, newAccount, mAppCallingUID);
-                mAccountManager.setUserData(
-                        newAccount,
-                        getBrokerAppCacheKey(key),
-                        encrypted);
+                mAccountManager.setUserData(newAccount, getBrokerAppCacheKey(key), encrypted);
             }
 
             // Record calling UID for this account so that app can get token
@@ -1064,8 +1072,7 @@ public class AuthenticationActivity extends Activity {
             // Store cachekeys for each UID
             // Activity has access to packagename and UID, but background call
             // in getAuthToken only knows about UID
-            String keylist = mAccountManager.getUserData(cacheAccount,
-                    USERDATA_CALLER_CACHEKEYS + callingUID);
+            String keylist = mAccountManager.getUserData(cacheAccount, USERDATA_CALLER_CACHEKEYS + callingUID);
 
             if (keylist == null) {
                 keylist = "";
@@ -1142,9 +1149,7 @@ public class AuthenticationActivity extends Activity {
 
     class TokenTaskResult {
         private AuthenticationResult mTaskResult;
-
         private Exception mTaskException;
-
         private String mAccountName;
     }
 }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -71,10 +71,19 @@ import java.security.cert.X509Certificate;
 import java.util.Locale;
 import java.util.UUID;
 
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_AUTHORITY;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_CORRELATIONID;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_LOGIN_HINT;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_NAME;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_PROMPT;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_REDIRECT;
+import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_RESOURCE;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.RT_AGE;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CliTelemInfo.SPE_RING;
+import static com.microsoft.aad.adal.AuthenticationConstants.Browser.REQUEST_ID;
 
 /**
  * Authentication Activity to launch {@link WebView} for authentication.
@@ -372,32 +381,29 @@ public class AuthenticationActivity extends Activity {
     private AuthenticationRequest getAuthenticationRequestFromIntent(final Intent callingIntent) {
         final String methodName = ":getAuthenticationRequestFromIntent";
         AuthenticationRequest authRequest = null;
+
         if (isBrokerRequest(callingIntent)) {
             Logger.v(TAG + methodName, "It is a broker request. Get request info from bundle extras.");
-            String authority = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_AUTHORITY);
-            String resource = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_RESOURCE);
-            String redirect = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_REDIRECT);
-            String loginhint = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_LOGIN_HINT);
-            String accountName = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_NAME);
-            String clientidKey = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY);
-            String correlationId = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_CORRELATIONID);
-            String prompt = callingIntent
-                    .getStringExtra(AuthenticationConstants.Broker.ACCOUNT_PROMPT);
+
+            final String authority = callingIntent.getStringExtra(ACCOUNT_AUTHORITY);
+            final String resource = callingIntent.getStringExtra(ACCOUNT_RESOURCE);
+            final String redirect = callingIntent.getStringExtra(ACCOUNT_REDIRECT);
+            final String loginhint = callingIntent.getStringExtra(ACCOUNT_LOGIN_HINT);
+            final String accountName = callingIntent.getStringExtra(ACCOUNT_NAME);
+            final String clientidKey = callingIntent.getStringExtra(ACCOUNT_CLIENTID_KEY);
+            final String correlationId = callingIntent.getStringExtra(ACCOUNT_CORRELATIONID);
+            final String prompt = callingIntent.getStringExtra(ACCOUNT_PROMPT);
+
             PromptBehavior promptBehavior = PromptBehavior.Auto;
+
             if (!StringExtensions.isNullOrBlank(prompt)) {
                 promptBehavior = PromptBehavior.valueOf(prompt);
             }
 
-            mWaitingRequestId = callingIntent.getIntExtra(
-                    AuthenticationConstants.Browser.REQUEST_ID, 0);
+            mWaitingRequestId = callingIntent.getIntExtra(REQUEST_ID, 0);
+
             UUID correlationIdParsed = null;
+
             if (!StringExtensions.isNullOrBlank(correlationId)) {
                 try {
                     correlationIdParsed = UUID.fromString(correlationId);
@@ -407,8 +413,17 @@ public class AuthenticationActivity extends Activity {
                             ADALError.CORRELATION_ID_FORMAT);
                 }
             }
-            authRequest = new AuthenticationRequest(authority, resource, clientidKey, redirect,
-                    loginhint, correlationIdParsed, false);
+
+            authRequest = new AuthenticationRequest(
+                    authority,
+                    resource,
+                    clientidKey,
+                    redirect,
+                    loginhint,
+                    correlationIdParsed,
+                    false // isExtendedLifetimeEnabled
+            );
+
             authRequest.setBrokerAccountName(accountName);
             authRequest.setPrompt(promptBehavior);
             authRequest.setRequestId(mWaitingRequestId);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -20,7 +20,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package com.microsoft.aad.adal;
 
 import android.accounts.Account;
@@ -40,7 +39,6 @@ import android.os.Bundle;
 import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.Window;
@@ -49,6 +47,8 @@ import android.webkit.ClientCertRequest;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 import android.webkit.WebView;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.gson.Gson;
 import com.microsoft.aad.adal.AuthenticationResult.AuthenticationStatus;
@@ -129,7 +129,7 @@ public class AuthenticationActivity extends Activity {
         private int mWaitingRequestId = -1;
 
         @Override
-        public void onReceive(Context context, Intent intent) {
+        public void onReceive(final Context context, final Intent intent) {
             final String methodName = ":onReceive";
             Logger.v(TAG + methodName, "ActivityBroadcastReceiver onReceive");
 
@@ -155,7 +155,7 @@ public class AuthenticationActivity extends Activity {
     // is still necessary for API level 20 and below.
     @SuppressLint("SetJavaScriptEnabled")
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         final String methodName = ":onCreate";
         super.onCreate(savedInstanceState);
         setContentView(this.getResources().getIdentifier("activity_authentication", "layout",
@@ -344,7 +344,7 @@ public class AuthenticationActivity extends Activity {
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle outState) {
+    protected void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
 
         // Save the state of the WebView
@@ -352,7 +352,7 @@ public class AuthenticationActivity extends Activity {
     }
 
     @Override
-    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+    protected void onRestoreInstanceState(final Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
 
         // Restore the state of the WebView
@@ -360,14 +360,13 @@ public class AuthenticationActivity extends Activity {
     }
 
     private void setupWebView() {
-
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.requestFocus(View.FOCUS_DOWN);
 
         // Set focus to the view for touch event
         mWebView.setOnTouchListener(new View.OnTouchListener() {
             @Override
-            public boolean onTouch(View view, MotionEvent event) {
+            public boolean onTouch(final View view, final MotionEvent event) {
                 int action = event.getAction();
                 if ((action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_UP) && !view.hasFocus()) {
                     view.requestFocus();
@@ -384,7 +383,7 @@ public class AuthenticationActivity extends Activity {
         mWebView.setVisibility(View.INVISIBLE);
     }
 
-    private AuthenticationRequest getAuthenticationRequestFromIntent(Intent callingIntent) {
+    private AuthenticationRequest getAuthenticationRequestFromIntent(final Intent callingIntent) {
         final String methodName = ":getAuthenticationRequestFromIntent";
         AuthenticationRequest authRequest = null;
         if (isBrokerRequest(callingIntent)) {
@@ -441,7 +440,7 @@ public class AuthenticationActivity extends Activity {
     /**
      * Return error to caller and finish this activity.
      */
-    private void returnError(ADALError errorCode, String argument) {
+    private void returnError(final ADALError errorCode, final String argument) {
         // Set result back to account manager call
         Logger.w(TAG, "Argument error:" + argument);
         Intent resultIntent = new Intent();
@@ -458,7 +457,9 @@ public class AuthenticationActivity extends Activity {
         this.finish();
     }
 
-    private String getBrokerStartUrl(String loadUrl, String packageName, String signatureDigest) {
+    private String getBrokerStartUrl(final String loadUrl,
+                                     final String packageName,
+                                     final String signatureDigest) {
         if (!StringExtensions.isNullOrBlank(packageName)
                 && !StringExtensions.isNullOrBlank(signatureDigest)) {
             try {
@@ -476,7 +477,7 @@ public class AuthenticationActivity extends Activity {
         return loadUrl;
     }
 
-    private boolean isBrokerRequest(Intent callingIntent) {
+    private boolean isBrokerRequest(final Intent callingIntent) {
         // Intent should have a flag and activity is hosted inside broker
         return callingIntent != null
                 && !StringExtensions.isNullOrBlank(callingIntent
@@ -489,7 +490,7 @@ public class AuthenticationActivity extends Activity {
      * @param resultCode result code to be returned to the called
      * @param data       intent to be returned to the caller
      */
-    private void returnToCaller(int resultCode, Intent data) {
+    private void returnToCaller(final int resultCode, Intent data) {
         final String methodName = ":returnToCaller";
         Logger.v(TAG + methodName, "Return To Caller:" + resultCode);
         displaySpinner(false);
@@ -624,7 +625,7 @@ public class AuthenticationActivity extends Activity {
             super(AuthenticationActivity.this, mRedirectUrl, mAuthRequest, mUIEvent);
         }
 
-        public void processRedirectUrl(final WebView view, String url) {
+        public void processRedirectUrl(final WebView view, final String url) {
             final String methodName = ":processRedirectUrl";
             if (!isBrokerRequest(getIntent())) {
                 // It is pointing to redirect. Final url can be processed to
@@ -652,7 +653,7 @@ public class AuthenticationActivity extends Activity {
             }
         }
 
-        public boolean processInvalidUrl(final WebView view, String url) {
+        public boolean processInvalidUrl(final WebView view, final String url) {
             final String methodName = ":processInvalidUrl";
             if (isBrokerRequest(getIntent())
                     && url.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX)) {
@@ -681,12 +682,12 @@ public class AuthenticationActivity extends Activity {
             return false;
         }
 
-        public void showSpinner(boolean status) {
+        public void showSpinner(final boolean status) {
             displaySpinner(status);
         }
 
         @Override
-        public void sendResponse(int returnCode, Intent responseIntent) {
+        public void sendResponse(final int returnCode, final Intent responseIntent) {
             returnToCaller(returnCode, responseIntent);
         }
 
@@ -701,18 +702,19 @@ public class AuthenticationActivity extends Activity {
         }
 
         @Override
-        public void setPKeyAuthStatus(boolean status) {
+        public void setPKeyAuthStatus(final boolean status) {
             mPkeyAuthRedirect = status;
         }
 
         @Override
-        public void postRunnable(Runnable item) {
+        public void postRunnable(final Runnable item) {
             mWebView.post(item);
         }
 
         @TargetApi(Build.VERSION_CODES.LOLLIPOP)
         @Override
-        public void onReceivedClientCertRequest(WebView view, final ClientCertRequest request) {
+        public void onReceivedClientCertRequest(final WebView view,
+                                                final ClientCertRequest request) {
             final String methodName = ":onReceivedClientCertRequest";
             Logger.v(TAG + methodName, "Webview receives client TLS request.");
 
@@ -733,7 +735,7 @@ public class AuthenticationActivity extends Activity {
             KeyChain.choosePrivateKeyAlias(AuthenticationActivity.this, new KeyChainAliasCallback() {
 
                 @Override
-                public void alias(String alias) {
+                public void alias(final String alias) {
                     if (alias == null) {
                         Logger.v(TAG + methodName, "No certificate chosen by user, cancelling the TLS request.");
                         request.cancel();
@@ -766,7 +768,7 @@ public class AuthenticationActivity extends Activity {
      *
      * @param show True if spinner needs to be displayed, False otherwise
      */
-    private void displaySpinner(boolean show) {
+    private void displaySpinner(final boolean show) {
         final String methodName = ":displaySpinner";
         if (!AuthenticationActivity.this.isFinishing()
                 && !AuthenticationActivity.this.isChangingConfigurations() && mSpinner != null) {
@@ -782,14 +784,14 @@ public class AuthenticationActivity extends Activity {
         }
     }
 
-    private void displaySpinnerWithMessage(CharSequence charSequence) {
+    private void displaySpinnerWithMessage(final CharSequence charSequence) {
         if (!AuthenticationActivity.this.isFinishing() && mSpinner != null) {
             mSpinner.show();
             mSpinner.setMessage(charSequence);
         }
     }
 
-    private void returnResult(int resultcode, Intent intent) {
+    private void returnResult(final int resultcode, final Intent intent) {
         // Set result back to account manager call
         this.setAccountAuthenticatorResult(intent.getExtras());
         this.setResult(resultcode, intent);
@@ -852,8 +854,10 @@ public class AuthenticationActivity extends Activity {
             // Intentionally left blank
         }
 
-        public TokenTask(IWebRequestHandler webHandler, final AuthenticationRequest request,
-                         final String packageName, final int callingUID) {
+        public TokenTask(final IWebRequestHandler webHandler,
+                         final AuthenticationRequest request,
+                         final String packageName,
+                         final int callingUID) {
             mRequestHandler = webHandler;
             mRequest = request;
             mPackageName = packageName;
@@ -862,7 +866,7 @@ public class AuthenticationActivity extends Activity {
         }
 
         @Override
-        protected TokenTaskResult doInBackground(String... urlItems) {
+        protected TokenTaskResult doInBackground(final String... urlItems) {
             Oauth2 oauthRequest = new Oauth2(mRequest, mRequestHandler, mJWSBuilder);
             TokenTaskResult result = new TokenTaskResult();
             try {
@@ -890,7 +894,7 @@ public class AuthenticationActivity extends Activity {
             return result;
         }
 
-        private String getBrokerAppCacheKey(String cacheKey)
+        private String getBrokerAppCacheKey(final String cacheKey)
                 throws NoSuchAlgorithmException, UnsupportedEncodingException {
             // include UID in the key for broker to store caches for different
             // apps under same account entry
@@ -904,17 +908,19 @@ public class AuthenticationActivity extends Activity {
             return digestKey;
         }
 
-        private void appendAppUIDToAccount(Account account)
+        @SuppressLint("MissingPermission")
+        private void appendAppUIDToAccount(final Account account)
                 throws GeneralSecurityException, IOException {
             final String methodName = ":appendAppUIDToAccount";
             String appIdList = mAccountManager.getUserData(account,
                     AuthenticationConstants.Broker.ACCOUNT_UID_CACHES);
+
             if (appIdList == null) {
                 appIdList = "";
             } else {
                 try {
                     appIdList = mStorageHelper.decrypt(appIdList);
-                } catch (GeneralSecurityException | IOException ex) {
+                } catch (final GeneralSecurityException | IOException ex) {
                     Logger.e(TAG + methodName, "appUIDList failed to decrypt", "appIdList:" + appIdList,
                             ADALError.ENCRYPTION_FAILED, ex);
                     appIdList = "";
@@ -937,6 +943,7 @@ public class AuthenticationActivity extends Activity {
             }
         }
 
+        @SuppressLint("MissingPermission")
         private void setAccount(final TokenTaskResult result)
                 throws GeneralSecurityException, IOException {
             // TODO Add token logging
@@ -959,7 +966,8 @@ public class AuthenticationActivity extends Activity {
 
             // Single user in authenticator is already created.
             // This is only registering UID for the app
-            UserInfo userinfo = result.mTaskResult.getUserInfo();
+            final UserInfo userinfo = result.mTaskResult.getUserInfo();
+
             if (userinfo == null || StringExtensions.isNullOrBlank(userinfo.getUserId())) {
                 // return userid in the userinfo and use only account name
                 // for all fields
@@ -984,10 +992,10 @@ public class AuthenticationActivity extends Activity {
                         AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
                         userinfo.getDisplayableId());
             }
+
             result.mAccountName = name;
             Logger.i(TAG + methodName, "Setting account in account manager. ",
                     "Package: " + mPackageName + " calling app UID:" + mAppCallingUID + " Account name: " + name);
-
 
             // Cache logic will be changed based on latest logic
             // This is currently keeping accesstoken and MRRT separate
@@ -998,6 +1006,7 @@ public class AuthenticationActivity extends Activity {
             Logger.i(TAG + methodName, "app context:" + getApplicationContext().getPackageName()
                     + " context:" + AuthenticationActivity.this.getPackageName()
                     + " calling packagename:" + getCallingPackage(), "");
+
             if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
                 Logger.i(TAG + methodName, "Calling app doesn't provide the secret key.", "");
             }
@@ -1036,7 +1045,10 @@ public class AuthenticationActivity extends Activity {
             appendAppUIDToAccount(newAccount);
         }
 
-        private void saveCacheKey(String key, Account cacheAccount, int callingUID) {
+        @SuppressLint("MissingPermission")
+        private void saveCacheKey(final String key,
+                                  final Account cacheAccount,
+                                  final int callingUID) {
             final String methodName = ":saveCacheKey";
             Logger.v(TAG + methodName, "Get CacheKeys for account");
             // Store cachekeys for each UID
@@ -1044,9 +1056,11 @@ public class AuthenticationActivity extends Activity {
             // in getAuthToken only knows about UID
             String keylist = mAccountManager.getUserData(cacheAccount,
                     AuthenticationConstants.Broker.USERDATA_CALLER_CACHEKEYS + callingUID);
+
             if (keylist == null) {
                 keylist = "";
             }
+
             if (!keylist.contains(AuthenticationConstants.Broker.CALLER_CACHEKEY_PREFIX + key)) {
                 Logger.v(TAG + methodName, "Account does not have the cache key. Saving it to account for the caller. ",
                         "callerUID: " + callingUID + "The key to be saved is: " + key, null);
@@ -1059,7 +1073,7 @@ public class AuthenticationActivity extends Activity {
         }
 
         @Override
-        protected void onPostExecute(TokenTaskResult result) {
+        protected void onPostExecute(final TokenTaskResult result) {
             Logger.v(TAG, "Token task returns the result");
             displaySpinner(false);
             Intent intent = new Intent();
@@ -1103,7 +1117,7 @@ public class AuthenticationActivity extends Activity {
                     );
                 }
 
-                UserInfo userinfo = result.mTaskResult.getUserInfo();
+                final UserInfo userinfo = result.mTaskResult.getUserInfo();
 
                 if (userinfo != null) {
                     intent.putExtra(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -57,6 +57,7 @@ import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.logging.Logger;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -157,13 +158,10 @@ public class AuthenticationActivity extends Activity {
         public void onReceive(final Context context, final Intent intent) {
             final String methodName = ":onReceive";
 
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "ActivityBroadcastReceiver onReceive"
-            );
+            Logger.verbose(TAG + methodName, "ActivityBroadcastReceiver onReceive");
 
             if (null != intent.getAction() && intent.getAction().equalsIgnoreCase(ACTION_CANCEL)) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                Logger.verbose(
                         TAG + methodName,
                         "ActivityBroadcastReceiver onReceive action is for cancelling Authentication Activity"
                 );
@@ -171,7 +169,7 @@ public class AuthenticationActivity extends Activity {
                 int cancelRequestId = intent.getIntExtra(REQUEST_ID, 0);
 
                 if (cancelRequestId == mWaitingRequestId) {
-                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    Logger.verbose(
                             TAG + methodName,
                             "Waiting requestId is same and cancelling this activity"
                     );
@@ -207,16 +205,13 @@ public class AuthenticationActivity extends Activity {
         CookieManager cookieManager = CookieManager.getInstance();
         cookieManager.setAcceptCookie(true);
 
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG + methodName,
-                "AuthenticationActivity was created."
-        );
+        Logger.verbose(TAG + methodName, "AuthenticationActivity was created.");
 
         // Get the message from the intent
         mAuthRequest = getAuthenticationRequestFromIntent(getIntent());
 
         if (mAuthRequest == null) {
-            com.microsoft.identity.common.internal.logging.Logger.warn(
+            Logger.warn(
                     TAG + methodName,
                     "Intent for Authentication Activity doesn't have the request details, returning to caller"
             );
@@ -270,10 +265,7 @@ public class AuthenticationActivity extends Activity {
         if (!AuthenticationSettings.INSTANCE.getDisableWebViewHardwareAcceleration()) {
             mWebView.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null);
 
-            com.microsoft.identity.common.internal.logging.Logger.warn(
-                    TAG + methodName,
-                    "Hardware acceleration is disabled in WebView"
-            );
+            Logger.warn(TAG + methodName, "Hardware acceleration is disabled in WebView");
         }
 
         mStartUrl = "about:blank";
@@ -282,11 +274,7 @@ public class AuthenticationActivity extends Activity {
             final Oauth2 oauth = new Oauth2(mAuthRequest);
             mStartUrl = oauth.getCodeRequestUrl();
         } catch (UnsupportedEncodingException e) {
-            com.microsoft.identity.common.internal.logging.Logger.error(
-                    TAG + methodName,
-                    "Encoding format is not supported. ",
-                    e
-            );
+            Logger.error(TAG + methodName, "Encoding format is not supported. ", e);
 
             final Intent resultIntent = new Intent();
             resultIntent.putExtra(RESPONSE_REQUEST_INFO, mAuthRequest);
@@ -296,17 +284,14 @@ public class AuthenticationActivity extends Activity {
         }
 
         // Create the broadcast receiver for cancel
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
+        Logger.verbose(
                 TAG + methodName,
                 "Init broadcastReceiver with request. "
                         + "RequestId:"
                         + mAuthRequest.getRequestId()
         );
 
-        com.microsoft.identity.common.internal.logging.Logger.verbosePII(
-                TAG + methodName,
-                mAuthRequest.getLogInfo()
-        );
+        Logger.verbosePII(TAG + methodName, mAuthRequest.getLogInfo());
 
         mReceiver = new ActivityBroadcastReceiver();
         mReceiver.mWaitingRequestId = mAuthRequest.getRequestId();
@@ -316,10 +301,7 @@ public class AuthenticationActivity extends Activity {
         mWebView.getSettings().setUserAgentString(userAgent + CLIENT_TLS_NOT_SUPPORTED);
         userAgent = mWebView.getSettings().getUserAgentString();
 
-        com.microsoft.identity.common.internal.logging.Logger.verbosePII(
-                TAG + methodName,
-                "UserAgent:" + userAgent
-        );
+        Logger.verbosePII(TAG + methodName, "UserAgent:" + userAgent);
 
         if (isBrokerRequest(getIntent())) {
             // This activity is started from calling app and running in
@@ -327,7 +309,7 @@ public class AuthenticationActivity extends Activity {
             mCallingPackage = getCallingPackage();
 
             if (mCallingPackage == null) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                Logger.verbose(
                         TAG + methodName,
                         "Calling package is null, startActivityForResult is not used to call this activity"
                 );
@@ -339,7 +321,7 @@ public class AuthenticationActivity extends Activity {
 
                 return;
             }
-            com.microsoft.identity.common.internal.logging.Logger.info(
+            Logger.info(
                     TAG + methodName,
                     "It is a broker request for package:" + mCallingPackage
             );
@@ -358,7 +340,7 @@ public class AuthenticationActivity extends Activity {
             mStartUrl = getBrokerStartUrl(mStartUrl, mCallingPackage, signatureDigest);
 
             if (!isCallerBrokerInstaller()) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                Logger.verbose(
                         TAG + methodName,
                         "Caller needs to be verified using special redirectUri"
                 );
@@ -366,7 +348,7 @@ public class AuthenticationActivity extends Activity {
                 mRedirectUrl = PackageHelper.getBrokerRedirectUrl(mCallingPackage, signatureDigest);
             }
 
-            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+            Logger.verbosePII(
                     TAG + methodName,
                     "Broker redirectUrl: " + mRedirectUrl
                             + " The calling package is: " + mCallingPackage
@@ -375,19 +357,13 @@ public class AuthenticationActivity extends Activity {
                             + " Start url: " + mStartUrl
             );
         } else {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Non-broker request for package " + getCallingPackage()
-            );
-            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
-                    TAG + methodName,
-                    "Start url: " + mStartUrl
-            );
+            Logger.verbose(TAG + methodName, "Non-broker request for package " + getCallingPackage());
+            Logger.verbosePII(TAG + methodName, "Start url: " + mStartUrl);
         }
 
         mRegisterReceiver = false;
         final String postUrl = mStartUrl;
-        com.microsoft.identity.common.internal.logging.Logger.infoPII(
+        Logger.infoPII(
                 TAG + methodName,
                 "Device info:" + android.os.Build.VERSION.RELEASE
                         + " "
@@ -399,12 +375,9 @@ public class AuthenticationActivity extends Activity {
 
         // Also log correlation id
         if (mAuthRequest.getCorrelationId() == null) {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Null correlation id in the request."
-            );
+            Logger.verbose(TAG + methodName, "Null correlation id in the request.");
         } else {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+            Logger.verbose(
                     TAG + methodName,
                     "Correlation id for request sent is:"
                             + mAuthRequest.getCorrelationId().toString()
@@ -417,20 +390,14 @@ public class AuthenticationActivity extends Activity {
                 @Override
                 public void run() {
                     // load blank first to avoid error for not loading webview
-                    com.microsoft.identity.common.internal.logging.Logger.verbose(
-                            TAG + methodName,
-                            "Launching webview for acquiring auth code."
-                    );
+                    Logger.verbose(TAG + methodName, "Launching webview for acquiring auth code.");
                     mWebView.loadUrl("about:blank");
                     mWebView.loadUrl(postUrl);
                 }
 
             });
         } else {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Reuse webview"
-            );
+            Logger.verbose(TAG + methodName, "Reuse webview");
         }
     }
 
@@ -442,21 +409,15 @@ public class AuthenticationActivity extends Activity {
 
         if (!StringExtensions.isNullOrBlank(packageName)) {
             if (packageName.equals(AuthenticationSettings.INSTANCE.getBrokerPackageName())) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
-                        TAG + methodName,
-                        "Same package as broker."
-                );
+                Logger.verbose(TAG + methodName, "Same package as broker.");
 
                 return true;
             }
 
             final String signature = info.getCurrentSignatureForPackage(packageName);
 
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Checking broker signature."
-            );
-            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+            Logger.verbose(TAG + methodName, "Checking broker signature.");
+            Logger.verbosePII(
                     TAG + methodName,
                     "Check signature for " + packageName
                             + " signature:" + signature
@@ -518,7 +479,7 @@ public class AuthenticationActivity extends Activity {
         AuthenticationRequest authRequest = null;
 
         if (isBrokerRequest(callingIntent)) {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+            Logger.verbose(
                     TAG + methodName,
                     "It is a broker request. Get request info from bundle extras."
             );
@@ -547,7 +508,7 @@ public class AuthenticationActivity extends Activity {
                 try {
                     correlationIdParsed = UUID.fromString(correlationId);
                 } catch (final IllegalArgumentException ex) {
-                    com.microsoft.identity.common.internal.logging.Logger.error(
+                    Logger.error(
                             TAG + methodName,
                             "CorrelationId is malformed: " + correlationId,
                             ex
@@ -583,10 +544,7 @@ public class AuthenticationActivity extends Activity {
      */
     private void returnError(final ADALError errorCode, final String argument) {
         // Set result back to account manager call
-        com.microsoft.identity.common.internal.logging.Logger.warn(
-                TAG,
-                "Argument error:" + argument
-        );
+        Logger.warn(TAG, "Argument error:" + argument);
 
         final Intent resultIntent = new Intent();
         // TODO only send adalerror from activity side as int
@@ -616,11 +574,8 @@ public class AuthenticationActivity extends Activity {
                 // This encoding issue will happen at the beginning of API call,
                 // if it is not supported on this device. ADAL uses one encoding
                 // type.
-                com.microsoft.identity.common.internal.logging.Logger.error(
-                        TAG,
-                        "Unsupported encoding",
-                        e
-                );
+                Logger.error(TAG, "Unsupported encoding", e);
+                Logger.error(TAG, "Exception details", e);
             }
         }
         return loadUrl;
@@ -640,10 +595,7 @@ public class AuthenticationActivity extends Activity {
      */
     private void returnToCaller(final int resultCode, Intent data) {
         final String methodName = ":returnToCaller";
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG + methodName,
-                "Return To Caller:" + resultCode
-        );
+        Logger.verbose(TAG + methodName, "Return To Caller:" + resultCode);
 
         displaySpinner(false);
 
@@ -652,13 +604,10 @@ public class AuthenticationActivity extends Activity {
         }
 
         if (mAuthRequest == null) {
-            com.microsoft.identity.common.internal.logging.Logger.warn(
-                    TAG + methodName,
-                    "Request object is null"
-            );
+            Logger.warn(TAG + methodName, "Request object is null");
         } else {
             // set request id related to this response to send the delegateId
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+            Logger.verbose(
                     TAG + methodName,
                     "Set request id related to response. "
                             + "REQUEST_ID for caller returned to:"
@@ -675,10 +624,7 @@ public class AuthenticationActivity extends Activity {
     @Override
     protected void onPause() {
         final String methodName = ":onPause";
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG + methodName,
-                "AuthenticationActivity onPause unregister receiver"
-        );
+        Logger.verbose(TAG + methodName, "AuthenticationActivity onPause unregister receiver");
 
         super.onPause();
 
@@ -691,10 +637,7 @@ public class AuthenticationActivity extends Activity {
         mRegisterReceiver = true;
 
         if (mSpinner != null) {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Spinner at onPause will dismiss"
-            );
+            Logger.verbose(TAG + methodName, "Spinner at onPause will dismiss");
             mSpinner.dismiss();
         }
 
@@ -708,18 +651,12 @@ public class AuthenticationActivity extends Activity {
         // It can come here from onCreate, onRestart or onPause.
         // Don't load url again since it will send another 2FA request
         if (mRegisterReceiver) {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Webview onResume will register receiver."
-            );
+            Logger.verbose(TAG + methodName, "Webview onResume will register receiver.");
 
-            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
-                    TAG + methodName,
-                    "StartUrl: " + mStartUrl
-            );
+            Logger.verbosePII(TAG + methodName, "StartUrl: " + mStartUrl);
 
             if (mReceiver != null) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                Logger.verbose(
                         TAG + methodName,
                         "Webview onResume register broadcast receiver for request. "
                                 + "RequestId: "
@@ -753,20 +690,14 @@ public class AuthenticationActivity extends Activity {
 
     @Override
     protected void onRestart() {
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG,
-                "AuthenticationActivity onRestart"
-        );
+        Logger.verbose(TAG, "AuthenticationActivity onRestart");
         super.onRestart();
         mRegisterReceiver = true;
     }
 
     @Override
     public void onBackPressed() {
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG,
-                "Back button is pressed"
-        );
+        Logger.verbose(TAG, "Back button is pressed");
 
         // User should be able to click back button to cancel in case pkeyauth
         // happen.
@@ -781,10 +712,7 @@ public class AuthenticationActivity extends Activity {
     }
 
     private void cancelRequest() {
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG,
-                "Sending intent to cancel authentication activity"
-        );
+        Logger.verbose(TAG, "Sending intent to cancel authentication activity");
         final Intent resultIntent = new Intent();
 
         if (mUIEvent != null) {
@@ -796,7 +724,7 @@ public class AuthenticationActivity extends Activity {
 
     private void prepareForBrokerResume() {
         final String methodName = ":prepareForBrokerResume";
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
+        Logger.verbose(
                 TAG + methodName,
                 "Return to caller with BROKER_REQUEST_RESUME, and waiting for result."
         );
@@ -838,10 +766,7 @@ public class AuthenticationActivity extends Activity {
             if (!isBrokerRequest(getIntent())) {
                 // It is pointing to redirect. Final url can be processed to
                 // get the code or error.
-                com.microsoft.identity.common.internal.logging.Logger.info(
-                        TAG + methodName,
-                        "It is not a broker request"
-                );
+                Logger.info(TAG + methodName, "It is not a broker request");
 
                 final Intent resultIntent = new Intent();
                 resultIntent.putExtra(RESPONSE_FINAL_URL, url);
@@ -850,10 +775,7 @@ public class AuthenticationActivity extends Activity {
 
                 view.stopLoading();
             } else {
-                com.microsoft.identity.common.internal.logging.Logger.info(
-                        TAG + methodName,
-                        "It is a broker request"
-                );
+                Logger.info(TAG + methodName, "It is a broker request");
 
                 displaySpinnerWithMessage(
                         AuthenticationActivity.this.getText(
@@ -879,12 +801,12 @@ public class AuthenticationActivity extends Activity {
             final String methodName = ":processInvalidUrl";
 
             if (isBrokerRequest(getIntent()) && url.startsWith(REDIRECT_PREFIX)) {
-                com.microsoft.identity.common.internal.logging.Logger.error(
+                Logger.error(
                         TAG + methodName,
                         "The RedirectUri is not as expected.",
                         null
                 );
-                com.microsoft.identity.common.internal.logging.Logger.errorPII(
+                Logger.errorPII(
                         TAG + methodName,
                         String.format("Received %s and expected %s", url, mRedirectUrl),
                         null
@@ -903,26 +825,16 @@ public class AuthenticationActivity extends Activity {
             }
 
             if (url.toLowerCase(Locale.US).equals("about:blank")) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
-                        TAG + methodName,
-                        "It is an blank page request"
-                );
+                Logger.verbose(TAG + methodName, "It is an blank page request");
 
                 return true;
             }
 
             if (!url.toLowerCase(Locale.US).startsWith(REDIRECT_SSL_PREFIX)) {
                 final String errMsg = "The webview was redirected to an unsafe URL.";
-                com.microsoft.identity.common.internal.logging.Logger.error(
-                        TAG + methodName,
-                        errMsg,
-                        null
-                );
+                Logger.error(TAG + methodName, errMsg, null);
 
-                returnError(
-                        ADALError.WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED,
-                        errMsg
-                );
+                returnError(ADALError.WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED, errMsg);
 
                 view.stopLoading();
 
@@ -966,19 +878,16 @@ public class AuthenticationActivity extends Activity {
         public void onReceivedClientCertRequest(final WebView view,
                                                 final ClientCertRequest request) {
             final String methodName = ":onReceivedClientCertRequest";
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Webview receives client TLS request."
-            );
+            Logger.verbose(TAG + methodName, "Webview receives client TLS request.");
 
             final Principal[] acceptableCertIssuers = request.getPrincipals();
 
             // When ADFS server sends null or empty issuers, we'll continue with cert prompt.
             if (acceptableCertIssuers != null) {
-                for (Principal issuer : acceptableCertIssuers) {
+                for (final Principal issuer : acceptableCertIssuers) {
                     if (issuer.getName().contains("CN=MS-Organization-Access")) {
                         //Checking if received acceptable issuers contain "CN=MS-Organization-Access"
-                        com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        Logger.verbose(
                                 TAG + methodName,
                                 "Cancelling the TLS request, not respond to TLS challenge triggered by device authentication."
                         );
@@ -995,7 +904,7 @@ public class AuthenticationActivity extends Activity {
                         @Override
                         public void alias(final String alias) {
                             if (alias == null) {
-                                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                                Logger.verbose(
                                         TAG + methodName,
                                         "No certificate chosen by user, cancelling the TLS request."
                                 );
@@ -1007,29 +916,17 @@ public class AuthenticationActivity extends Activity {
                                 final X509Certificate[] certChain = KeyChain.getCertificateChain(getApplicationContext(), alias);
                                 final PrivateKey privateKey = KeyChain.getPrivateKey(getCallingContext(), alias);
 
-                                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                                Logger.verbose(
                                         TAG + methodName,
                                         "Certificate is chosen by user, proceed with TLS request."
                                 );
                                 request.proceed(privateKey, certChain);
                                 return;
                             } catch (final KeyChainException e) {
-                                com.microsoft.identity.common.internal.logging.Logger.error(
-                                        TAG + methodName,
-                                        "Keychain exception",
-                                        null
-                                );
-                                com.microsoft.identity.common.internal.logging.Logger.errorPII(
-                                        TAG + methodName,
-                                        "Exception details:",
-                                        e
-                                );
+                                Logger.error(TAG + methodName, "Keychain exception", null);
+                                Logger.errorPII(TAG + methodName, "Exception details:", e);
                             } catch (final InterruptedException e) {
-                                com.microsoft.identity.common.internal.logging.Logger.error(
-                                        TAG + methodName,
-                                        "InterruptedException exception",
-                                        e
-                                );
+                                Logger.error(TAG + methodName, "InterruptedException exception", e);
                             }
 
                             request.cancel();
@@ -1055,7 +952,7 @@ public class AuthenticationActivity extends Activity {
         if (!AuthenticationActivity.this.isFinishing()
                 && !AuthenticationActivity.this.isChangingConfigurations() && mSpinner != null) {
             // Used externally to verify web view processing.
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+            Logger.verbose(
                     TAG + methodName,
                     "DisplaySpinner:" + show
                             + " showing:" + mSpinner.isShowing()
@@ -1094,10 +991,7 @@ public class AuthenticationActivity extends Activity {
         // Added here to make Authenticator work with one common code base
         if (isBrokerRequest(getIntent()) && mAccountAuthenticatorResponse != null) {
             // send the result bundle back if set, otherwise send an error.
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG,
-                    "It is a broker request"
-            );
+            Logger.verbose(TAG, "It is a broker request");
 
             if (mAuthenticatorResultBundle == null) {
                 mAccountAuthenticatorResponse.onError(
@@ -1163,28 +1057,20 @@ public class AuthenticationActivity extends Activity {
 
             try {
                 result.mTaskResult = oauthRequest.getToken(urlItems[0]);
-                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                Logger.verbosePII(
                         TAG,
                         "Process result returned from TokenTask. "
                                 + mRequest.getLogInfo()
                 );
             } catch (final IOException | AuthenticationException exc) {
-                com.microsoft.identity.common.internal.logging.Logger.error(
-                        TAG,
-                        "Error in processing code to get a token.",
-                        exc
-                );
-                com.microsoft.identity.common.internal.logging.Logger.errorPII(
-                        TAG,
-                        mRequest.getLogInfo(),
-                        null
-                );
+                Logger.error(TAG, "Error in processing code to get a token.", exc);
+                Logger.errorPII(TAG, mRequest.getLogInfo(), null);
 
                 result.mTaskException = exc;
             }
 
             if (result.mTaskResult != null && result.mTaskResult.getAccessToken() != null) {
-                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                Logger.verbosePII(
                         TAG,
                         "Token task successfully returns access token. "
                                 + mRequest.getLogInfo()
@@ -1194,16 +1080,8 @@ public class AuthenticationActivity extends Activity {
                 try {
                     setAccount(result);
                 } catch (final GeneralSecurityException | IOException exc) {
-                    com.microsoft.identity.common.internal.logging.Logger.error(
-                            TAG,
-                            "Error in setting the account.",
-                            null
-                    );
-                    com.microsoft.identity.common.internal.logging.Logger.errorPII(
-                            TAG,
-                            mRequest.getLogInfo(),
-                            exc
-                    );
+                    Logger.error(TAG, "Error in setting the account.", null);
+                    Logger.errorPII(TAG, mRequest.getLogInfo(), exc);
 
                     result.mTaskException = exc;
                 }
@@ -1222,12 +1100,9 @@ public class AuthenticationActivity extends Activity {
                             + cacheKey
             );
 
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG,
-                    "Get broker app cache key."
-            );
+            Logger.verbose(TAG, "Get broker app cache key.");
 
-            com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+            Logger.verbosePII(
                     TAG,
                     "Key hash is:" + digestKey
                             + " calling app UID:" + mAppCallingUID
@@ -1250,46 +1125,26 @@ public class AuthenticationActivity extends Activity {
                 try {
                     appIdList = mStorageHelper.decrypt(appIdList);
                 } catch (final GeneralSecurityException | IOException ex) {
-                    com.microsoft.identity.common.internal.logging.Logger.error(
-                            TAG + methodName,
-                            "appUIDList failed to decrypt",
-                            null
-                    );
+                    Logger.error(TAG + methodName, "appUIDList failed to decrypt", null);
 
-                    com.microsoft.identity.common.internal.logging.Logger.errorPII(
-                            TAG + methodName,
-                            "appIdList:" + appIdList,
-                            ex
-                    );
+                    Logger.errorPII(TAG + methodName, "appIdList:" + appIdList, ex);
 
                     appIdList = "";
-                    com.microsoft.identity.common.internal.logging.Logger.info(
-                            TAG + methodName,
-                            "Reset the appUIDlist"
-                    );
+                    Logger.info(TAG + methodName, "Reset the appUIDlist");
                 }
             }
 
-            com.microsoft.identity.common.internal.logging.Logger.info(
-                    TAG + methodName,
-                    "Add calling UID."
-            );
+            Logger.info(TAG + methodName, "Add calling UID.");
 
-            com.microsoft.identity.common.internal.logging.Logger.infoPII(
+            Logger.infoPII(
                     TAG + methodName,
                     "App UID: " + mAppCallingUID
                             + "appIdList:" + appIdList
             );
 
             if (!appIdList.contains(USERDATA_UID_KEY + mAppCallingUID)) {
-                com.microsoft.identity.common.internal.logging.Logger.info(
-                        TAG + methodName,
-                        "Account has new calling UID."
-                );
-                com.microsoft.identity.common.internal.logging.Logger.infoPII(
-                        TAG + methodName,
-                        "App UID: " + mAppCallingUID
-                );
+                Logger.info(TAG + methodName, "Account has new calling UID.");
+                Logger.infoPII(TAG + methodName, "App UID: " + mAppCallingUID);
 
                 final String encryptedValue = mStorageHelper.encrypt(
                         appIdList
@@ -1328,18 +1183,12 @@ public class AuthenticationActivity extends Activity {
             if (userinfo == null || StringExtensions.isNullOrBlank(userinfo.getUserId())) {
                 // return userid in the userinfo and use only account name
                 // for all fields
-                com.microsoft.identity.common.internal.logging.Logger.info(
-                        TAG + methodName,
-                        "Set userinfo from account"
-                );
+                Logger.info(TAG + methodName, "Set userinfo from account");
 
                 result.mTaskResult.setUserInfo(new UserInfo(name, name, "", "", name));
                 mRequest.setLoginHint(name);
             } else {
-                com.microsoft.identity.common.internal.logging.Logger.info(
-                        TAG + methodName,
-                        "Saving userinfo to account"
-                );
+                Logger.info(TAG + methodName, "Saving userinfo to account");
                 mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_USERID, userinfo.getUserId());
                 mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_GIVEN_NAME, userinfo.getGivenName());
                 mAccountManager.setUserData(newAccount, ACCOUNT_USERINFO_FAMILY_NAME, userinfo.getFamilyName());
@@ -1349,12 +1198,9 @@ public class AuthenticationActivity extends Activity {
 
             result.mAccountName = name;
 
-            com.microsoft.identity.common.internal.logging.Logger.info(
-                    TAG + methodName,
-                    "Setting account in account manager."
-            );
+            Logger.info(TAG + methodName, "Setting account in account manager.");
 
-            com.microsoft.identity.common.internal.logging.Logger.infoPII(
+            Logger.infoPII(
                     TAG + methodName,
                     "Package: " + mPackageName
                             + " calling app UID:" + mAppCallingUID
@@ -1368,7 +1214,7 @@ public class AuthenticationActivity extends Activity {
             // access.
             final Gson gson = new Gson();
 
-            com.microsoft.identity.common.internal.logging.Logger.infoPII(
+            Logger.infoPII(
                     TAG + methodName,
                     "app context:" + getApplicationContext().getPackageName()
                             + " context:" + AuthenticationActivity.this.getPackageName()
@@ -1376,10 +1222,7 @@ public class AuthenticationActivity extends Activity {
             );
 
             if (AuthenticationSettings.INSTANCE.getSecretKeyData() == null) {
-                com.microsoft.identity.common.internal.logging.Logger.info(
-                        TAG + methodName,
-                        "Calling app doesn't provide the secret key."
-                );
+                Logger.info(TAG + methodName, "Calling app doesn't provide the secret key.");
             }
 
             final TokenCacheItem item = TokenCacheItem.createRegularTokenCacheItem(
@@ -1427,10 +1270,7 @@ public class AuthenticationActivity extends Activity {
             // Record calling UID for this account so that app can get token
             // in the background call without requiring server side
             // validation
-            com.microsoft.identity.common.internal.logging.Logger.info(
-                    TAG + methodName,
-                    "Set calling uid:" + mAppCallingUID
-            );
+            Logger.info(TAG + methodName, "Set calling uid:" + mAppCallingUID);
 
             appendAppUIDToAccount(newAccount);
         }
@@ -1441,10 +1281,7 @@ public class AuthenticationActivity extends Activity {
                                   final int callingUID) {
             final String methodName = ":saveCacheKey";
 
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Get CacheKeys for account"
-            );
+            Logger.verbose(TAG + methodName, "Get CacheKeys for account");
 
             // Store cachekeys for each UID
             // Activity has access to packagename and UID, but background call
@@ -1456,12 +1293,12 @@ public class AuthenticationActivity extends Activity {
             }
 
             if (!keylist.contains(CALLER_CACHEKEY_PREFIX + key)) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
+                Logger.verbose(
                         TAG + methodName,
                         "Account does not have the cache key. Saving it to account for the caller."
                 );
 
-                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
+                Logger.verbosePII(
                         TAG + methodName,
                         "callerUID: " + callingUID
                                 + "The key to be saved is: " + key
@@ -1470,36 +1307,20 @@ public class AuthenticationActivity extends Activity {
                 keylist += CALLER_CACHEKEY_PREFIX + key;
                 mAccountManager.setUserData(cacheAccount, USERDATA_CALLER_CACHEKEYS + callingUID, keylist);
 
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
-                        TAG + methodName,
-                        "Cache key saved into key list for the caller."
-                );
-                com.microsoft.identity.common.internal.logging.Logger.verbosePII(
-                        TAG + methodName,
-                        "keylist:" + keylist
-                );
+                Logger.verbose(TAG + methodName, "Cache key saved into key list for the caller.");
+                Logger.verbosePII(TAG + methodName, "keylist:" + keylist);
             }
         }
 
         @Override
         protected void onPostExecute(final TokenTaskResult result) {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG,
-                    "Token task returns the result"
-            );
+            Logger.verbose(TAG, "Token task returns the result");
             displaySpinner(false);
             Intent intent = new Intent();
 
             if (result.mTaskResult == null) {
-                com.microsoft.identity.common.internal.logging.Logger.verbose(
-                        TAG,
-                        "Token task has exception"
-                );
-
-                returnError(
-                        ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN,
-                        result.mTaskException.getMessage()
-                );
+                Logger.verbose(TAG, "Token task has exception");
+                returnError(ADALError.AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN, result.mTaskException.getMessage());
 
                 return;
             }


### PR DESCRIPTION
Moves logging to new `Logger`, cleans up a lot of formatting issues that were a readability nightmare, fixes a potential NPE.