### PR TITLE
Added debug broker redirect uri; set default client id; authority alw…

### DIFF
--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
@@ -62,11 +62,11 @@ public class Constants {
 
 
     enum ClientId {
+        ADFSV4("4b0db8c2-9f26-4417-8bde-3f0e3656f8e0"),
         ONEDRIVE("af124e86-4e96-495a-b70a-90f90ab96707"),
         OFFICE("d3590ed6-52b3-4102-aeff-aad2292ab01c"),
         APPCHECK2_BF("f5d01c1c-abe6-4207-ae2d-5bc9af251724"),
         GUESTCLIENT("ea5c8087-2476-489c-ae03-ad44a2ac399d"),
-        ADFSV4("4b0db8c2-9f26-4417-8bde-3f0e3656f8e0"),
         ADFSV3("68a10fc3-ead9-41b8-ac5e-5b78af044736"),
         ADFSV2("e3fbd64e-3bdc-4fe9-b531-31660912b944"),
         PING("6b748729-d940-4482-8724-5eb87a817a10"),
@@ -85,7 +85,8 @@ public class Constants {
         Regular(BuildConfig.REGULAR_REDIDRECT_URI),
         Regular2("msauth://com.microsoft.aad.adal.userappwithbroker/L8kGVGYgNOaxbhn9Y7vR%2F6LIEG8%3D"),
         Broker("urn:ietf:wg:oauth:2.0:oob"),
-        LABS("msauth://com.microsoft.aad.adal.userappwithbroker/2%2BQqCWt1ilKg0IrfKT6CkdMpPqk%3D");
+        LABS("msauth://com.microsoft.aad.adal.userappwithbroker/2%2BQqCWt1ilKg0IrfKT6CkdMpPqk%3D"),
+        LABSDEBUG("msauth://com.microsoft.aad.adal.userappwithbroker/1wIqXSqBj7w%2bh11ZifsnqwgyKrY%3d");
 
         private final String text;
         RedirectUri(String s) {

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -177,16 +177,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     void prepareRequestParameters(final AcquireTokenFragment.RequestOptions requestOptions) {
         mRequestAuthority = requestOptions.getAuthorityType().getText();
-        final String authority = getAuthorityBasedOnUPN(requestOptions.getLoginHint(), mRequestAuthority);
-        if (null != authority && !authority.isEmpty()) {
-            //Replace the request authority with the preferred authority stored in shared preference
-            mAuthority = authority;
-            mAuthContext = new AuthenticationContext(mApplicationContext, mAuthority, false);
-        } else {
-            //If there is no preferred authority stored, use the type-in authority
-            mAuthority = mRequestAuthority;
-            mAuthContext = new AuthenticationContext(mApplicationContext, mAuthority, true);
-        }
+        mAuthority = mRequestAuthority;
+        mAuthContext = new AuthenticationContext(mApplicationContext, mAuthority, true);
 
         //TODO: We can add UX to set or not set this
         mAuthContext.setClientCapabilites(new ArrayList<>(Arrays.asList("CP1")));


### PR DESCRIPTION
- Made adfsv4 the default client id
- Commented out code for determining authority based on the looked up user from shared preferences. Code now always uses the specified authority (UI drop down)
- Added LABSDEBUG redirect URI which matches the signature from the debug.keystore included with android-complete
