### PR TITLE
add Coverage Report tasks for Adal

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'maven-publish'
 apply from: 'versioning/version_tasks.gradle'
 apply plugin: 'maven'
+apply plugin: 'jacoco'
 
 group = 'com.microsoft.aad'
 
@@ -53,11 +54,12 @@ android {
     }
     buildTypes {
         debug {
-            testCoverageEnabled false
+            testCoverageEnabled true
             debuggable true
 
         }
         release {
+            testCoverageEnabled true
             minifyEnabled false
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
@@ -181,6 +183,31 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
     destinationDir = reporting.file("$project.buildDir/outputs/jar/")
+}
+
+task createAdalJacocoReportTask() {
+    group = "Reporting"
+    description = "Generate AndroidTests Coverage Report tasks for every build Flavour"
+
+    def buildTypes = android.buildTypes.collect { type ->
+        type.name
+    }
+    def productFlavors = android.productFlavors.collect { flavor ->
+        flavor.name
+    }
+    // When no product flavors defined, use empty string
+    if (!productFlavors) productFlavors.add('')
+    productFlavors.each { productFlavorName ->
+        buildTypes.each { buildTypeName ->
+            def sourceName = "${productFlavorName}${buildTypeName.capitalize()}"
+
+            // Tasks for generation AndroidTests Coverage reports for every sourceName
+            task "${sourceName}AdalCoverageReport" (type:JacocoReport, dependsOn: ["create${sourceName.capitalize()}CoverageReport"]) {
+                group = "Reporting"
+                description = "Generate Adal AndroidTests Coverage Reports on the ${sourceName.capitalize()} build."
+            }
+        }
+    }
 }
 
 // For publishing to the remote maven repo.


### PR DESCRIPTION
This Pull Request is related to ITEM - https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1152996

It adds the tasks which generates tasks for all buildFlavour combination to generate AndroidTests Coverage Report.

To generate the Coverage report:
1. First got to root directory, android-complete/
2. Then run -> gradlew createAdalJacocoReportTask
3. Then run -> gradlew localDebugAdalCoverageReport (where local is build and Debug is Flavour, so one can replace it with other build and Flavours)
4. Reports will be available in report folder