### PR TITLE
Replaced deprecated versionCode with getLongVersionCode

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -35,6 +35,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.pm.PackageInfoCompat;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
@@ -498,18 +499,18 @@ class AcquireTokenRequest {
      */
     private boolean checkIfBrokerHasLltChanges() {
         PackageManager packageManager = mContext.getPackageManager();
-        int authVersionCode = Integer.MAX_VALUE;
-        int cpVersionCode = Integer.MAX_VALUE;
+        long authVersionCode = Long.MAX_VALUE;
+        long cpVersionCode = Long.MAX_VALUE;
 
         try {
             PackageInfo authPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, 0);
-            authVersionCode = authPackageInfo.versionCode;
+            authVersionCode = PackageInfoCompat.getLongVersionCode(authPackageInfo);
         } catch (PackageManager.NameNotFoundException ignored) {
         }
 
         try {
             PackageInfo cpPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, 0);
-            cpVersionCode = cpPackageInfo.versionCode;
+            cpVersionCode = PackageInfoCompat.getLongVersionCode(cpPackageInfo);
         } catch (PackageManager.NameNotFoundException ignored) {
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -41,6 +41,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
 
+import androidx.core.content.pm.PackageInfoCompat;
+
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
@@ -781,7 +783,7 @@ class BrokerProxy implements IBrokerProxy {
     public String getBrokerAppVersion(final String brokerAppPackageName) throws NameNotFoundException {
         final PackageInfo packageInfo = mContext.getPackageManager().getPackageInfo(brokerAppPackageName, 0);
 
-        return "VersionName=" + packageInfo.versionName + ";VersonCode=" + packageInfo.versionCode + ".";
+        return "VersionName=" + packageInfo.versionName + ";VersonCode=" + PackageInfoCompat.getLongVersionCode(packageInfo) + ".";
     }
 
     private Bundle getBrokerOptions(final AuthenticationRequest request) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v.Next
 - [PATCH] Fixes for MFA setup using Authenticator app.(#1579)
 - [MINOR] Changes to Broker Validation to allow setting whether to trust debug brokers (prod brokers are always trusted).
 - [PATCH] Update common dependency to 3.1.0 (#1583)
+- [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1584)
 
 Version 3.1.2
 -------------


### PR DESCRIPTION
Replaced the deprecated `PackageInfo.versionCode` with `PackageInfoCompat.getLongVersionCode(packageInfo)`. Used PackageInfoCompat for compatibility reasons.

Work Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1226174
Issue: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/issues/863