### PR TITLE
Catch/log error if makeKey throws

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -29,12 +29,12 @@ import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.cache.ADALOAuth2TokenCache;
-import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
 import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
@@ -47,10 +47,8 @@ import com.microsoft.identity.common.internal.providers.microsoft.azureactivedir
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import static com.microsoft.aad.adal.TokenEntryType.FRT_TOKEN_ENTRY;
 import static com.microsoft.aad.adal.TokenEntryType.MRRT_TOKEN_ENTRY;
@@ -306,7 +304,7 @@ class TokenCacheAccessor {
     /**
      * Update token cache with returned auth result.
      */
-    void updateTokenCache(final AuthenticationRequest request,  final AuthenticationResult result) throws MalformedURLException {
+    void updateTokenCache(final AuthenticationRequest request, final AuthenticationResult result) throws MalformedURLException {
         if (result == null || StringExtensions.isNullOrBlank(result.getAccessToken())) {
             return;
         }
@@ -607,11 +605,22 @@ class TokenCacheAccessor {
                                                  final String clientId,
                                                  final String userId,
                                                  final KeyMakerStrategy strategy) {
-        final String keyToAdd = strategy.makeKey(authority, clientId, userId);
-        if (strategy.isFrt()) {
-            addDeletionKeyForFRTIfRTValueIsStale(keysToRemove, deletionTarget, keyToAdd);
-        } else {
-            keysToRemove.add(keyToAdd);
+        try {
+            final String keyToAdd = strategy.makeKey(authority, clientId, userId);
+            if (strategy.isFrt()) {
+                addDeletionKeyForFRTIfRTValueIsStale(keysToRemove, deletionTarget, keyToAdd);
+            } else {
+                keysToRemove.add(keyToAdd);
+            }
+        } catch (final Exception e) {
+            Logger.w(
+                    TAG,
+                    "Exception encountered during key generation."
+                            + "\n"
+                            + "CacheItem client_id: " + deletionTarget.getClientId()
+                            + "\n"
+                            + "CacheItem family_id: " + deletionTarget.getFamilyClientId()
+            );
         }
     }
 


### PR DESCRIPTION
Issue originally reported by Kaizala -- this change logs a warning rather than crashes.

Cause of this error state is unclear:
```
com.microsoft.aad.adal.CacheKey.createCacheKey CacheKey.java:93
com.microsoft.aad.adal.CacheKey.createCacheKeyForFRT CacheKey.java:198
com.microsoft.aad.adal.TokenCacheAccessor$1.makeKey TokenCacheAccessor.java:522
com.microsoft.aad.adal.TokenCacheAccessor.addDeletionKeyForMRRTOrFRTEntry TokenCacheAccessor.java:610
com.microsoft.aad.adal.TokenCacheAccessor.addDeletionKeysForMRRTOrFRTEntry TokenCacheAccessor.java:600
com.microsoft.aad.adal.TokenCacheAccessor.getKeyListToRemoveForMRRTOrFRT TokenCacheAccessor.java:531
com.microsoft.aad.adal.TokenCacheAccessor.removeTokenCacheItem TokenCacheAccessor.java:403
com.microsoft.aad.adal.AcquireTokenRequest.removeTokensForUser AcquireTokenRequest.java:542
com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilentWithBroker AcquireTokenRequest.java:509
com.microsoft.aad.adal.AcquireTokenRequest.acquireTokenSilentFlow AcquireTokenRequest.java:476
com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilent AcquireTokenRequest.java:373
com.microsoft.aad.adal.AcquireTokenRequest.performAcquireTokenRequest AcquireTokenRequest.java:352
com.microsoft.aad.adal.AcquireTokenRequest.access$200 AcquireTokenRequest.java:55
com.microsoft.aad.adal.AcquireTokenRequest$1.run AcquireTokenRequest.java:129
java.util.concurrent.ThreadPoolExecutor.runWorker ThreadPoolExecutor.java:1162
java.util.concurrent.ThreadPoolExecutor$Worker.run ThreadPoolExecutor.java:636
java.lang.Thread.run Thread.java:764
```