### PR TITLE
Add release signing config for adal test app

### DIFF
--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -36,6 +36,16 @@ android {
                 keyPassword "android"
             }
         }
+
+        release {
+            def debugKeyFile = rootProject.file("gradle/debug.keystore")
+            if(debugKeyFile.exists()){
+                storeFile rootProject.file("gradle/debug.keystore")
+                storePassword "android"
+                keyAlias "androiddebugkey"
+                keyPassword "android"
+            }
+        }
     }
 
     flavorDimensions 'main'
@@ -54,6 +64,7 @@ android {
             buildConfigField("String", "REGULAR_REDIDRECT_URI", "\"msauth://com.microsoft.aad.adal.userappwithbroker/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D\"")
         }
         release {
+            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             buildConfigField("String", "REGULAR_REDIDRECT_URI", "\"msauth://com.microsoft.aad.adal.userappwithbroker/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D\"")


### PR DESCRIPTION
This makes it easy to create release builds for ADAL Test App (just uses the debug keystore).

Had committed this long time back (April 2020), just forgot to open a PR 😃