### PR TITLE
Add SAML assertion

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -1869,7 +1869,7 @@ public final class AuthenticationContextTest {
         // Call acquire token silent using assertion which will try to fetch refresh token
         AuthenticationResult result = context.acquireTokenSilentSyncWithAssertion("sample assertion",
                 AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE, "resource",
-                "clientId", TEST_IDTOKEN_USERID, false, null);
+                "clientId", TEST_IDTOKEN_USERID);
 
         // Check if the access token is present in the result and if its stored in the cache
         assertEquals("Token is same as passed in response", "TokenForSamlAssertionTest", result.getAccessToken());

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -1830,6 +1830,56 @@ public final class AuthenticationContextTest {
         clearCache(context);
     }
 
+    /**
+     * Test acquire token silent sync using assertion call.
+     *
+     * @throws IOException
+     * @throws InterruptedException
+     * @throws AuthenticationException
+     */
+    @Test
+    public void testAcquireTokenSilentSyncWithAssertionPositive() throws IOException, AuthenticationException,
+            InterruptedException {
+
+        final FileMockContext mockContext = new FileMockContext(androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getContext());
+        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getContext());
+        final AuthenticationContext context = getAuthenticationContext(mockContext, VALID_AUTHORITY, false, mockCache);
+
+        final MockActivity testActivity = new MockActivity();
+        final CountDownLatch signal = new CountDownLatch(1);
+        testActivity.mSignal = signal;
+
+        final String response = "{\"id_token\":\"" + TEST_IDTOKEN
+                + "\",\"access_token\":\"TokenForSamlAssertionTest\","
+                + "\"token_type\":\"Bearer\","
+                + "\"expires_in\":\"3600\","
+                + "\"expires_on\":\"1368768616\","
+                + "\"refresh_token\":\"refresh112\","
+                + "\"scope\":\"*\", "
+                + "\"client_info\":\"" + Util.TEST_CLIENT_INFO + "\""
+                +"}";
+
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        // Call acquire token silent using assertion which will try to fetch refresh token
+        AuthenticationResult result = context.acquireTokenSilentSyncWithAssertion("sample assertion",
+                AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE, "resource",
+                "clientId", TEST_IDTOKEN_USERID, false, null);
+
+        // Check if the access token is present in the result and if its stored in the cache
+        assertEquals("Token is same as passed in response", "TokenForSamlAssertionTest", result.getAccessToken());
+        assertNotNull("Cache is NOT empty for passed userid for regular token",
+                mockCache.getItem(CacheKey.createCacheKeyForRTEntry(VALID_AUTHORITY, "resource", "clientId",
+                        TEST_IDTOKEN_USERID)));
+
+        clearCache(context);
+    }
+
     @Test
     public void testSilentRequestTokenItemNotContainRT() throws InterruptedException {
         final FileMockContext mockContext = new FileMockContext(androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getContext());

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -466,6 +466,7 @@ class AcquireTokenRequest {
             throws AuthenticationException {
 
         final boolean requestEligibleForBroker = mBrokerProxy.verifyBrokerForSilentRequest(authenticationRequest);
+        final String methodName = ":acquireTokenSilentFlow";
 
         //1. if forceRefresh == true OR claimsChallenge is not null AND the request is eligible for the broker
         if ((authenticationRequest.getForceRefresh() || authenticationRequest.isClaimsChallengePresent()) && requestEligibleForBroker) {
@@ -479,11 +480,14 @@ class AcquireTokenRequest {
         }
 
         //3. try SAML Assertion
-        if (authenticationRequest.getSamlAssertion() != null) {
+        if (authenticationRequest.getSamlAssertion() != null && authenticationRequest.getAssertionType() != null) {
             final AuthenticationResult authResultFromSaml = tryAcquireTokenSilentWithAssertion(authenticationRequest);
             if (isAccessTokenReturned(authResultFromSaml)) {
+                Logger.v(TAG + methodName, "Access token has been acquired using the saml assertion.");
                 return authResultFromSaml;
-            }            
+            } else {
+                Logger.w(TAG + methodName, "Failed to acquire tokens using saml assertion.");
+            }
         }
 
         //4. We couldn't get locally...If eligible return via broker... otherwise return local result

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -458,8 +458,9 @@ class AcquireTokenRequest {
 
     /**
      * Handles the silent flow. Will always lookup local cache. If there is a valid AT in local cache, will use it. If
-     * AT in local cache is already expired, will try RT in the local cache. If RT requst failed, and if we can switch
-     * to broker for auth, will switch to broker for authentication.
+     * AT in local cache is already expired, will try RT in the local cache. If RT requst failed, then use saml assertion passed in the 
+     * request to acquire RT and AT. If this too fails and if we can switch to broker for auth, 
+     * will switch to broker for authentication.
      */
     private AuthenticationResult acquireTokenSilentFlow(final AuthenticationRequest authenticationRequest)
             throws AuthenticationException {
@@ -477,7 +478,15 @@ class AcquireTokenRequest {
             return authResult;
         }
 
-        //3. We couldn't get locally...If eligible return via broker... otherwise return local result
+        //3. try SAML Assertion
+        if(authenticationRequest.getSamlAssertion()){
+            final AuthenticationResult authResultFromSaml = tryAcquireTokenSilentWithAssertion(authenticationRequest);
+            if (isAccessTokenReturned(authResultFromSaml)) {
+                return authResultFromSaml;
+            }            
+        }
+
+        //4. We couldn't get locally...If eligible return via broker... otherwise return local result
         if (requestEligibleForBroker) {
             return tryAcquireTokenSilentWithBroker(authenticationRequest);
         } else {
@@ -498,6 +507,21 @@ class AcquireTokenRequest {
 
         return acquireTokenSilentHandler.getAccessToken();
     }
+
+    /**
+     * Try acquire token using saml assertion.
+     */
+    private AuthenticationResult tryAcquireTokenSilentWithAssertion(final AuthenticationRequest authenticationRequest)
+            throws AuthenticationException {
+        final String methodName = ":tryAcquireTokenSilentWithAssertion";
+        Logger.v(TAG + methodName, "Try to silently get token using SAML Assertion.");
+        final AcquireTokenSilentHandler acquireTokenSilentHandler = new AcquireTokenSilentHandler(mContext,
+                authenticationRequest, mTokenCacheAccessor);
+        removeTokensForUser(authenticationRequest);
+
+        return acquireTokenSilentHandler.getAccessTokenUsingAssertion();
+    }
+
 
     /**
      * Try acquire token silent with broker.

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -479,7 +479,7 @@ class AcquireTokenRequest {
         }
 
         //3. try SAML Assertion
-        if(authenticationRequest.getSamlAssertion() != null) {
+        if (authenticationRequest.getSamlAssertion() != null) {
             final AuthenticationResult authResultFromSaml = tryAcquireTokenSilentWithAssertion(authenticationRequest);
             if (isAccessTokenReturned(authResultFromSaml)) {
                 return authResultFromSaml;
@@ -520,7 +520,6 @@ class AcquireTokenRequest {
         
         return acquireTokenSilentHandler.getAccessTokenUsingAssertion();
     }
-
 
     /**
      * Try acquire token silent with broker.

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -479,7 +479,7 @@ class AcquireTokenRequest {
         }
 
         //3. try SAML Assertion
-        if(authenticationRequest.getSamlAssertion()){
+        if(authenticationRequest.getSamlAssertion() != null) {
             final AuthenticationResult authResultFromSaml = tryAcquireTokenSilentWithAssertion(authenticationRequest);
             if (isAccessTokenReturned(authResultFromSaml)) {
                 return authResultFromSaml;
@@ -517,8 +517,7 @@ class AcquireTokenRequest {
         Logger.v(TAG + methodName, "Try to silently get token using SAML Assertion.");
         final AcquireTokenSilentHandler acquireTokenSilentHandler = new AcquireTokenSilentHandler(mContext,
                 authenticationRequest, mTokenCacheAccessor);
-        removeTokensForUser(authenticationRequest);
-
+        
         return acquireTokenSilentHandler.getAccessTokenUsingAssertion();
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -345,7 +345,7 @@ class AcquireTokenRequest {
         // 1) throw AuthenticationException if
         //    a) No access token is returned from local flow and no prompt is allowed
         //    b) Server error or network errors when sending post request to token endpoint with grant_type
-        //       as refresh_token in local flow
+        //       as refresh_token in local flow or with grant type as assertion
         //    c) Broker returns ERROR_CODE_BAD_ARGUMENTS, ACCOUNT_MANAGER_ERROR_CODE_BAD_AUTHENTICATION
         //       or ERROR_CODE_UNSUPPORTED_OPERATION
         // 2) Non-null AuthenticationResult if we could try silent request, and silent request either successfully

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -121,9 +121,9 @@ class AcquireTokenSilentHandler {
     AuthenticationResult getAccessTokenUsingAssertion() throws AuthenticationException {
         final String methodName = ":getAccessTokenUsingAssertion";
         final AuthenticationResult result = acquireTokenWithAssertion();
-        
-        if(isAccessTokenReturned(result)){
-            mTokenCacheAccessor.updateCachedItemWithResult(mAuthRequest,result, cachedItem);
+        // result should contain all the needed entries
+        if(result != null && !StringExtensions.isNullOrBlank(result.getAccessToken())) {
+            mTokenCacheAccessor.updateCachedItemWithResult(mAuthRequest,result, null);
         }
 
         return result;
@@ -150,7 +150,7 @@ class AcquireTokenSilentHandler {
             final JWSBuilder jwsBuilder = new JWSBuilder();
             final Oauth2 oauthRequest = new Oauth2(mAuthRequest, mWebRequestHandler, jwsBuilder);
 
-            result = oauthRequest.samlAssertion(samlAssertion, assertionType);
+            result = oauthRequest.refreshTokenUsingAssertion(samlAssertion, assertionType);
             if (result != null && StringExtensions.isNullOrBlank(result.getRefreshToken())) {
                 Logger.i(TAG + methodName, "Refresh token is not returned or empty", "");
                 // we have reached this point because we couldnt find the refresh token/use it

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -126,7 +126,7 @@ class AcquireTokenSilentHandler {
             try {
                 mTokenCacheAccessor.updateTokenCache(mAuthRequest, result);
             } catch (MalformedURLException e) {
-                Logger.v(TAG + methodName, "Access token fetched but unable to update token cache");
+                Logger.w(TAG + methodName, "Access token fetched but unable to update token cache");
                 throw new AuthenticationException(ADALError.DEVELOPER_AUTHORITY_IS_NOT_VALID_URL, e.getMessage(), e);
             }
         }
@@ -149,29 +149,17 @@ class AcquireTokenSilentHandler {
         final String samlAssertion = mAuthRequest.getSamlAssertion();
         final String assertionType = mAuthRequest.getAssertionType();
 
+
         try {
             final JWSBuilder jwsBuilder = new JWSBuilder();
             final Oauth2 oauthRequest = new Oauth2(mAuthRequest, mWebRequestHandler, jwsBuilder);
 
             result = oauthRequest.refreshTokenUsingAssertion(samlAssertion, assertionType);
             if (result != null && StringExtensions.isNullOrBlank(result.getRefreshToken())) {
-                Logger.i(TAG + methodName, "Refresh token is not returned or empty", "");
+                Logger.w(TAG + methodName, "Refresh token is not returned or empty");
                 // we have reached this point because we couldnt find the refresh token/use it
                 // so we cant set the refresh token
             }
-        } catch (final ServerRespondingWithRetryableException exc) {
-
-            Logger.e(TAG + methodName,
-                    "Error in assertion for request. ",
-                    "Request: " + mAuthRequest.getLogInfo()
-                            + " " + ExceptionExtensions.getExceptionMessage(exc)
-                            + " " + Log.getStackTraceString(exc),
-                    ADALError.AUTH_FAILED_NO_TOKEN,
-                    null);
-
-            throw new AuthenticationException(
-                    ADALError.AUTH_FAILED_NO_TOKEN, ExceptionExtensions.getExceptionMessage(exc),
-                    new AuthenticationException(ADALError.SERVER_ERROR, exc.getMessage(), exc));
         } catch (final IOException | AuthenticationException exc) {
             // Server side error or similar
             Logger.e(TAG + methodName,
@@ -208,7 +196,7 @@ class AcquireTokenSilentHandler {
             final Oauth2 oauthRequest = new Oauth2(mAuthRequest, mWebRequestHandler, jwsBuilder);
             result = oauthRequest.refreshToken(refreshToken);
             if (result != null && StringExtensions.isNullOrBlank(result.getRefreshToken())) {
-                Logger.i(TAG + methodName, "Refresh token is not returned or empty", "");
+                Logger.w(TAG + methodName, "Refresh token is not returned or empty");
                 result.setRefreshToken(refreshToken);
             }
         } catch (final ServerRespondingWithRetryableException exc) {

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenSilentHandler.java
@@ -122,7 +122,7 @@ class AcquireTokenSilentHandler {
         final String methodName = ":getAccessTokenUsingAssertion";
         final AuthenticationResult result = acquireTokenWithAssertion();
         
-        if(result != null && !StringExtensions.isNullOrBlank(result.getAccessToken())) {
+        if (result != null && !StringExtensions.isNullOrBlank(result.getAccessToken())) {
             try {
                 mTokenCacheAccessor.updateTokenCache(mAuthRequest, result);
             } catch (MalformedURLException e) {
@@ -189,7 +189,6 @@ class AcquireTokenSilentHandler {
 
         return result;
     }
-
 
     /**
      * Send token request with grant_type as refresh_token to token endpoint for getting new access token.

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -32,7 +32,7 @@ public final class AuthenticationConstants {
      */
     private AuthenticationConstants() {
     }
-    
+
     /**
      * ADAL package name.
      */

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -32,8 +32,7 @@ public final class AuthenticationConstants {
      */
     private AuthenticationConstants() {
     }
-
-        
+    
     /**
      * ADAL package name.
      */
@@ -58,22 +57,6 @@ public final class AuthenticationConstants {
      * Default access token expiration time in seconds.
      */
     public static final int DEFAULT_EXPIRATION_TIME_SEC = com.microsoft.identity.common.adal.internal.AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC;
-
-
-    /**
-     * Represents the assertion types in SAML assertion.
-     */ 
-    
-    public static final class SamlAssertion {
-
-        public enum ADAssertionType {
-            /*! Default option. Assumes the assertion provided is of type SAML 1.1. */
-            AD_SAML1_1,
-
-            /*! Assumes the assertion provided is of type SAML 2. */
-            AD_SAML2,
-        }
-    }
 
 
     /**
@@ -367,7 +350,6 @@ public final class AuthenticationConstants {
         public static final String MSID_OAUTH2_SAML11_BEARER_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE;
 
         public static final String MSID_OAUTH2_SAML2_BEARER_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML2_BEARER_VALUE;
-
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -33,6 +33,7 @@ public final class AuthenticationConstants {
     private AuthenticationConstants() {
     }
 
+        
     /**
      * ADAL package name.
      */
@@ -57,6 +58,23 @@ public final class AuthenticationConstants {
      * Default access token expiration time in seconds.
      */
     public static final int DEFAULT_EXPIRATION_TIME_SEC = com.microsoft.identity.common.adal.internal.AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC;
+
+
+    /**
+     * Represents the assertion types in SAML assertion.
+     */ 
+    
+    public static final class SamlAssertion {
+
+        public enum ADAssertionType {
+            /*! Default option. Assumes the assertion provided is of type SAML 1.1. */
+            AD_SAML1_1,
+
+            /*! Assumes the assertion provided is of type SAML 2. */
+            AD_SAML2,
+        }
+    }
+
 
     /**
      * Holding all the constant value involved in the webview.
@@ -816,21 +834,10 @@ public final class AuthenticationConstants {
              */
             public static final String SPE_RING = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SPE_RING;
         }
+
     }
 
-    /**
-     * Represents the assertion types in SAML assertion.
-     */
-    public static final class SamlAssertion {
 
-        public enum ADAssertionType{
-            /*! Default option. Assumes the assertion provided is of type SAML 1.1. */
-            AD_SAML1_1,
-            
-            /*! Assumes the assertion provided is of type SAML 2. */
-            AD_SAML2,
-        }
-    }
 
     /**
      * Represents the oauth2 error code.

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -58,7 +58,6 @@ public final class AuthenticationConstants {
      */
     public static final int DEFAULT_EXPIRATION_TIME_SEC = com.microsoft.identity.common.adal.internal.AuthenticationConstants.DEFAULT_EXPIRATION_TIME_SEC;
 
-
     /**
      * Holding all the constant value involved in the webview.
      */
@@ -344,7 +343,6 @@ public final class AuthenticationConstants {
         /**
          * SAML assertion related parameters.
          */
-
         public static final String ASSERTION = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.ASSERTION;
 
         public static final String MSID_OAUTH2_SAML11_BEARER_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE;
@@ -816,10 +814,7 @@ public final class AuthenticationConstants {
              */
             public static final String SPE_RING = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SPE_RING;
         }
-
     }
-
-
 
     /**
      * Represents the oauth2 error code.

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -237,6 +237,8 @@ public final class AuthenticationConstants {
          */
         public static final String SCOPE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.SCOPE;
 
+        public static final String MSID_OAUTH2_SCOPE_OPENID_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SCOPE_OPENID_VALUE;
+
         /**
          * String of state.
          */
@@ -337,6 +339,17 @@ public final class AuthenticationConstants {
         static final String CLAIMS = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.CLAIMS;
 
         static final String CLOUD_INSTANCE_HOST_NAME = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.CLOUD_INSTANCE_HOST_NAME;
+        
+        /**
+         * SAML assertion related parameters.
+         */
+
+        public static final String ASSERTION = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.ASSERTION;
+
+        public static final String MSID_OAUTH2_SAML11_BEARER_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE;
+
+        public static final String MSID_OAUTH2_SAML2_BEARER_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML2_BEARER_VALUE;
+
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -806,6 +806,20 @@ public final class AuthenticationConstants {
     }
 
     /**
+     * Represents the assertion types in SAML assertion.
+     */
+    public static final class SamlAssertion {
+
+        public enum ADAssertionType{
+            /*! Default option. Assumes the assertion provided is of type SAML 1.1. */
+            AD_SAML1_1,
+            
+            /*! Assumes the assertion provided is of type SAML 2. */
+            AD_SAML2,
+        }
+    }
+
+    /**
      * Represents the oauth2 error code.
      */
     protected static final class OAuth2ErrorCode {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -237,8 +237,6 @@ public final class AuthenticationConstants {
          */
         public static final String SCOPE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.SCOPE;
 
-        public static final String MSID_OAUTH2_SCOPE_OPENID_VALUE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.MSID_OAUTH2_SCOPE_OPENID_VALUE;
-
         /**
          * String of state.
          */

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -648,7 +648,6 @@ public class AuthenticationContext {
         return acquireTokenSilentSync(null, null, resource, clientId, userId, forceRefresh, claims, apiEventString);
     }
 
-
     /**
      *
      * This function tries to acquire token silently. It will first look at the cache
@@ -658,7 +657,6 @@ public class AuthenticationContext {
      * it will use the provided assertion and its type to acquire the same.
      * This method will not show UI for the user. If prompt is needed, the method
      * will return an exception
-     *
      *
      * @param assertion the actual saml assertion
      * @param assertionType version of saml assertion being used
@@ -673,7 +671,6 @@ public class AuthenticationContext {
      * {@link UserInfo}.
      * @throws AuthenticationException If silent request fails to get the token back.
      * @throws InterruptedException    If the main thread is interrupted before or during the activity.
-     *
      */
     public AuthenticationResult acquireTokenSilentSyncWithAssertion(final String assertion,
                                                                     final String assertionType,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -645,7 +645,7 @@ public class AuthenticationContext {
                                                         final String apiEventString)
             throws AuthenticationException, InterruptedException {
         final String methodName = ":acquireTokenSilentSync";
-        return acquireTokenSilentSyncWithAssertion(null, null, resource, clientId, userId, forceRefresh, claims);
+        return acquireTokenSilentSync(null, null, resource, clientId, userId, forceRefresh, claims, apiEventString);
     }
 
 
@@ -675,8 +675,6 @@ public class AuthenticationContext {
      * @throws InterruptedException    If the main thread is interrupted before or during the activity.
      *
      */
-
-
     public AuthenticationResult acquireTokenSilentSyncWithAssertion(final String assertion,
                                                                     final String assertionType,
                                                                     final String resource,
@@ -684,9 +682,22 @@ public class AuthenticationContext {
                                                                     final String userId,
                                                                     final boolean forceRefresh,
                                                                     final String claims)
-            throws AuthenticationException, InterruptedException{
+            throws AuthenticationException, InterruptedException {
         final String methodName = ":acquireTokenSilentSyncWithAssertion";
-        final String apiEventString = EventStrings.ACQUIRE_TOKEN_WITH_SAML_ASSERTION;
+        return acquireTokenSilentSync(assertion, assertionType, resource, clientId, userId,
+                forceRefresh, claims, EventStrings.ACQUIRE_TOKEN_WITH_SAML_ASSERTION);
+    }
+
+    private AuthenticationResult acquireTokenSilentSync(final String assertion,
+                                                        final String assertionType,
+                                                        final String resource,
+                                                        final String clientId,
+                                                        final String userId,
+                                                        final boolean forceRefresh,
+                                                        final String claims,
+                                                        final String apiEventString)
+            throws AuthenticationException, InterruptedException {
+        final String methodName = ":acquireTokenSilentSync";
         validateClaims(claims);
         checkPreRequirements(resource, clientId);
         checkADFSValidationRequirements(null);
@@ -698,7 +709,6 @@ public class AuthenticationContext {
         final String requestId = Telemetry.registerNewRequest();
         final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, apiEventString);
         apiEvent.setPromptBehavior(PromptBehavior.Auto.toString());
-
         final AuthenticationRequest request = new AuthenticationRequest(assertion, assertionType, mAuthority, resource,
                 clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh, claims);
                 
@@ -754,9 +764,7 @@ public class AuthenticationContext {
         }
 
         return authenticationResult.get();
-
     }
-
 
     /**
      * The function will first look at the cache and automatically checks for

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -645,26 +645,9 @@ public class AuthenticationContext {
                                                         final String apiEventString)
             throws AuthenticationException, InterruptedException {
         final String methodName = ":acquireTokenSilentSync";
-        return acquireTokenSilentSyncWithAssertion(null, null, resource, clientId, userId, false, claims, EventStrings.ACQUIRE_TOKEN_WITH_SAML_ASSERTION);
+        return acquireTokenSilentSyncWithAssertion(null, null, resource, clientId, userId, forceRefresh, claims);
     }
 
-
-    public AuthenticationResult acquireTokenSilentSyncWithAssertion(String assertion, AuthenticationConstants.SamlAssertion.ADAssertionType assertionType,
-                                                                    String resource, String clientId, String userId, boolean forceRefresh)
-            throws AuthenticationException, InterruptedException {
-
-        return acquireTokenSilentSyncWithAssertion(assertion, assertionType, resource, clientId, userId,
-                forceRefresh, null, EventStrings.ACQUIRE_TOKEN_WITH_SAML_ASSERTION);
-    }
-
-
-    public AuthenticationResult acquireTokenSilentSyncWithAssertion(String assertion, AuthenticationConstants.SamlAssertion.ADAssertionType assertionType,
-                                                                    String resource, String clientId, String userId, String claims)
-            throws AuthenticationException, InterruptedException {
-
-        return acquireTokenSilentSyncWithAssertion(assertion, assertionType, resource, clientId, userId,
-                false, claims, EventStrings.ACQUIRE_TOKEN_WITH_SAML_ASSERTION);
-    }
 
     /**
      *
@@ -677,7 +660,7 @@ public class AuthenticationContext {
      * will return an exception
      *
      *
-     * @param assertion the actuall saml assertion
+     * @param assertion the actual saml assertion
      * @param assertionType version of saml assertion being used
      * @param resource required resource identifier.
      * @param clientId required client identifier.
@@ -694,17 +677,16 @@ public class AuthenticationContext {
      */
 
 
-    private AuthenticationResult acquireTokenSilentSyncWithAssertion(final String assertion,
-                                                                     final AuthenticationConstants.SamlAssertion.ADAssertionType assertionType, 
-                                                                     final String resource,
-                                                                     final String clientId,
-                                                                     final String userId,
-                                                                     final boolean forceRefresh,
-                                                                     final String claims,
-                                                                     final String apiEventString)
+    public AuthenticationResult acquireTokenSilentSyncWithAssertion(final String assertion,
+                                                                    final String assertionType,
+                                                                    final String resource,
+                                                                    final String clientId,
+                                                                    final String userId,
+                                                                    final boolean forceRefresh,
+                                                                    final String claims)
             throws AuthenticationException, InterruptedException{
         final String methodName = ":acquireTokenSilentSyncWithAssertion";
-
+        final String apiEventString = EventStrings.ACQUIRE_TOKEN_WITH_SAML_ASSERTION;
         validateClaims(claims);
         checkPreRequirements(resource, clientId);
         checkADFSValidationRequirements(null);
@@ -717,10 +699,9 @@ public class AuthenticationContext {
         final APIEvent apiEvent = createApiEvent(mContext, clientId, requestId, apiEventString);
         apiEvent.setPromptBehavior(PromptBehavior.Auto.toString());
 
-        final AuthenticationRequest request = assertion == null ? new AuthenticationRequest(assertion, assertionType, mAuthority, resource,
-                clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh, claims) : 
-                new AuthenticationRequest(mAuthority, resource, clientId, userId, getRequestCorrelationId(), 
-                getExtendedLifetimeEnabled(), forceRefresh, claims);
+        final AuthenticationRequest request = new AuthenticationRequest(assertion, assertionType, mAuthority, resource,
+                clientId, userId, getRequestCorrelationId(), getExtendedLifetimeEnabled(), forceRefresh, claims);
+                
         request.setSilent(true);
         request.setPrompt(PromptBehavior.Auto);
         request.setUserIdentifierType(UserIdentifierType.UniqueId);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -26,6 +26,7 @@ package com.microsoft.aad.adal;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 
 import java.io.Serializable;
 import java.util.List;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -26,7 +26,6 @@ package com.microsoft.aad.adal;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 
 import java.io.Serializable;
 import java.util.List;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -88,6 +88,10 @@ class AuthenticationRequest implements Serializable {
 
     private List<String> mClientCapabilities;
 
+    private String mSamlAssertion = null;
+
+    private AuthenticationConstants.SamlAssertion.ADAssertionType mAssertionType;
+
     /**
      * Developer can use acquireToken(with loginhint) or acquireTokenSilent(with
      * userid), so this sets the type of the request.
@@ -178,6 +182,21 @@ class AuthenticationRequest implements Serializable {
         mClaimsChallenge = claimsChallenge;
     }
 
+    AuthenticationRequest(String assertion, AuthenticationConstants.SamlAssertion.ADAssertionType assertionType, String authority, 
+        String resource, String clientid, String userid, UUID correlationId, boolean isExtendedLifetimeEnabled, boolean forceRefresh, 
+        String claimsChallenge) {
+        mSamlAssertion = assertion;
+        mAssertionType = assertionType;
+        mAuthority = authority;
+        mResource = resource;
+        mClientId = clientid;
+        mUserId = userid;
+        mCorrelationId = correlationId;
+        mIsExtendedLifetimeEnabled = isExtendedLifetimeEnabled;
+        mForceRefresh = forceRefresh;
+        mClaimsChallenge = claimsChallenge;
+    }
+
     AuthenticationRequest(String authority, String resource, String clientId,
                           UUID correlationId, boolean isExtendedLifetimeEnabled) {
         mAuthority = authority;
@@ -190,6 +209,14 @@ class AuthenticationRequest implements Serializable {
     public boolean isClaimsChallengePresent() {
         // if developer pass claims down through extra qp, we should also skip cache.
         return !StringExtensions.isNullOrBlank(this.getClaimsChallenge());
+    }
+
+    public String getSamlAssertion() {
+        return mSamlAssertion;
+    }
+
+    public AuthenticationConstants.SamlAssertion.ADAssertionType getAssertionType() {
+        return mAssertionType;
     }
 
     public String getAuthority() {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -25,6 +25,7 @@ package com.microsoft.aad.adal;
 
 import androidx.annotation.Nullable;
 
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.Serializable;
@@ -188,7 +189,14 @@ class AuthenticationRequest implements Serializable {
         this(authority, resource, clientid, userid, correlationId, isExtendedLifetimeEnabled,
                 forceRefresh, claimsChallenge);
         mSamlAssertion = assertion;
+        if (assertionType != AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE &&
+                assertionType != AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML2_BEARER_VALUE) {
+           assertionType = null;
+        } else {
+            mLoginHint = userid;
+        }
         mAssertionType = assertionType;
+
     }
 
     AuthenticationRequest(String authority, String resource, String clientId,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -189,7 +189,6 @@ class AuthenticationRequest implements Serializable {
                 forceRefresh, claimsChallenge);
         mSamlAssertion = assertion;
         mAssertionType = assertionType;
-
     }
 
     AuthenticationRequest(String authority, String resource, String clientId,

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -91,7 +91,7 @@ class AuthenticationRequest implements Serializable {
 
     private String mSamlAssertion = null;
 
-    private AuthenticationConstants.SamlAssertion.ADAssertionType mAssertionType;
+    private String mAssertionType;
 
     /**
      * Developer can use acquireToken(with loginhint) or acquireTokenSilent(with
@@ -183,19 +183,14 @@ class AuthenticationRequest implements Serializable {
         mClaimsChallenge = claimsChallenge;
     }
 
-    AuthenticationRequest(String assertion, AuthenticationConstants.SamlAssertion.ADAssertionType assertionType, String authority, 
-        String resource, String clientid, String userid, UUID correlationId, boolean isExtendedLifetimeEnabled, boolean forceRefresh, 
-        String claimsChallenge) {
+    AuthenticationRequest(String assertion, String assertionType, String authority,
+                          String resource, String clientid, String userid, UUID correlationId, 
+                          boolean isExtendedLifetimeEnabled, boolean forceRefresh, String claimsChallenge) {
+        this(authority, resource, clientid, userid, correlationId, isExtendedLifetimeEnabled,
+                forceRefresh, claimsChallenge);
         mSamlAssertion = assertion;
         mAssertionType = assertionType;
-        mAuthority = authority;
-        mResource = resource;
-        mClientId = clientid;
-        mUserId = userid;
-        mCorrelationId = correlationId;
-        mIsExtendedLifetimeEnabled = isExtendedLifetimeEnabled;
-        mForceRefresh = forceRefresh;
-        mClaimsChallenge = claimsChallenge;
+
     }
 
     AuthenticationRequest(String authority, String resource, String clientId,
@@ -216,7 +211,7 @@ class AuthenticationRequest implements Serializable {
         return mSamlAssertion;
     }
 
-    public AuthenticationConstants.SamlAssertion.ADAssertionType getAssertionType() {
+    public String getAssertionType() {
         return mAssertionType;
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -321,7 +321,7 @@ class Oauth2 {
                 StringExtensions.urlFormEncode(mRequest.getClientId()),
 
                 AuthenticationConstants.OAuth2.SCOPE,
-                AuthenticationConstants.OAuth2.MSID_OAUTH2_SCOPE_OPENID_VALUE,
+                AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE,
 
                 AuthenticationConstants.OAuth2.CLIENT_INFO,
                 AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE
@@ -571,7 +571,8 @@ class Oauth2 {
         return postMessage(requestMessage, headers);
     }
 
-    public AuthenticationResult refreshTokenUsingAssertion(String samlAssertion, String assertionType)
+    public AuthenticationResult refreshTokenUsingAssertion(@NonNull final String samlAssertion,
+                                                           @NonNull final String assertionType)
             throws IOException, AuthenticationException {
         final String requestMessage;
         if (mWebRequestHandler == null) {

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -325,12 +325,10 @@ class Oauth2 {
 
                 AuthenticationConstants.OAuth2.CLIENT_INFO,
                 AuthenticationConstants.OAuth2.CLIENT_INFO_TRUE
-              
         );
         
         message = buildRequestMessage(message);
         return message;
-        
     }
 
     public String buildRequestMessage(String message) throws UnsupportedEncodingException {
@@ -600,7 +598,6 @@ class Oauth2 {
         Logger.v(TAG, "Sending request to redeem token with assertion.");
         return postMessage(requestMessage, headers);
     }
-
 
     /**
      * parse final url for code(normal flow) or token(implicit flow) and then it

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -186,6 +186,8 @@ final class EventStrings {
 
     static final String ACQUIRE_TOKEN_WITH_REFRESH_TOKEN_2 = "5";
 
+    static final String ACQUIRE_TOKEN_WITH_SAML_ASSERTION = "20";    
+
     static final String ACQUIRE_TOKEN_1 = "100";
 
     static final String ACQUIRE_TOKEN_2 = "104";

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/EventStrings.java
@@ -186,7 +186,7 @@ final class EventStrings {
 
     static final String ACQUIRE_TOKEN_WITH_REFRESH_TOKEN_2 = "5";
 
-    static final String ACQUIRE_TOKEN_WITH_SAML_ASSERTION = "20";    
+    static final String ACQUIRE_TOKEN_WITH_SAML_ASSERTION = "6";
 
     static final String ACQUIRE_TOKEN_1 = "100";
 

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/AcquireTokenFragment.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/AcquireTokenFragment.java
@@ -51,10 +51,13 @@ public class AcquireTokenFragment extends Fragment {
     private Spinner mPromptBehavior;
     private Spinner mClientId;
     private Spinner mRedirectUri;
+    private Spinner mAssertionType;
+    private EditText mAssertion;
     private Switch mUseBroker;
 
     private Button mAcquireToken;
     private Button mAcquireTokenSilent;
+    private Button mAcquireTokenWithAssertion;
 
     private OnFragmentInteractionListener mOnFragmentInteractionListener;
 
@@ -72,12 +75,14 @@ public class AcquireTokenFragment extends Fragment {
         mClientId = (Spinner) view.findViewById(R.id.client_id);
         mRedirectUri = (Spinner) view.findViewById(R.id.redirect_uri);
         mResource = (Spinner) view.findViewById(R.id.data_profile);
-
+        mAssertionType = (Spinner) view.findViewById(R.id.assertionType);
+        mAssertion = (EditText) view.findViewById(R.id.assertion);
         mPromptBehavior = (Spinner) view.findViewById(R.id.prompt_behavior);
 
         mExtraQp = (EditText) view.findViewById(R.id.extraQP);
         mAcquireToken = (Button) view.findViewById(R.id.btn_acquiretoken);
         mAcquireTokenSilent = (Button) view.findViewById(R.id.btn_acquiretokensilent);
+        mAcquireTokenWithAssertion = (Button) view.findViewById(R.id.btn_acquireTokenUsingAssertion);
         mUseBroker = view.findViewById(R.id.use_broker);
 
         bindSpinnerChoice(mAuthority, Constants.AuthorityType.class);
@@ -85,6 +90,7 @@ public class AcquireTokenFragment extends Fragment {
         bindSpinnerChoice(mResource, Constants.DataProfile.class);
         bindSpinnerChoice(mClientId, Constants.ClientId.class);
         bindSpinnerChoice(mRedirectUri, Constants.RedirectUri.class);
+        bindSpinnerChoice(mAssertionType, Constants.AssertionVersion.class);
 
         mAcquireToken.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -97,6 +103,13 @@ public class AcquireTokenFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 mOnFragmentInteractionListener.onAcquireTokenSilentClicked(getCurrentRequestOptions());
+            }
+        });
+
+        mAcquireTokenWithAssertion.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mOnFragmentInteractionListener.onAcquireTokenWithAssertionClicked(getCurrentRequestOptions());
             }
         });
 
@@ -146,7 +159,9 @@ public class AcquireTokenFragment extends Fragment {
         final Constants.RedirectUri redirectUri = Constants.RedirectUri.valueOf(mRedirectUri.getSelectedItem().toString());
         final Constants.ClientId clientId = Constants.ClientId.valueOf(mClientId.getSelectedItem().toString());
         final boolean useBroker = mUseBroker.isChecked();
-        return RequestOptions.create(authority, loginHint, extraQp, resource, behavior, clientId, redirectUri, useBroker);
+        final Constants.AssertionVersion assertionVersion = Constants.AssertionVersion.valueOf(mAssertionType.getSelectedItem().toString());
+        final String assertion = mAssertion.getText().toString();
+        return RequestOptions.create(authority, loginHint, extraQp, resource, behavior, clientId, redirectUri, useBroker, assertion, assertionVersion);
     }
 
     static class RequestOptions {
@@ -158,12 +173,14 @@ public class AcquireTokenFragment extends Fragment {
         final Constants.RedirectUri mRedirectUri;
         final Constants.ClientId mClientId;
         final boolean mUseBroker;
+        final String mAssertion;
+        final Constants.AssertionVersion mAssertionType;
 
         RequestOptions(final String authority, final String loginHint,
                        final String extraQp, final Constants.DataProfile dataProfile,
                        final PromptBehavior behavior, final Constants.ClientId clientId,
                        final Constants.RedirectUri redirectUri,
-                       final boolean useBroker) {
+                       final boolean useBroker, final String assertion, final Constants.AssertionVersion assertionType) {
             mAuthority = authority;
             mLoginHint = loginHint;
             mExtraQp = extraQp;
@@ -172,11 +189,14 @@ public class AcquireTokenFragment extends Fragment {
             mClientId = clientId;
             mRedirectUri = redirectUri;
             mUseBroker = useBroker;
+            mAssertion = assertion;
+            mAssertionType = assertionType;
         }
 
         static RequestOptions create(final String authority, final String loginHint, final String extraQp, final Constants.DataProfile dataProfile,
-                                     final PromptBehavior behavior, final Constants.ClientId clientId, final Constants.RedirectUri redirectUri, final boolean useBroker) {
-            return new RequestOptions(authority, loginHint, extraQp, dataProfile, behavior, clientId, redirectUri, useBroker);
+                                     final PromptBehavior behavior, final Constants.ClientId clientId, final Constants.RedirectUri redirectUri,
+                                     final boolean useBroker, final String assertion, final Constants.AssertionVersion assertionType) {
+            return new RequestOptions(authority, loginHint, extraQp, dataProfile, behavior, clientId, redirectUri, useBroker, assertion, assertionType);
         }
 
         String getAuthority() {
@@ -207,6 +227,10 @@ public class AcquireTokenFragment extends Fragment {
             return mRedirectUri;
         }
 
+        String getAssertion() { return mAssertion;}
+
+        Constants.AssertionVersion getAssertionType() { return mAssertionType;}
+
         boolean getUseBroker() {
             return mUseBroker;
         }
@@ -217,5 +241,7 @@ public class AcquireTokenFragment extends Fragment {
         void onAcquireTokenClicked(final RequestOptions requestOptions);
 
         void onAcquireTokenSilentClicked(final RequestOptions requestOptions);
+
+        void onAcquireTokenWithAssertionClicked(final RequestOptions requestOptions);
     }
 }

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
@@ -23,6 +23,8 @@
 
 package com.microsoft.aad.adal.example.userappwithbroker;
 
+import com.microsoft.aad.adal.AuthenticationConstants;
+
 public class Constants {
     enum AuthorityType {
         AAD_COMMON("https://login.microsoftonline.com/common"),
@@ -101,6 +103,22 @@ public class Constants {
         private final String text;
 
         RedirectUri(String s) {
+            text = s;
+        }
+
+        public String getText() {
+            return text;
+        }
+    }
+
+    enum AssertionVersion {
+        None(null),
+        Version1_1(AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML11_BEARER_VALUE),
+        Version2(AuthenticationConstants.OAuth2.MSID_OAUTH2_SAML2_BEARER_VALUE);
+
+        private final String text;
+
+        AssertionVersion(String s) {
             text = s;
         }
 

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/MainActivity.java
@@ -40,6 +40,7 @@ import android.widget.Toast;
 import com.google.android.material.navigation.NavigationView;
 import com.microsoft.aad.adal.AuthenticationCallback;
 import com.microsoft.aad.adal.AuthenticationContext;
+import com.microsoft.aad.adal.AuthenticationException;
 import com.microsoft.aad.adal.AuthenticationResult;
 import com.microsoft.aad.adal.AuthenticationSettings;
 import com.microsoft.aad.adal.IDispatcher;
@@ -202,6 +203,30 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                             requestOptions.getClientId().getText());
                 } else {
                     showMessage("No uId matching the provided upn, cannot proceed with silent call");
+                }
+            }
+        }).start();
+
+    }
+
+    @Override
+    public void onAcquireTokenWithAssertionClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
+
+        prepareRequestParameters(requestOptions);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                String uId = requestOptions.getLoginHint();
+
+                if(requestOptions.getAssertionType().getText() == null){
+                    showMessage("Assertion type is selected as None");
+                } else if(TextUtils.isEmpty(uId)) {
+                    showMessage("No uId has been provided, cannot proceed with silent call");
+                } else {
+                    callAcquireTokenSilentWithAssertion(requestOptions.getAssertion(), requestOptions.getAssertionType().getText(),
+                            requestOptions.getDataProfile().getText(), uId,
+                            requestOptions.getClientId().getText());
                 }
             }
         }).start();
@@ -385,6 +410,30 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 showMessage("Error occurred when acquiring token silently: " + exc.getMessage());
             }
         });
+    }
+
+    /**
+     * Silent acquire token call. Requires to pass the user unique id. If user unique id is not passed,
+     * silent call to broker will be skipped. If the assertion is passed then token acquisition using
+     * assertion will be called.
+     */
+    private void callAcquireTokenSilentWithAssertion(final String assertion, final String version, final String resource,
+                                        final String userUniqueId, final String clientId) {
+        String messageException = "";
+
+        try {
+            mAuthResult = mAuthContext.acquireTokenSilentSyncWithAssertion(assertion, version, resource, clientId, userUniqueId);
+        } catch (final AuthenticationException authenticationException) {
+            messageException += "Authentication Exception";
+        } catch (final InterruptedException InterruptedException) {
+            messageException += "Interrupted Exception";
+        }
+
+        if (mAuthResult == null) {
+            showMessage("NULL Authentication Result, Exception : " + messageException);
+        } else {
+            showMessage("Response " + mAuthResult.getAccessToken());
+        }
     }
 
     private String getAuthorityBasedOnUPN(final String upn, final String requestAuthority) {

--- a/userappwithbroker/src/main/res/layout/fragment_acquire.xml
+++ b/userappwithbroker/src/main/res/layout/fragment_acquire.xml
@@ -185,6 +185,48 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="2"
+            android:text="Assertion Version" />
+
+        <Spinner
+            android:id="@+id/assertionType"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="8" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="10">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:text="Assertion" />
+
+        <EditText
+            android:id="@+id/assertion"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:layout_weight="8"
+            android:maxLines="1"
+            android:hint="Enter the assertion here"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="10">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
             android:text="Use Broker" />
 
         <Switch
@@ -203,9 +245,11 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
+            android:layout_below="@id/query_param_linear_layout"
             android:gravity="center"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:paddingTop="15dp"
+            android:id="@+id/acquire_token_buttons_layout">
 
             <Button
                 android:id="@+id/btn_acquiretoken"
@@ -224,8 +268,25 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_below="@id/acquire_token_buttons_layout"
+            android:gravity="center"
             android:orientation="horizontal"
-            android:weightSum="10">
+            android:layout_marginTop="10dp">
+
+            <Button
+                android:id="@+id/btn_acquireTokenUsingAssertion"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/acquire_token_assertion_button" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="10"
+            android:id="@+id/query_param_linear_layout">
 
             <TextView
                 android:layout_width="0dp"

--- a/userappwithbroker/src/main/res/values/strings.xml
+++ b/userappwithbroker/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="force_refresh">Force Refresh</string>
     <string name="acquire_token_button">AcquireToken</string>
     <string name="acquire_token_silent_button">AcquireTokenSilent</string>
+    <string name="acquire_token_assertion_button">Acquire Token With Assertion</string>
     <string name="result_hint_text">Acquire token interactive/silent flow result data goes here...</string>
     <string name="log_hint_text">Log data goes here...</string>
     <string name="clear_log_button">clear logs</string>


### PR DESCRIPTION
ADAL SDK on Android does not support silent token acquision based on SAML assertion, which is needed for MSA guest in AAD tenant related use cases.

Changes made :
* new method acquireTokenSilentSyncWithAssertion in AuthenticaitonContext which will be used by developers
* new constants needed for creating saml assertion based requests in AuthenticationConstants
* added methods to acquireTokenRequest, AcquireTokenSilentHandler and OAuth2 for new code flow 
* Changed the Authentication Request class for passing the assertion
* new apiEvent String for saml assertion
* new test case in AuthenticationContextTest for verification
