### PR TITLE
Use newly created nullsafe equalsIgnoreCase.

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -727,7 +727,7 @@ class AcquireTokenRequest {
             throw new UsageAuthenticationException(ADALError.DEVELOPER_REDIRECTURI_INVALID, "The redirectUri is null or blank.");
         }
 
-        if (inputUri.equalsIgnoreCase(AuthenticationConstants.Broker.BROKER_REDIRECT_URI)) {
+        if (AuthenticationConstants.Broker.BROKER_REDIRECT_URI.equalsIgnoreCase(inputUri)) {
             // TODO: Clean this up once we migrate all Logger functions to the common one.
             com.microsoft.identity.common.internal.logging.Logger.info(TAG + methodName, "This is a broker redirectUri. Bypass the check.");
             return;

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -45,6 +45,7 @@ import com.microsoft.identity.common.internal.providers.microsoft.azureactivedir
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Configuration;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryTokenResponse;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -443,7 +444,7 @@ class TokenCacheAccessor {
         final List<TokenCacheItem> mrrtsMatchingRequest = new ArrayList<>();
         while (allItems.hasNext()) {
             final TokenCacheItem tokenCacheItem = allItems.next();
-            if (tokenCacheItem.getAuthority().equalsIgnoreCase(mAuthority) && tokenCacheItem.getClientId().equalsIgnoreCase(clientId)
+            if (StringUtil.equalsIgnoreCase(tokenCacheItem.getAuthority(), mAuthority) && StringUtil.equalsIgnoreCase(tokenCacheItem.getClientId(), clientId)
                     && (tokenCacheItem.getIsMultiResourceRefreshToken() || StringExtensions.isNullOrBlank(tokenCacheItem.getResource()))) {
                 mrrtsMatchingRequest.add(tokenCacheItem);
             }


### PR DESCRIPTION
In reference to https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1550

* The only way I can understand the tokenCacheItem to be null is if something mutates the map unsafely.
* Create a nullsafe equalsIgnoreCase utility in common and use it here.


Please make sure every Pull Request has the following information:

* A reference to a related issue in your repository (mandatory)
* A description of the changes proposed in the pull request
* @mentions of the person required for reviewing proposed changes (optional)