### PR TITLE
Fix test app, pass authority in silent response

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -547,6 +547,7 @@ class BrokerProxy implements IBrokerProxy {
 
             // set the x-ms-clitelem data
             result.setCliTelemInfo(cliTelemInfo);
+            result.setAuthority(bundleResult.getString(AuthenticationConstants.Broker.ACCOUNT_AUTHORITY));
 
             return result;
         }

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -304,15 +304,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             if (null != authResult.getAuthority()) {
                 final SharedPreferences.Editor prefEditor = mSharedPreference.edit();
                 if (null != authResult.getUserInfo() && null != authResult.getUserInfo().getDisplayableId()) {
-                    if (null != authResult.getUserInfo() && null != authResult.getUserInfo().getIdentityProvider()) {
-                        prefEditor.putString(
-                                (authResult.getUserInfo().getDisplayableId().trim() + ":" + authority.trim() +  ":authority").toLowerCase(),
-                                authResult.getUserInfo().getIdentityProvider().trim().toLowerCase());
-                    } else {
-                       prefEditor.putString(
-                               (authResult.getUserInfo().getDisplayableId().trim() + ":" + authority.trim() +  ":authority").toLowerCase(),
-                               authResult.getAuthority().trim().toLowerCase());
-                    }
+                    prefEditor.putString(
+                            (authResult.getUserInfo().getDisplayableId().trim() + ":" + authority.trim() +  ":authority").toLowerCase(),
+                            authResult.getAuthority().trim().toLowerCase());
                 }  else {
                     final Toast toast = Toast.makeText(mApplicationContext,
                             "Warning: the result authority is null," +


### PR DESCRIPTION
- In test app, we should always be saving the authority, not idp.
- Silent call should return authority.