### PR TITLE
Send ADAL version to token endpoint

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -652,6 +652,7 @@ class Oauth2 {
 
         try {
             mWebRequestHandler.setRequestCorrelationId(mRequest.getCorrelationId());
+            mWebRequestHandler.setClientVersion(AuthenticationContext.getVersionName());
             ClientMetrics.INSTANCE.beginClientMetricsRecord(authority, mRequest.getCorrelationId(),
                     headers);
             HttpWebResponse response = mWebRequestHandler.sendPost(authority, headers,


### PR DESCRIPTION
We're not sending ADAL version to the token endpoint. 

This is breaking the token endpoint's pkeyauth flow. They got a logic where they perform checks based on ADAL version. When the version is not provided, they do not know what to do and ended up sending us an empty request (instead of a PKeyAuth challenge).

This changes sets the value of ""x-client-Ver" in the header field of token endpoint requests. 