### PR TITLE
renamed AppTheme to AzureTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You can get the jar file from maven the repo and drop into the *libs* folder in 
     android:debuggable="true"
     android:icon="@drawable/ic_launcher"
     android:label="@string/app_name"
-    android:theme="@style/AppTheme" >
+    android:theme="@style/AzureTheme" >
 
     <activity
         android:name="com.microsoft.aad.adal.AuthenticationActivity"

--- a/adal/src/main/res/values-v11/styles.xml
+++ b/adal/src/main/res/values-v11/styles.xml
@@ -2,9 +2,9 @@
 
     <!--
         Base application theme for API 11+. This theme completely replaces
-        AppBaseTheme from res/values/styles.xml on API 11+ devices.
+        AzureBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AzureBaseTheme" parent="android:Theme.Holo.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/adal/src/main/res/values-v14/styles.xml
+++ b/adal/src/main/res/values-v14/styles.xml
@@ -2,10 +2,10 @@
 
     <!--
         Base application theme for API 14+. This theme completely replaces
-        AppBaseTheme from BOTH res/values/styles.xml and
+        AzureBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AzureBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/adal/src/main/res/values/styles.xml
+++ b/adal/src/main/res/values/styles.xml
@@ -2,9 +2,9 @@
 
     <!--
         Base application theme, dependent on API level. This theme is replaced
-        by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
+        by AzureBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Light">
+    <style name="AzureBaseTheme" parent="android:Theme.Light">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to
@@ -13,7 +13,7 @@
     </style>
 
     <!-- Application theme. -->
-    <style name="AppTheme" parent="AppBaseTheme">
+    <style name="AzureTheme" parent="AzureBaseTheme">
         <!-- All customizations that are NOT specific to a particular API-level can go here. -->
     </style>
 

--- a/userappwithbroker/src/main/AndroidManifest.xml
+++ b/userappwithbroker/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AzureTheme" >
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name" >

--- a/userappwithbroker/src/main/res/layout/app_bar_main.xml
+++ b/userappwithbroker/src/main/res/layout/app_bar_main.xml
@@ -35,14 +35,14 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:theme="@style/AzureTheme.AppBarOverlay">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            app:popupTheme="@style/AzureTheme.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/userappwithbroker/src/main/res/values-v11/styles.xml
+++ b/userappwithbroker/src/main/res/values-v11/styles.xml
@@ -2,9 +2,9 @@
 
     <!--
         Base application theme for API 11+. This theme completely replaces
-        AppBaseTheme from res/values/styles.xml on API 11+ devices.
+        AzureBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AzureBaseTheme" parent="android:Theme.Holo.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/userappwithbroker/src/main/res/values-v14/styles.xml
+++ b/userappwithbroker/src/main/res/values-v14/styles.xml
@@ -2,10 +2,10 @@
 
     <!--
         Base application theme for API 14+. This theme completely replaces
-        AppBaseTheme from BOTH res/values/styles.xml and
+        AzureBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AzureBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/userappwithbroker/src/main/res/values/styles.xml
+++ b/userappwithbroker/src/main/res/values/styles.xml
@@ -25,20 +25,20 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AzureTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="AppTheme.NoActionBar">
+    <style name="AzureTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="AzureTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="AzureTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 </resources>


### PR DESCRIPTION
Issue: https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/440

Description of issue:
When users uptake this library, their application `AppTheme` will be overwritten by the one defined at a higher level (in the Azure lib). This allows users to uptake without renaming their theme.

Changes:
* renamed `AppTheme` to `AzureTheme`
* renamed `AppBaseTheme` to `AzureBaseTheme`