### PR TITLE
Release Prep: 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ ADAL for Android gives you the ability to add support for Work Accounts to your 
 
 A Work Account is an identity you use to get work done from your organization or school. Anywhere you need to get access to your work life you'll use a Work Account. The Work Account can be tied to an Active Directory server running in your datacenter or live completely in the cloud like when you use Office 365. A Work Account will be how your users know that they are accessing their important documents and data backed my Microsoft security.
 
-## ADAL for Android 2.0.0 Released!
->Please note: ADAL 2.0.0 (released March 2020) is neither API-compatible nor cache-compatible the following versions:<br/>
+## ADAL for Android 2.0.1 Released!
+>Please note: Production ADAL 2.0.x releases (first released March 2020) are neither API-compatible nor cache-compatible with the following versions:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;- 2.0-alpha   (released 2015-07-27)<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;- 2.0.1-alpha (released 2015-09-25)<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;- 2.0.2-alpha (released 2016-05-27)<br/>
@@ -38,7 +38,7 @@ Note: A corpnet account is required to view the VSTS build.
 
 ## Versions
 
-Current version - 2.0.0
+Current version - 2.0.1
 
 Minimum recommended version - 1.15.1-hf1
 
@@ -132,7 +132,7 @@ repositories {
 }
 dependencies {
     // your dependencies here...
-    compile('com.microsoft.aad:adal:2.0.0') {
+    compile('com.microsoft.aad:adal:2.0.1') {
         // if your app includes android support
         // libraries or Gson in its dependencies
         // exclude that groupId from ADAL's compile
@@ -153,7 +153,7 @@ If you are using the m2e plugin in Eclipse, you can specify the dependency in yo
 <dependency>
     <groupId>com.microsoft.aad</groupId>
     <artifactId>adal</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <type>aar</type>
 </dependency>
 ```

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -138,10 +138,10 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '2.0.2', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '2.0.3-RC1', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:2.0.2") {
+    distApi("com.microsoft.identity:common:2.0.3-RC1") {
         transitive = false
     }
 

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.0.0
+versionName=2.0.1-RC1
 versionCode=1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+Version 2.0.1
+-------------
+- Uses common version: 2.0.3
+- Bugfix: Resolved ADAL/1513
+    * Fixed an issue whereby the ADAL version was not sent to the /token endpoint, blocking MS-PKAP handshakes
+- Bugfix: Resolved ADAL/1363
+    * Resolves a common memory leak resulting from successful auth requests
+
 Version 2.0.0
 -------------
 - Please note: ADAL 2.0.0 (released March 2020) is neither API-compatible nor cache-compatible with the following versions:


### PR DESCRIPTION
In this PR:
- ~Update submodule pointer to use `common@2.0.3`~ (9862e1805e63b5ad169597f1fae2d05bfcc7a072)
- ~Update version codes~ (f9631d6474c1317bcfcd55d22eaa2ba824162d0f)
- ~Update README~ (b94b2373760164f1020d88f24fb733de5505797f)
- ~Update changelog~ (bf64e2b60bd5cf2cf429d918db6645a0f5b58b41)
- ~Update gradle deps~ (57a0bf12bd33c4be81d7527010a40ef424fbef4f)