### PR TITLE
Return ADALError.MDM_REQUIRED after the user interacts with MDM link

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/ADALError.java
@@ -29,8 +29,6 @@ import android.content.res.Resources;
 
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ErrorStrings;
-import com.microsoft.identity.common.exception.ClientException;
-import com.microsoft.identity.common.exception.ServiceException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -650,7 +648,12 @@ public enum ADALError {
     /**
      * Common core to ADAL mapping failed
      */
-    MAPPING_FAILURE("Common core returned an exception code that ADAL cannot parse");
+    MAPPING_FAILURE("Common core returned an exception code that ADAL cannot parse"),
+
+    /**
+     * Device is required to be managed.
+     */
+    MDM_REQUIRED("Device needs to be managed to access the resource");
 
     private String mDescription;
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -916,7 +916,12 @@ public class AuthenticationActivity extends DualScreenActivity {
                             + " showing:" + (mSpinner.getVisibility() == View.VISIBLE)
             );
 
-            mSpinner.setVisibility(show ? View.VISIBLE : View.INVISIBLE);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    mSpinner.setVisibility(show ? View.VISIBLE : View.INVISIBLE);
+                }
+            });
         }
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -38,12 +38,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.aad.adal.ChallengeResponseBuilder.ChallengeResponse;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.JWSBuilder;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.logging.Logger;
 
 import java.util.HashMap;
 import java.util.Locale;
+
 import java.util.Map;
 
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.BROWSER_EXT_INSTALL_PREFIX;
@@ -57,8 +59,6 @@ import static com.microsoft.aad.adal.AuthenticationConstants.Browser.RESPONSE_RE
 import static com.microsoft.aad.adal.AuthenticationConstants.OAuth2.CODE;
 import static com.microsoft.aad.adal.AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION;
 import static com.microsoft.aad.adal.AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.UIResponse.BROWSER_CODE_MDM;
 
 abstract class BasicWebViewClient extends WebViewClient {
 
@@ -422,10 +422,10 @@ abstract class BasicWebViewClient extends WebViewClient {
 
             view.stopLoading();
 
-            if (url.contains(BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER)) {
+            if (url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER)) {
                 Logger.warn(TAG + methodName, "Failed to launch Company Portal, falling back to browser.");
-                openLinkInBrowser(url.replace(BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, ""));
-                sendResponse(BROWSER_CODE_MDM, new Intent());
+                openLinkInBrowser(url.replace(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, ""));
+                sendResponse(AuthenticationConstants.UIResponse.BROWSER_CODE_MDM, new Intent());
             } else {
                 openLinkInBrowser(url);
                 cancelWebViewRequest(null);

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -424,7 +424,7 @@ abstract class BasicWebViewClient extends WebViewClient {
 
             if (url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER)) {
                 Logger.warn(TAG + methodName, "Failed to launch Company Portal, falling back to browser.");
-                openLinkInBrowser(url.replace(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, ""));
+                openLinkInBrowser(url);
                 sendResponse(AuthenticationConstants.UIResponse.BROWSER_CODE_MDM, new Intent());
             } else {
                 openLinkInBrowser(url);


### PR DESCRIPTION
Server will attach a query string (ismdmurl=1) along with the browser link to tell us that this link belongs to Intune (MDM) flow.

WebView will detect that query string and return AuthenticationConstants.UIResponse.BROWSER_CODE_MDM (instead of BROWSER_CODE_CANCEL)