### PR TITLE
Enable SSO for acquire token by refresh token API (for Scotty Flow)

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -146,9 +146,15 @@ class AcquireTokenRequest {
     }
 
     /**
-     * Developer is using refresh token call to do refresh without cache usage.
-     * App context or activity is not needed. Async requests are created, so this
-     * needs to be called at UI thread.
+     * This API allows to obtain a new access token in exchange for a refresh token. The refresh
+     * token must be provided to this API. The tokens obtained via this API may or may not be saved
+     * in ADAL's cache depending on two things: The openid scope was requested in the token, and a
+     * resource was supplied to the {@link AuthenticationRequest}. If both of those conditions are
+     * true, then tokens are saved in the cache, else not.
+     *
+     * @param refreshToken          the refresh token to use when exchanging for an access token
+     * @param authenticationRequest the {@link AuthenticationRequest} to use when requesting token
+     * @param externalCallback      the callback to which the result should be posted
      */
     void refreshTokenWithoutCache(final String refreshToken, final AuthenticationRequest authenticationRequest,
                                   final AuthenticationCallback<AuthenticationResult> externalCallback) {
@@ -178,7 +184,7 @@ class AcquireTokenRequest {
                         Logger.e(TAG + methodName, "Returned result with exchanging refresh token for access token is null" + correlationId, "",
                                 ADALError.AUTH_REFRESH_FAILED);
                         throw new AuthenticationException(
-                                ADALError.AUTH_REFRESH_FAILED, correlationId);
+                                ADALError.AUTH_REFRESH_FAILED, "No result received from refresh token request.");
                     }
 
                     if (!StringExtensions.isNullOrBlank(result.getErrorCode())) {

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -195,7 +195,14 @@ class AcquireTokenRequest {
 
                     final String rawIdToken = result.getIdToken();
 
-                    if (!TextUtils.isEmpty(rawIdToken)) {
+                    // We will save tokens in cache if we get back an ID Token and also we have a
+                    // resource available.
+                    //
+                    // The ID Token could be null if the caller did not ask for
+                    // the openid scope by not passing it to the Authentication Request,
+                    // whereas the resource could be null if the caller did not specify a resource
+                    // on the AuthenticationRequest.
+                    if (!TextUtils.isEmpty(rawIdToken) && !TextUtils.isEmpty(authenticationRequest.getResource())) {
                         final IdToken idTokenRecord = new IdToken(rawIdToken);
                         final UserInfo userInfo = new UserInfo(idTokenRecord);
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -33,10 +33,11 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Looper;
 import android.os.NetworkOnMainThreadException;
-import androidx.annotation.Nullable;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.text.TextUtils;
 import android.util.SparseArray;
+
+import androidx.annotation.Nullable;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.googleblog.android_developers.PRNGFixes;
 import com.microsoft.aad.adal.AuthenticationRequest.UserIdentifierType;
@@ -273,7 +274,7 @@ public class AuthenticationContext {
                              AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, PromptBehavior.Auto, null,
-                null , callback, EventStrings.ACQUIRE_TOKEN_1, wrapActivity(activity), false);
+                null, callback, EventStrings.ACQUIRE_TOKEN_1, wrapActivity(activity), false);
     }
 
     /**
@@ -302,7 +303,7 @@ public class AuthenticationContext {
                              AuthenticationCallback<AuthenticationResult> callback) {
 
         acquireToken(resource, clientId, redirectUri, loginHint, PromptBehavior.Auto, extraQueryParameters,
-                null, callback,  EventStrings.ACQUIRE_TOKEN_2, wrapActivity(activity), false);
+                null, callback, EventStrings.ACQUIRE_TOKEN_2, wrapActivity(activity), false);
     }
 
     /**
@@ -385,8 +386,8 @@ public class AuthenticationContext {
     }
 
     /**
-     * acquireToken will start an interactive auth flow to acquire new tokens 
-     * with the requested claims. Bypasses token cache if promptbehavior is not AUTO or claims are passed. 
+     * acquireToken will start an interactive auth flow to acquire new tokens
+     * with the requested claims. Bypasses token cache if promptbehavior is not AUTO or claims are passed.
      *
      * @param activity             Calling activity
      * @param resource             required resource identifier.
@@ -439,8 +440,8 @@ public class AuthenticationContext {
     }
 
     /**
-     * acquireToken will start an interactive auth flow to acquire new tokens 
-     * with the requested claims. Bypasses token cache if promptbehavior is not AUTO or claims are passed. 
+     * acquireToken will start an interactive auth flow to acquire new tokens
+     * with the requested claims. Bypasses token cache if promptbehavior is not AUTO or claims are passed.
      *
      * @param fragment             It accepts both type of fragments.
      * @param resource             required resource identifier.
@@ -465,16 +466,17 @@ public class AuthenticationContext {
     }
 
     /**
-     * acquireToken will authorize an end user to call the specified resource. 
+     * acquireToken will authorize an end user to call the specified resource.
      * The access token returned from the STS will be sent to the {@link AuthenticationCallback}
-     * and can be used to call the specified protected resource. 
-     * By default, acquireToken will attempt to fulfill the request silently, and 
-     * perform an interactive login if needed or explicitly specified in 
-     * the request. This overload uses an 
+     * and can be used to call the specified protected resource.
+     * By default, acquireToken will attempt to fulfill the request silently, and
+     * perform an interactive login if needed or explicitly specified in
+     * the request. This overload uses an
      * [AlertDialog](https://developer.android.com/guide/topics/ui/dialogs)
      * when user interaction is required. This overload does not support any flow
-     * requiring a 
+     * requiring a
      * [token broker](https://github.com/AzureAD/azure-activedirectory-library-for-android/wiki/Broker).
+     *
      * @param resource             required resource identifier.
      * @param clientId             required client identifier.
      * @param redirectUri          Optional. It will use packagename and provided suffix
@@ -495,14 +497,14 @@ public class AuthenticationContext {
     }
 
     /**
-     * acquireToken will authorize an end user to call the specified resource. 
+     * acquireToken will authorize an end user to call the specified resource.
      * The access token returned from the STS will be sent to the {@link AuthenticationCallback}
-     * and can be used to call the specified protected resource. 
-     * Bypasses token cache if @param prompt is not AUTO or claims are passed.  
-     * This overload uses an 
+     * and can be used to call the specified protected resource.
+     * Bypasses token cache if @param prompt is not AUTO or claims are passed.
+     * This overload uses an
      * [AlertDialog](https://developer.android.com/guide/topics/ui/dialogs)
      * when user interaction is required. This overload does not support any flow
-     * requiring a 
+     * requiring a
      * [token broker](https://github.com/AzureAD/azure-activedirectory-library-for-android/wiki/Broker).
      *
      * @param resource             required resource identifier.
@@ -531,7 +533,7 @@ public class AuthenticationContext {
                               @Nullable final String loginHint, @Nullable final PromptBehavior prompt,
                               @Nullable String extraQueryParameters, @Nullable final String claims,
                               final AuthenticationCallback<AuthenticationResult> callback, String apiEventString,
-                              final IWindowComponent fragment, final boolean useDialog){
+                              final IWindowComponent fragment, final boolean useDialog) {
 
         throwIfClaimsInBothExtraQpAndClaimsParameter(claims, extraQueryParameters);
 
@@ -555,7 +557,7 @@ public class AuthenticationContext {
             setAppInfoToRequest(request);
             request.setClientCapabilities(mClientCapabilites);
 
-            if(!StringExtensions.isNullOrBlank(loginHint)) {
+            if (!StringExtensions.isNullOrBlank(loginHint)) {
                 apiEvent.setLoginHint(loginHint);
                 request.setUserIdentifierType(UserIdentifierType.LoginHint);
             }
@@ -620,10 +622,10 @@ public class AuthenticationContext {
      * will use the refresh token automatically. This method will not show UI
      * for the user. If prompt is needed, the method will return an exception
      *
-     * @param resource required resource identifier.
-     * @param clientId required client identifier.
-     * @param userId   UserID obtained from
-     *                 {@link AuthenticationResult #getUserInfo()}
+     * @param resource     required resource identifier.
+     * @param clientId     required client identifier.
+     * @param userId       UserID obtained from
+     *                     {@link AuthenticationResult #getUserInfo()}
      * @param forceRefresh when true, access token is renewed using broker if available; otherwise, uses local refresh token
      * @return A {@link Future} object representing the
      * {@link AuthenticationResult} of the call. It contains Access
@@ -822,13 +824,13 @@ public class AuthenticationContext {
      * refresh token automatically. This method will not show UI for the user.
      * If prompt is needed, the method will return an exception
      *
-     * @param resource required resource identifier.
-     * @param clientId required client identifier.
-     * @param userId   UserId obtained from {@link UserInfo} inside
-     *                 {@link AuthenticationResult}
+     * @param resource     required resource identifier.
+     * @param clientId     required client identifier.
+     * @param userId       UserId obtained from {@link UserInfo} inside
+     *                     {@link AuthenticationResult}
      * @param forceRefresh when true, access token is renewed using broker if available; otherwise, uses local refresh token
-     * @param callback required {@link AuthenticationCallback} object for async
-     *                 call.
+     * @param callback     required {@link AuthenticationCallback} object for async
+     *                     call.
      */
     public void acquireTokenSilentAsync(String resource,
                                         String clientId,
@@ -863,12 +865,12 @@ public class AuthenticationContext {
     }
 
     private void acquireTokenSilentAsync(final String resource,
-                                        final String clientId,
-                                        final String userId,
-                                        final boolean forceRefresh,
-                                        final String claims,
-                                        final String apiEventString,
-                                        final AuthenticationCallback<AuthenticationResult> callback) {
+                                         final String clientId,
+                                         final String userId,
+                                         final boolean forceRefresh,
+                                         final String claims,
+                                         final String apiEventString,
+                                         final AuthenticationCallback<AuthenticationResult> callback) {
 
         if (!checkPreRequirements(resource, clientId, callback) || !checkADFSValidationRequirements(null, callback)) {
             // AD FS validation cannot be perfomed, stop executing
@@ -899,7 +901,6 @@ public class AuthenticationContext {
         createAcquireTokenRequest(apiEvent).acquireToken(null, false, request, callback);
 
     }
-
 
 
     /**
@@ -940,7 +941,9 @@ public class AuthenticationContext {
         apiEvent.setIsDeprecated(true);
 
         final AuthenticationRequest request = new AuthenticationRequest(mAuthority,
-                null, clientId, getRequestCorrelationId(), getExtendedLifetimeEnabled());
+                null, clientId, getRequestCorrelationId(), getExtendedLifetimeEnabled(),
+                AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE
+        );
 
         // It is not using cache and refresh is not expected to
         // show authentication activity.
@@ -992,7 +995,9 @@ public class AuthenticationContext {
 
         // Authenticator is not supported if user is managing the cache
         final AuthenticationRequest request = new AuthenticationRequest(mAuthority,
-                resource, clientId, getRequestCorrelationId(), getExtendedLifetimeEnabled());
+                resource, clientId, getRequestCorrelationId(), getExtendedLifetimeEnabled(),
+                AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE
+        );
 
         request.setTelemetryRequestId(requestId);
 
@@ -1123,7 +1128,7 @@ public class AuthenticationContext {
         Logger.setCorrelationId(requestCorrelationId);
     }
 
-    private void setAppInfoToRequest(AuthenticationRequest request){
+    private void setAppInfoToRequest(AuthenticationRequest request) {
         String packageName = mContext.getPackageName();
         request.setAppName(packageName);
         try {
@@ -1155,46 +1160,47 @@ public class AuthenticationContext {
 
     /**
      * Util method to merge
+     *
      * @param claims input claims passed on acquireToken call
      * @return merged claims with capabilities
      * @throws JSONException if input claims is an invalid JSON
-     *
-     * Sample input claim :
-     *      {
-                "userinfo":
-                {
-                    "given_name": {"essential": true},
-                    "email": {"essential": true},
-                },
-                "id_token":
-                {
-                    "auth_time": {"essential": true},
-                }
-            }
-
-     Sample capabilities list : [CP1, CP2 CP3]
-
-     Output merged claims :
-        {
-            "userinfo": {
-                "given_name": {
-                    "essential": true
-                },
-                "email": {
-                    "essential": true
-                }
-            },
-            "id_token": {
-                "auth_time": {
-                    "essential": true
-                }
-            },
-            "access_token": {
-                "xms_cc": {
-                    "values": ["CP1", "CP2"]
-                }
-            }
-        }
+     *                       <p>
+     *                       Sample input claim :
+     *                       {
+     *                       "userinfo":
+     *                       {
+     *                       "given_name": {"essential": true},
+     *                       "email": {"essential": true},
+     *                       },
+     *                       "id_token":
+     *                       {
+     *                       "auth_time": {"essential": true},
+     *                       }
+     *                       }
+     *                       <p>
+     *                       Sample capabilities list : [CP1, CP2 CP3]
+     *                       <p>
+     *                       Output merged claims :
+     *                       {
+     *                       "userinfo": {
+     *                       "given_name": {
+     *                       "essential": true
+     *                       },
+     *                       "email": {
+     *                       "essential": true
+     *                       }
+     *                       },
+     *                       "id_token": {
+     *                       "auth_time": {
+     *                       "essential": true
+     *                       }
+     *                       },
+     *                       "access_token": {
+     *                       "xms_cc": {
+     *                       "values": ["CP1", "CP2"]
+     *                       }
+     *                       }
+     *                       }
      */
     public static String mergeClaimsWithClientCapabilities(final String claims,
                                                            final List<String> clientCapabilities) {
@@ -1518,7 +1524,7 @@ public class AuthenticationContext {
         return mClientCapabilites;
     }
 
-    public void setClientCapabilites(List<String> clientCapabilites){
+    public void setClientCapabilites(List<String> clientCapabilites) {
         mClientCapabilites = clientCapabilites;
     }
 
@@ -1565,8 +1571,8 @@ public class AuthenticationContext {
 
     private void validateClaims(final String claims) throws AuthenticationException {
         try {
-            if(!TextUtils.isEmpty(claims)) {
-               new JSONObject(claims);
+            if (!TextUtils.isEmpty(claims)) {
+                new JSONObject(claims);
             }
         } catch (JSONException e) {
             throw new AuthenticationException(ADALError.JSON_PARSE_ERROR, "Invalid claims request parameters", e);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -951,7 +951,7 @@ public class AuthenticationContext {
 
         request.setTelemetryRequestId(requestId);
 
-        // Authenticator is not supported if user is managing the cache
+        // Broker is not supported for the Acquire Token By Refresh Token API
         createAcquireTokenRequest(apiEvent).refreshTokenWithoutCache(refreshToken, request, callback);
     }
 
@@ -993,7 +993,7 @@ public class AuthenticationContext {
         apiEvent.setPromptBehavior(PromptBehavior.Auto.toString());
         apiEvent.setIsDeprecated(true);
 
-        // Authenticator is not supported if user is managing the cache
+        // Broker is not supported for the Acquire Token By Refresh Token API
         final AuthenticationRequest request = new AuthenticationRequest(mAuthority,
                 resource, clientId, getRequestCorrelationId(), getExtendedLifetimeEnabled(),
                 AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -1164,43 +1164,43 @@ public class AuthenticationContext {
      * @param claims input claims passed on acquireToken call
      * @return merged claims with capabilities
      * @throws JSONException if input claims is an invalid JSON
-     *                       <p>
-     *                       Sample input claim :
-     *                       {
-     *                       "userinfo":
-     *                       {
-     *                       "given_name": {"essential": true},
-     *                       "email": {"essential": true},
-     *                       },
-     *                       "id_token":
-     *                       {
-     *                       "auth_time": {"essential": true},
-     *                       }
-     *                       }
-     *                       <p>
-     *                       Sample capabilities list : [CP1, CP2 CP3]
-     *                       <p>
-     *                       Output merged claims :
-     *                       {
-     *                       "userinfo": {
-     *                       "given_name": {
-     *                       "essential": true
-     *                       },
-     *                       "email": {
-     *                       "essential": true
-     *                       }
-     *                       },
-     *                       "id_token": {
-     *                       "auth_time": {
-     *                       "essential": true
-     *                       }
-     *                       },
-     *                       "access_token": {
-     *                       "xms_cc": {
-     *                       "values": ["CP1", "CP2"]
-     *                       }
-     *                       }
-     *                       }
+     *
+     * <pre>
+     Sample input claim :
+        {
+            "userinfo": {
+                "given_name": {"essential": true},
+                "email": {"essential": true},
+            },
+            "id_token": {
+                "auth_time": {"essential": true},
+            }
+        }
+
+    Sample capabilities list : [CP1, CP2 CP3]
+
+    Output merged claims :
+        {
+            "userinfo": {
+                "given_name": {
+                    "essential": true
+                },
+                "email": {
+                    "essential": true
+                }
+            },
+            "id_token": {
+                "auth_time": {
+                    "essential": true
+                }
+            },
+            "access_token": {
+                "xms_cc": {
+                    "values": ["CP1", "CP2"]
+                }
+            }
+        }
+     * </pre>
      */
     public static String mergeClaimsWithClientCapabilities(final String claims,
                                                            final List<String> clientCapabilities) {

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -189,6 +189,16 @@ class AuthenticationRequest implements Serializable {
         mIsExtendedLifetimeEnabled = isExtendedLifetimeEnabled;
     }
 
+    /**
+     * Create an Authentication Request to obtain a token. This overload also accepts a scope param.
+     *
+     * @param authority                 Authority URL
+     * @param resource                  Resource that is requested
+     * @param clientId                  ClientId for the app
+     * @param correlationId             Correlation Id used for logging & telemetry
+     * @param isExtendedLifetimeEnabled a boolean indicating if extended lifetime enabled
+     * @param scope                     the scope requested
+     */
     AuthenticationRequest(String authority, String resource, String clientId,
                           UUID correlationId, boolean isExtendedLifetimeEnabled, String scope) {
         mAuthority = authority;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -50,6 +50,8 @@ class AuthenticationRequest implements Serializable {
 
     private String mResource = null;
 
+    private String mScope = null;
+
     private String mClientId = null;
 
     private String mLoginHint = null;
@@ -187,6 +189,16 @@ class AuthenticationRequest implements Serializable {
         mIsExtendedLifetimeEnabled = isExtendedLifetimeEnabled;
     }
 
+    AuthenticationRequest(String authority, String resource, String clientId,
+                          UUID correlationId, boolean isExtendedLifetimeEnabled, String scope) {
+        mAuthority = authority;
+        mClientId = clientId;
+        mResource = resource;
+        mCorrelationId = correlationId;
+        mIsExtendedLifetimeEnabled = isExtendedLifetimeEnabled;
+        mScope = scope;
+    }
+
     public boolean isClaimsChallengePresent() {
         // if developer pass claims down through extra qp, we should also skip cache.
         return !StringExtensions.isNullOrBlank(this.getClaimsChallenge());
@@ -203,7 +215,7 @@ class AuthenticationRequest implements Serializable {
     public String getRedirectUri() {
         return mRedirectUri;
     }
-    
+
     public void setRedirectUri(final String redirectUri) {
         mRedirectUri = redirectUri;
     }
@@ -212,10 +224,14 @@ class AuthenticationRequest implements Serializable {
         return mResource;
     }
 
+    public String getScope() {
+        return mScope;
+    }
+
     public String getClientId() {
         return mClientId;
     }
-    
+
     public void setClientId(final String id) {
         mClientId = id;
     }
@@ -227,7 +243,7 @@ class AuthenticationRequest implements Serializable {
     public UUID getCorrelationId() {
         return this.mCorrelationId;
     }
-    
+
     public void setCorrelationId(UUID correlationId) {
         mCorrelationId = correlationId;
     }
@@ -239,7 +255,7 @@ class AuthenticationRequest implements Serializable {
     public void setExtraQueryParamsAuthentication(String queryParam) {
         mExtraQueryParamsAuthentication = queryParam;
     }
-    
+
     public String getLogInfo() {
         return String.format("Request authority:%s clientid:%s", mAuthority, mClientId);
     }
@@ -278,11 +294,11 @@ class AuthenticationRequest implements Serializable {
         mLoginHint = name;
     }
 
-    public void setUserName(String name){
+    public void setUserName(String name) {
         mLoginHint = name;
         mBrokerAccountName = name;
     }
-    
+
     public String getUserId() {
         return mUserId;
     }
@@ -319,6 +335,10 @@ class AuthenticationRequest implements Serializable {
         this.mResource = resource;
     }
 
+    public void setScope(String scope) {
+        this.mScope = scope;
+    }
+
     public boolean getIsExtendedLifetimeEnabled() {
         return mIsExtendedLifetimeEnabled;
     }
@@ -338,7 +358,7 @@ class AuthenticationRequest implements Serializable {
     public boolean getSkipCache() {
         return mSkipCache;
     }
-    
+
     /**
      * Get either loginhint or user id based what's passed in the request.
      */
@@ -384,11 +404,11 @@ class AuthenticationRequest implements Serializable {
         return mInstanceDiscoveryMetadata;
     }
 
-    public boolean getForceRefresh(){
+    public boolean getForceRefresh() {
         return mForceRefresh;
     }
 
-    public void setForceRefresh(boolean forceRefresh){
+    public void setForceRefresh(boolean forceRefresh) {
         mForceRefresh = forceRefresh;
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationRequest.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.aad.adal;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
@@ -199,8 +200,8 @@ class AuthenticationRequest implements Serializable {
      * @param isExtendedLifetimeEnabled a boolean indicating if extended lifetime enabled
      * @param scope                     the scope requested
      */
-    AuthenticationRequest(String authority, String resource, String clientId,
-                          UUID correlationId, boolean isExtendedLifetimeEnabled, String scope) {
+    AuthenticationRequest(@NonNull String authority, @Nullable String resource, @NonNull String clientId,
+                          @NonNull UUID correlationId, boolean isExtendedLifetimeEnabled, @NonNull String scope) {
         mAuthority = authority;
         mClientId = clientId;
         mResource = resource;

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -309,6 +309,7 @@ class Oauth2 {
                     StringExtensions.urlFormEncode(mRequest.getResource()));
         }
 
+        // append scope to request if provided
         if (!StringExtensions.isNullOrBlank(mRequest.getScope())) {
             message = String.format(STRING_FORMAT_QUERY_PARAM, message, "scope",
                     StringExtensions.urlFormEncode(mRequest.getScope()));

--- a/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/Oauth2.java
@@ -25,9 +25,10 @@ package com.microsoft.aad.adal;
 
 import android.net.Uri;
 import android.os.Build;
-import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Base64;
+
+import androidx.annotation.NonNull;
 
 import com.microsoft.aad.adal.ChallengeResponseBuilder.ChallengeResponse;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -306,6 +307,11 @@ class Oauth2 {
         if (!StringExtensions.isNullOrBlank(mRequest.getResource())) {
             message = String.format(STRING_FORMAT_QUERY_PARAM, message, AuthenticationConstants.AAD.RESOURCE,
                     StringExtensions.urlFormEncode(mRequest.getResource()));
+        }
+
+        if (!StringExtensions.isNullOrBlank(mRequest.getScope())) {
+            message = String.format(STRING_FORMAT_QUERY_PARAM, message, "scope",
+                    StringExtensions.urlFormEncode(mRequest.getScope()));
         }
 
         // sending redirect uri for the refresh token request if it's provided


### PR DESCRIPTION
In this PR, we've enabled the Scotty flow. Essentially we've enabled SSO via calling acquireTokenByRefreshToken APIs.

Previously ADAL did not store tokens in cache for the acquireTokenByRefreshToken API, however, we have to start saving tokens in cache for this API so that next time when someone calls acquireTokenSilent for this API, then they can get silent SSO.

To achieve this, we've done the following in this API:

- Add optional `scope` parameter to internal Acquire Token Request API
- Pass `openid` scope for AcquireTokenByRefreshToken API
- When the response comes back, save the tokens in cache
