### PR TITLE
Deprecate AuthenticationSettings#setSecretKey()

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Fiddler is the easiest HTTP tracing tool.  Use the following links to setup it u
 acquireToken method without activity supports dialog prompt.
 
 ### Encryption
+>Important! Providing custom secret keys to ADAL is **deprecated**. Consumers of ADAL are advised to avoid setting their own keys. As no API is currently provided to transition off of custom secret key usage, this API remains available for use only in backwards compatibility scenarios.
 
 ADAL encrypts the tokens and store in SharedPreferences by default. You can look at the StorageHelper class to see the details. ADAL uses AndroidKeyStore for 4.3(API18) and above for secure storage of private keys. If you want to use ADAL for lower SDK versions, you need to **provide secret key at AuthenticationSettings.INSTANCE.setSecretKey**
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationSettings.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationSettings.java
@@ -69,6 +69,7 @@ public enum AuthenticationSettings {
      *
      * @return byte[] secret data
      */
+    @Deprecated
     public byte[] getSecretKeyData() {
         return com.microsoft.identity.common.adal.internal.AuthenticationSettings.INSTANCE.getSecretKeyData();
     }
@@ -79,6 +80,7 @@ public enum AuthenticationSettings {
      *
      * @param rawKey App related key to use in encrypt/decrypt
      */
+    @Deprecated
     public void setSecretKey(byte[] rawKey) {
         com.microsoft.identity.common.adal.internal.AuthenticationSettings.INSTANCE.setSecretKey(rawKey);
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ v.Next
 - [MINOR] Changes to Broker Validation to allow setting whether to trust debug brokers (prod brokers are always trusted).
 - [PATCH] Update common dependency to 3.1.0 (#1583)
 - [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1584)
+- [PATCH] Deprecated ADAL namespaced AuthenticationSettings#setSecretKey(), #getSecretKey()
 
 Version 3.1.2
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@ v.Next
 - [MINOR] Changes to Broker Validation to allow setting whether to trust debug brokers (prod brokers are always trusted).
 - [PATCH] Update common dependency to 3.1.0 (#1583)
 - [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1584)
-- [PATCH] Deprecated ADAL namespaced AuthenticationSettings#setSecretKey(), #getSecretKey()
+- [PATCH] Deprecated ADAL namespaced AuthenticationSettings#setSecretKey(), #getSecretKey() (#1586)
 
 Version 3.1.2
 -------------


### PR DESCRIPTION
Impetus:
- https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1300836

Design PR:
- https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/2638

Summary of changes:
- Updates submodule to `HEAD@dev`
- Deprecates `AuthenticationSettings#setSecretKey` and corollary `#getSecretKey` method
- Updates changelog accordingly
- Updates README to capture guidance change