### PR TITLE
Remove the request from the DELEGATE_MAP once we're done processing it

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -31,8 +31,9 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import androidx.annotation.Nullable;
 import android.util.Log;
+
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
@@ -724,6 +725,7 @@ class AcquireTokenRequest {
                 final AuthenticationRequestState waitingRequest;
                 try {
                     waitingRequest = mAuthContext.getWaitingRequest(requestId);
+                    mAuthContext.removeWaitingRequest(requestId); // We have the request, we can now remove it.
                     Logger.v(TAG + methodName, "Waiting request found. " + "RequestId:" + requestId);
                 } catch (final AuthenticationException authenticationException) {
                     Logger.e(TAG + methodName,


### PR DESCRIPTION
Mostly resolves #1363

ADAL has a memory leak that occurs when the request is _successful_. If the request fails,  `AcquireTokenRequest#waitingRequestOnError` is called to clean up the `DELEGATE_MAP` -- oddly, if the request does _not_ fail, the `waitingRequest` is not cleaned up.

This isn't a _perfect solution_ because it ultimately still allows for `Context` objects to be assigned to a `static` value, even if only temporarily.

This change avoids a larger refactor of the `AuthenticationContext` object