### PR TITLE
Set WebSettings#setAllowFileAccess(false)

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -436,6 +436,8 @@ public class AuthenticationActivity extends DualScreenActivity {
     private void setupWebView() {
         final WebSettings webSettings = mWebView.getSettings();
         webSettings.setJavaScriptEnabled(true);
+        // Explicitly set false, may be true for older devices (ICS MR1 & earlier)
+        webSettings.setAllowUniversalAccessFromFileURLs(false);
         webSettings.setAllowContentAccess(false);
         mWebView.requestFocus(View.FOCUS_DOWN);
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -434,6 +434,7 @@ public class AuthenticationActivity extends DualScreenActivity {
 
     private void setupWebView() {
         mWebView.getSettings().setJavaScriptEnabled(true);
+        mWebView.getSettings().setAllowContentAccess(false);
         mWebView.requestFocus(View.FOCUS_DOWN);
 
         // Set focus to the view for touch event

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -436,8 +436,7 @@ public class AuthenticationActivity extends DualScreenActivity {
     private void setupWebView() {
         final WebSettings webSettings = mWebView.getSettings();
         webSettings.setJavaScriptEnabled(true);
-        // Explicitly set false, may be true for older devices (ICS MR1 & earlier)
-        webSettings.setAllowUniversalAccessFromFileURLs(false);
+        webSettings.setAllowFileAccess(false);
         webSettings.setAllowContentAccess(false);
         mWebView.requestFocus(View.FOCUS_DOWN);
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -43,6 +43,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.webkit.ClientCertRequest;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
@@ -433,8 +434,9 @@ public class AuthenticationActivity extends DualScreenActivity {
     }
 
     private void setupWebView() {
-        mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.getSettings().setAllowContentAccess(false);
+        final WebSettings webSettings = mWebView.getSettings();
+        webSettings.setJavaScriptEnabled(true);
+        webSettings.setAllowContentAccess(false);
         mWebView.requestFocus(View.FOCUS_DOWN);
 
         // Set focus to the view for touch event
@@ -451,10 +453,10 @@ public class AuthenticationActivity extends DualScreenActivity {
 
         });
 
-        mWebView.getSettings().setLoadWithOverviewMode(true);
-        mWebView.getSettings().setDomStorageEnabled(true);
-        mWebView.getSettings().setUseWideViewPort(true);
-        mWebView.getSettings().setBuiltInZoomControls(true);
+        webSettings.setLoadWithOverviewMode(true);
+        webSettings.setDomStorageEnabled(true);
+        webSettings.setUseWideViewPort(true);
+        webSettings.setBuiltInZoomControls(true);
         mWebView.setWebViewClient(new CustomWebViewClient());
         mWebView.setVisibility(View.INVISIBLE);
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -121,16 +121,14 @@ class AuthenticationDialog {
                     mAcquireTokenRequest.onActivityResult(AuthenticationConstants.UIRequest.BROWSER_FLOW,
                             AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
 
-                    if (mHandlerInView != null) {
-                        mHandlerInView.post(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (mDialog != null && mDialog.isShowing()) {
-                                    mDialog.dismiss();
-                                }
+                    mHandlerInView.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (mDialog != null && mDialog.isShowing()) {
+                                mDialog.dismiss();
                             }
-                        });
-                    }
+                        }
+                    });
                     return;
                 }
 
@@ -149,6 +147,7 @@ class AuthenticationDialog {
                         userAgent + AuthenticationConstants.Broker.CLIENT_TLS_NOT_SUPPORTED);
                 userAgent = webSettings.getUserAgentString();
                 Logger.v(TAG + methodName, "UserAgent:" + userAgent);
+
                 // Set focus to the view for touch event
                 mWebView.setOnTouchListener(new View.OnTouchListener() {
                     @Override
@@ -199,9 +198,10 @@ class AuthenticationDialog {
         });
     }
 
-    private void cancelFlow(@Nullable Intent errorIntent) {
+    private void cancelFlow(@Nullable final Intent errorIntent) {
         Logger.i(TAG, "Cancelling dialog", "");
         Intent resultIntent = errorIntent;
+
         int resultCode;
         if (resultIntent == null) {
             resultIntent = new Intent();
@@ -228,8 +228,9 @@ class AuthenticationDialog {
 
     class DialogWebViewClient extends BasicWebViewClient {
 
-        DialogWebViewClient(Context ctx, String stopRedirect,
-                            AuthenticationRequest request) {
+        DialogWebViewClient(final Context ctx,
+                            final String stopRedirect,
+                            final AuthenticationRequest request) {
             super(ctx, stopRedirect, request, null);
         }
 
@@ -253,18 +254,21 @@ class AuthenticationDialog {
             }
         }
 
-        public void sendResponse(int returnCode, Intent responseIntent) {
+        public void sendResponse(int returnCode, final Intent responseIntent) {
             // Close this dialog
             mDialog.dismiss();
-            mAcquireTokenRequest.onActivityResult(AuthenticationConstants.UIRequest.BROWSER_FLOW,
-                    returnCode, responseIntent);
+            mAcquireTokenRequest.onActivityResult(
+                    AuthenticationConstants.UIRequest.BROWSER_FLOW,
+                    returnCode,
+                    responseIntent
+            );
         }
 
         public void postRunnable(Runnable item) {
             mHandlerInView.post(item);
         }
 
-        public void processRedirectUrl(final WebView view, String url) {
+        public void processRedirectUrl(final WebView view, final String url) {
             Intent resultIntent = new Intent();
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, url);
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO, mRequest);
@@ -275,7 +279,7 @@ class AuthenticationDialog {
         }
 
         @Override
-        public void cancelWebViewRequest(@Nullable Intent errorIntent) {
+        public void cancelWebViewRequest(@Nullable final Intent errorIntent) {
             cancelFlow(errorIntent);
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -136,6 +136,7 @@ class AuthenticationDialog {
                 }
 
                 mWebView.getSettings().setJavaScriptEnabled(true);
+                mWebView.getSettings().setAllowContentAccess(false);
                 mWebView.requestFocus(View.FOCUS_DOWN);
                 String userAgent = mWebView.getSettings().getUserAgentString();
                 mWebView.getSettings().setUserAgentString(

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -139,8 +139,7 @@ class AuthenticationDialog {
                 }
 
                 final WebSettings webSettings = mWebView.getSettings();
-                // Explicitly set false, may be true for older devices (ICS MR1 & earlier)
-                webSettings.setAllowUniversalAccessFromFileURLs(false);
+                webSettings.setAllowFileAccess(false);
                 webSettings.setJavaScriptEnabled(true);
                 webSettings.setAllowContentAccess(false);
                 mWebView.requestFocus(View.FOCUS_DOWN);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -139,6 +139,8 @@ class AuthenticationDialog {
                 }
 
                 final WebSettings webSettings = mWebView.getSettings();
+                // Explicitly set false, may be true for older devices (ICS MR1 & earlier)
+                webSettings.setAllowUniversalAccessFromFileURLs(false);
                 webSettings.setJavaScriptEnabled(true);
                 webSettings.setAllowContentAccess(false);
                 mWebView.requestFocus(View.FOCUS_DOWN);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -63,7 +63,7 @@ class AuthenticationDialog {
     private WebView mWebView;
 
     AuthenticationDialog(Handler handler, Context context, final AcquireTokenRequest acquireTokenRequest,
-            AuthenticationRequest request) {
+                         AuthenticationRequest request) {
         mHandlerInView = handler;
         mContext = context;
         mAcquireTokenRequest = acquireTokenRequest;
@@ -96,14 +96,14 @@ class AuthenticationDialog {
                 // using static layout
                 try {
                     webviewInDialog = inflater.inflate(dialogAuthenticationResourceId, null);
-                }catch(InflateException e){
+                } catch (InflateException e) {
                     //This code was added to debug a threading issue; however there could be other cases when this would occur... so leaving in.
                     //NOTE: With the threading issue even though the exception was caught the test app still interrupted (looks like a crash)... presumably because of
                     //The Android System Webview (Chromium) crashed; however the app does continue after Android restarts the system web view
                     Logger.e(TAG, "Failed to inflate authentication dialog", "", ADALError.DEVELOPER_DIALOG_INFLATION_ERROR, e);
                 }
 
-                if(webviewInDialog != null) {
+                if (webviewInDialog != null) {
                     mWebView = (WebView) webviewInDialog.findViewById(getResourceId(
                             "com_microsoft_aad_adal_webView1", "id"));
                 }
@@ -225,7 +225,7 @@ class AuthenticationDialog {
     class DialogWebViewClient extends BasicWebViewClient {
 
         DialogWebViewClient(Context ctx, String stopRedirect,
-                AuthenticationRequest request) {
+                            AuthenticationRequest request) {
             super(ctx, stopRedirect, request, null);
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -62,15 +62,17 @@ class AuthenticationDialog {
 
     private WebView mWebView;
 
-    AuthenticationDialog(Handler handler, Context context, final AcquireTokenRequest acquireTokenRequest,
-                         AuthenticationRequest request) {
+    AuthenticationDialog(final Handler handler,
+                         final Context context,
+                         final AcquireTokenRequest acquireTokenRequest,
+                         final AuthenticationRequest request) {
         mHandlerInView = handler;
         mContext = context;
         mAcquireTokenRequest = acquireTokenRequest;
         mRequest = request;
     }
 
-    private int getResourceId(String name, String type) {
+    private int getResourceId(final String name, final String type) {
         return mContext.getResources().getIdentifier(name, type, mContext.getPackageName());
     }
 
@@ -91,12 +93,11 @@ class AuthenticationDialog {
                 //Need to be sure that the resource id is actually found
                 int dialogAuthenticationResourceId = getResourceId("dialog_authentication", "layout");
 
-
                 View webviewInDialog = null;
                 // using static layout
                 try {
                     webviewInDialog = inflater.inflate(dialogAuthenticationResourceId, null);
-                } catch (InflateException e) {
+                } catch (final InflateException e) {
                     //This code was added to debug a threading issue; however there could be other cases when this would occur... so leaving in.
                     //NOTE: With the threading issue even though the exception was caught the test app still interrupted (looks like a crash)... presumably because of
                     //The Android System Webview (Chromium) crashed; however the app does continue after Android restarts the system web view
@@ -104,9 +105,11 @@ class AuthenticationDialog {
                 }
 
                 if (webviewInDialog != null) {
-                    mWebView = (WebView) webviewInDialog.findViewById(getResourceId(
-                            "com_microsoft_aad_adal_webView1", "id"));
+                    mWebView = (WebView) webviewInDialog.findViewById(
+                            getResourceId("com_microsoft_aad_adal_webView1", "id")
+                    );
                 }
+
                 if (mWebView == null) {
                     Logger.e(
                             TAG + methodName,
@@ -117,6 +120,7 @@ class AuthenticationDialog {
                             mRequest.getRequestId());
                     mAcquireTokenRequest.onActivityResult(AuthenticationConstants.UIRequest.BROWSER_FLOW,
                             AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
+
                     if (mHandlerInView != null) {
                         mHandlerInView.post(new Runnable() {
                             @Override

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationDialog.java
@@ -34,6 +34,7 @@ import android.view.InflateException;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
@@ -135,13 +136,14 @@ class AuthenticationDialog {
                     Logger.d(TAG + methodName, "Hardware acceleration is disabled in WebView");
                 }
 
-                mWebView.getSettings().setJavaScriptEnabled(true);
-                mWebView.getSettings().setAllowContentAccess(false);
+                final WebSettings webSettings = mWebView.getSettings();
+                webSettings.setJavaScriptEnabled(true);
+                webSettings.setAllowContentAccess(false);
                 mWebView.requestFocus(View.FOCUS_DOWN);
-                String userAgent = mWebView.getSettings().getUserAgentString();
-                mWebView.getSettings().setUserAgentString(
+                String userAgent = webSettings.getUserAgentString();
+                webSettings.setUserAgentString(
                         userAgent + AuthenticationConstants.Broker.CLIENT_TLS_NOT_SUPPORTED);
-                userAgent = mWebView.getSettings().getUserAgentString();
+                userAgent = webSettings.getUserAgentString();
                 Logger.v(TAG + methodName, "UserAgent:" + userAgent);
                 // Set focus to the view for touch event
                 mWebView.setOnTouchListener(new View.OnTouchListener() {
@@ -156,10 +158,10 @@ class AuthenticationDialog {
                     }
                 });
 
-                mWebView.getSettings().setLoadWithOverviewMode(true);
-                mWebView.getSettings().setDomStorageEnabled(true);
-                mWebView.getSettings().setUseWideViewPort(true);
-                mWebView.getSettings().setBuiltInZoomControls(true);
+                webSettings.setLoadWithOverviewMode(true);
+                webSettings.setDomStorageEnabled(true);
+                webSettings.setUseWideViewPort(true);
+                webSettings.setBuiltInZoomControls(true);
 
                 try {
                     Oauth2 oauth = new Oauth2(mRequest);


### PR DESCRIPTION
~Closes #1074~

[Related security guidance](https://wiki.sei.cmu.edu/confluence/display/android/DRD02-J.+Do+not+allow+WebView+to+access+sensitive+local+resource+through+file+scheme)

Repurposing this PR - [see documentation from `setAllowFileAccess()`](https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean))
>To prevent possible security issues targeting Build.VERSION_CODES.Q and earlier, you should explicitly set this value to false.