### PR TITLE
Add new overload for onReceivedError (deprecation warning)

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -160,7 +160,6 @@ abstract class BasicWebViewClient extends WebViewClient {
                                 final int errorCode,
                                 @NonNull final String description,
                                 @NonNull final String failingUrl) {
-        super.onReceivedError(view, errorCode, description, failingUrl);
         sendErrorResponse(errorCode, description);
     }
 
@@ -169,7 +168,6 @@ abstract class BasicWebViewClient extends WebViewClient {
     public void onReceivedError(@NonNull final WebView view,
                                 @NonNull final WebResourceRequest request,
                                 @NonNull WebResourceError error) {
-        super.onReceivedError(view, request, error);
         sendErrorResponse(error.getErrorCode(), error.getDescription().toString());
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -27,15 +27,19 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.net.http.SslError;
+import android.os.Build;
 import android.text.TextUtils;
 import android.view.View;
 import android.webkit.HttpAuthHandler;
 import android.webkit.SslErrorHandler;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import com.microsoft.aad.adal.ChallengeResponseBuilder.ChallengeResponse;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -152,11 +156,25 @@ abstract class BasicWebViewClient extends WebViewClient {
     }
 
     @Override
-    public void onReceivedError(final WebView view,
+    public void onReceivedError(@NonNull final WebView view,
                                 final int errorCode,
-                                final String description,
-                                final String failingUrl) {
+                                @NonNull final String description,
+                                @NonNull final String failingUrl) {
         super.onReceivedError(view, errorCode, description, failingUrl);
+        sendErrorResponse(errorCode, description);
+    }
+
+    @Override
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    public void onReceivedError(@NonNull final WebView view,
+                                @NonNull final WebResourceRequest request,
+                                @NonNull WebResourceError error) {
+        super.onReceivedError(view, request, error);
+        sendErrorResponse(error.getErrorCode(), error.getDescription().toString());
+    }
+
+    private void sendErrorResponse(final int errorCode,
+                                   @NonNull final String description) {
         showSpinner(false);
 
         com.microsoft.identity.common.internal.logging.Logger.errorPII(

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+vNext
+-------------
+- Adds API23 WebViewClient#onReceivedError overload (#1580)
+
 Version 3.1.2
 -------------
 - Android changes for SDK30, see [the android developers notice](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html).


### PR DESCRIPTION
Impetus:
https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=1226175

Related:
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1197