### PR TITLE
Replaced deprecated PackageInfo.signatures with PackageInfo.signingInfo

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -2296,8 +2296,7 @@ public final class AcquireTokenRequestTest {
                 mockedSignature.toByteArray()
         ).thenReturn(Base64.decode(Util.ENCODED_SIGNATURE, Base64.NO_WRAP));
 
-        final PackageInfo mockedPackageInfo = Mockito.mock(PackageInfo.class);
-        mockedPackageInfo.signatures = new Signature[]{mockedSignature};
+        final PackageInfo mockedPackageInfo = com.microsoft.identity.common.Util.addSignatures(Mockito.mock(PackageInfo.class), new Signature[]{mockedSignature});
 
         final PackageManager mockedPackageManager = Mockito.mock(PackageManager.class);
         when(

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -35,7 +35,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
-import com.microsoft.identity.common.internal.util.SignUtil;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 
 import junit.framework.Assert;
 
@@ -82,7 +82,7 @@ public class AndroidTestHelper {
                 .getInstrumentation()
                 .getContext();
 
-        for (Signature signature : SignUtil.getSignatures(context)) {
+        for (Signature signature : PackageHelper.getSignatures(context)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -82,10 +82,7 @@ public class AndroidTestHelper {
                 .getInstrumentation()
                 .getContext();
 
-        PackageInfo info = context.getPackageManager()
-                .getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNATURES);
-
-        for (Signature signature : SignUtil.getSignatures(info)) {
+        for (Signature signature : SignUtil.getSignatures(context)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -35,6 +35,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
+import com.microsoft.identity.common.internal.util.SignUtil;
 
 import junit.framework.Assert;
 
@@ -84,7 +85,7 @@ public class AndroidTestHelper {
         PackageInfo info = context.getPackageManager()
                 .getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNATURES);
 
-        for (Signature signature : info.signatures) {
+        for (Signature signature : SignUtil.getSignatures(info)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -196,7 +196,7 @@ public final class AuthenticationContextTest {
         AuthenticationSettings.INSTANCE.setUseBroker(false);
         // ADAL is set to this signature for now
         PackageInfo info = getInstrumentation().getContext().getPackageManager()
-                .getPackageInfo(getInstrumentation().getContext().getPackageName(), PackageManager.GET_SIGNATURES);
+                .getPackageInfo(getInstrumentation().getContext().getPackageName(), SignUtil.getPackageManagerFlag());
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -43,6 +43,7 @@ import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.net.HttpUrlConnectionFactory;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 import com.microsoft.identity.common.internal.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
@@ -52,7 +53,6 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
-import com.microsoft.identity.common.internal.util.SignUtil;
 
 import junit.framework.Assert;
 
@@ -196,12 +196,12 @@ public final class AuthenticationContextTest {
         AuthenticationSettings.INSTANCE.setUseBroker(false);
         // ADAL is set to this signature for now
         PackageInfo info = getInstrumentation().getContext().getPackageManager()
-                .getPackageInfo(getInstrumentation().getContext().getPackageName(), SignUtil.getPackageManagerFlag());
+                .getPackageInfo(getInstrumentation().getContext().getPackageName(), PackageHelper.getPackageManagerFlag());
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : SignUtil.getSignatures(info)) {
+        for (Signature signature : PackageHelper.getSignatures(info)) {
             final byte[] testSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(testSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -52,6 +52,7 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
+import com.microsoft.identity.common.internal.util.SignUtil;
 
 import junit.framework.Assert;
 
@@ -200,7 +201,7 @@ public final class AuthenticationContextTest {
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : info.signatures) {
+        for (Signature signature : SignUtil.getSignatures(info)) {
             final byte[] testSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(testSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -389,7 +389,7 @@ public final class BrokerAccountServiceTest {
 
     private SignatureData getSignature(final Context context, final String packageName)
             throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
-        PackageInfo info = PackageHelper.getPackageInfo(context, packageName);
+        PackageInfo info = PackageHelper.getPackageInfo(context.getPackageManager(), packageName);
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -45,7 +45,7 @@ import androidx.test.rule.ServiceTestRule;
 
 import com.microsoft.identity.common.Util;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.internal.util.SignUtil;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 
 import junit.framework.Assert;
 
@@ -389,14 +389,14 @@ public final class BrokerAccountServiceTest {
 
     private SignatureData getSignature(final Context context, final String packageName)
             throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
-        PackageInfo info = SignUtil.getPackageInfo(context, packageName);
+        PackageInfo info = PackageHelper.getPackageInfo(context, packageName);
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
         byte[] signatureByte;
         String signatureTag;
-        for (final Signature signature : SignUtil.getSignatures(info)) {
+        for (final Signature signature : PackageHelper.getSignatures(info)) {
             signatureByte = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(signatureByte);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -43,7 +43,9 @@ import android.util.Pair;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.rule.ServiceTestRule;
 
+import com.microsoft.identity.common.Util;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.util.SignUtil;
 
 import junit.framework.Assert;
 
@@ -377,8 +379,8 @@ public final class BrokerAccountServiceTest {
         Mockito.when(packageManager.checkPermission(Mockito.contains("android.permission.GET_ACCOUNTS"),
                 Mockito.anyString())).thenReturn(PackageManager.PERMISSION_DENIED);
 
-        final PackageInfo packageInfo = Mockito.mock(PackageInfo.class);
-        packageInfo.signatures = new Signature[]{signature};
+        final PackageInfo packageInfo = Util.addSignatures(Mockito.mock(PackageInfo.class), new Signature[]{signature});
+
         Mockito.when(packageManager.getPackageInfo(Mockito.anyString(), Mockito.anyInt())).thenReturn(packageInfo);
 
         Mockito.when(packageManager.checkPermission(Mockito.contains("android.permission.GET_ACCOUNTS"),
@@ -395,7 +397,7 @@ public final class BrokerAccountServiceTest {
         // until it finds the correct one for ADAL broker.
         byte[] signatureByte;
         String signatureTag;
-        for (final Signature signature : info.signatures) {
+        for (final Signature signature : SignUtil.getSignatures(info)) {
             signatureByte = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(signatureByte);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -389,8 +389,7 @@ public final class BrokerAccountServiceTest {
 
     private SignatureData getSignature(final Context context, final String packageName)
             throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
-        PackageInfo info = context.getPackageManager().getPackageInfo(packageName,
-                PackageManager.GET_SIGNATURES);
+        PackageInfo info = SignUtil.getPackageInfo(context, packageName);
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -49,8 +49,10 @@ import android.util.Base64;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.microsoft.identity.common.Util;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
+import com.microsoft.identity.common.internal.util.SignUtil;
 
 import junit.framework.Assert;
 
@@ -134,7 +136,7 @@ public class BrokerProxyTests {
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : info.signatures) {
+        for (Signature signature : SignUtil.getSignatures(info)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);
@@ -1172,10 +1174,8 @@ public class BrokerProxyTests {
     private PackageManager getPackageManager(final Signature signature, final String packageName,
                                              boolean permissionStatus) throws NameNotFoundException {
         PackageManager mockPackage = mock(PackageManager.class);
-        PackageInfo info = new PackageInfo();
-        Signature[] signatures = new Signature[1];
-        signatures[0] = signature;
-        info.signatures = signatures;
+        PackageInfo info = Util.addSignatures(new PackageInfo(), new Signature[]{signature});
+
         when(mockPackage.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)).thenReturn(info);
         when(mockPackage.checkPermission(anyString(), anyString()))
                 .thenReturn(permissionStatus ? PackageManager.PERMISSION_GRANTED : PackageManager.PERMISSION_DENIED);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -52,7 +52,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.microsoft.identity.common.Util;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
-import com.microsoft.identity.common.internal.util.SignUtil;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 
 import junit.framework.Assert;
 
@@ -130,13 +130,13 @@ public class BrokerProxyTests {
                         .getPackageInfo(
                                 androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
                                         .getContext().getPackageName(),
-                                SignUtil.getPackageManagerFlag()
+                                PackageHelper.getPackageManagerFlag()
                         );
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : SignUtil.getSignatures(info)) {
+        for (Signature signature : PackageHelper.getSignatures(info)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);
@@ -1176,7 +1176,7 @@ public class BrokerProxyTests {
         PackageManager mockPackage = mock(PackageManager.class);
         PackageInfo info = Util.addSignatures(new PackageInfo(), new Signature[]{signature});
 
-        when(mockPackage.getPackageInfo(packageName, SignUtil.getPackageManagerFlag())).thenReturn(info);
+        when(mockPackage.getPackageInfo(packageName, PackageHelper.getPackageManagerFlag())).thenReturn(info);
         when(mockPackage.checkPermission(anyString(), anyString()))
                 .thenReturn(permissionStatus ? PackageManager.PERMISSION_GRANTED : PackageManager.PERMISSION_DENIED);
         return mockPackage;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -130,7 +130,7 @@ public class BrokerProxyTests {
                         .getPackageInfo(
                                 androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
                                         .getContext().getPackageName(),
-                                PackageManager.GET_SIGNATURES
+                                SignUtil.getPackageManagerFlag()
                         );
 
         // Broker App can be signed with multiple certificates. It will look
@@ -1176,7 +1176,7 @@ public class BrokerProxyTests {
         PackageManager mockPackage = mock(PackageManager.class);
         PackageInfo info = Util.addSignatures(new PackageInfo(), new Signature[]{signature});
 
-        when(mockPackage.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)).thenReturn(info);
+        when(mockPackage.getPackageInfo(packageName, SignUtil.getPackageManagerFlag())).thenReturn(info);
         when(mockPackage.checkPermission(anyString(), anyString()))
                 .thenReturn(permissionStatus ? PackageManager.PERMISSION_GRANTED : PackageManager.PERMISSION_DENIED);
         return mockPackage;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
@@ -71,14 +71,10 @@ public class HttpDialogTests {
                         .getPath()
         );
 
-        // ADAL is set to this signature for now
-        PackageInfo info = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(),
-                PackageManager.GET_SIGNATURES);
-
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : SignUtil.getSignatures(info)) {
+        for (Signature signature : SignUtil.getSignatures(mContext)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
@@ -33,6 +33,7 @@ import android.util.Base64;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.util.SignUtil;
 
 import org.junit.Before;
 
@@ -77,7 +78,7 @@ public class HttpDialogTests {
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : info.signatures) {
+        for (Signature signature : SignUtil.getSignatures(info)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
@@ -33,7 +33,7 @@ import android.util.Base64;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.internal.util.SignUtil;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 
 import org.junit.Before;
 
@@ -74,7 +74,7 @@ public class HttpDialogTests {
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (Signature signature : SignUtil.getSignatures(mContext)) {
+        for (Signature signature : PackageHelper.getSignatures(mContext)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
@@ -93,14 +93,11 @@ public class PackageHelperTests {
 
         AuthenticationSettings.INSTANCE.setBrokerPackageName("invalid_do_not_switch");
         AuthenticationSettings.INSTANCE.setBrokerSignature("invalid_do_not_switch");
-        // ADAL is set to this signature for now
-        PackageInfo info = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(),
-                PackageManager.GET_SIGNATURES);
 
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (final Signature signature : SignUtil.getSignatures(info)) {
+        for (final Signature signature : SignUtil.getSignatures(mContext)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);
@@ -231,7 +228,7 @@ public class PackageHelperTests {
         when(
                 mockPackage.getPackageInfo(
                         packageName,
-                        PackageManager.GET_SIGNATURES
+                        SignUtil.getPackageManagerFlag()
                 )
         ).thenReturn(info);
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
@@ -34,7 +34,9 @@ import android.util.Base64;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.microsoft.identity.common.Util;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.util.SignUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -98,7 +100,7 @@ public class PackageHelperTests {
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (final Signature signature : info.signatures) {
+        for (final Signature signature : SignUtil.getSignatures(info)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);
@@ -221,11 +223,7 @@ public class PackageHelperTests {
                                              final String packageName,
                                              final int callingUID) throws NameNotFoundException {
         final PackageManager mockPackage = mock(PackageManager.class);
-        final PackageInfo info = new PackageInfo();
-
-        final Signature[] signatures = new Signature[1];
-        signatures[0] = signature;
-        info.signatures = signatures;
+        final PackageInfo info = Util.addSignatures(new PackageInfo(), new Signature[]{signature});
 
         final ApplicationInfo appInfo = new ApplicationInfo();
         appInfo.name = packageName;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/PackageHelperTests.java
@@ -36,7 +36,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.microsoft.identity.common.Util;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.internal.util.SignUtil;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 
 import org.junit.After;
 import org.junit.Before;
@@ -97,7 +97,7 @@ public class PackageHelperTests {
         // Broker App can be signed with multiple certificates. It will look
         // all of them
         // until it finds the correct one for ADAL broker.
-        for (final Signature signature : SignUtil.getSignatures(mContext)) {
+        for (final Signature signature : PackageHelper.getSignatures(mContext)) {
             mTestSignature = signature.toByteArray();
             MessageDigest md = MessageDigest.getInstance("SHA");
             md.update(mTestSignature);
@@ -228,7 +228,7 @@ public class PackageHelperTests {
         when(
                 mockPackage.getPackageInfo(
                         packageName,
-                        SignUtil.getPackageManagerFlag()
+                        PackageHelper.getPackageManagerFlag()
                 )
         ).thenReturn(info);
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TelemetryTest.java
@@ -107,8 +107,7 @@ public class TelemetryTest {
         when(mockedSignature.toByteArray()).thenReturn(Base64.decode(
                 Util.ENCODED_SIGNATURE, Base64.NO_WRAP));
 
-        final PackageInfo mockedPackageInfo = Mockito.mock(PackageInfo.class);
-        mockedPackageInfo.signatures = new Signature[]{mockedSignature};
+        final PackageInfo mockedPackageInfo = com.microsoft.identity.common.Util.addSignatures(Mockito.mock(PackageInfo.class), new Signature[]{mockedSignature});
 
         final PackageManager mockedPackageManager = Mockito.mock(PackageManager.class);
         when(mockedPackageManager.getPackageInfo(Mockito.anyString(), anyInt())).thenReturn(mockedPackageInfo);

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -35,6 +35,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.pm.PackageInfoCompat;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
@@ -497,27 +498,27 @@ class AcquireTokenRequest {
      * and retain the old behavior.
      */
     private boolean checkIfBrokerHasLltChanges() {
-        PackageManager packageManager = mContext.getPackageManager();
-        int authVersionCode = Integer.MAX_VALUE;
-        int cpVersionCode = Integer.MAX_VALUE;
-        int brokerHostVersionCode = Integer.MAX_VALUE;
+        final PackageManager packageManager = mContext.getPackageManager();
+        long authVersionCode = Long.MAX_VALUE;
+        long cpVersionCode = Long.MAX_VALUE;
+        long brokerHostVersionCode = Integer.MAX_VALUE;
 
         try {
-            PackageInfo authPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, 0);
-            authVersionCode = authPackageInfo.versionCode;
-        } catch (PackageManager.NameNotFoundException ignored) {
+            final PackageInfo authPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, 0);
+            authVersionCode = PackageInfoCompat.getLongVersionCode(authPackageInfo);
+        } catch (final PackageManager.NameNotFoundException ignored) {
         }
 
         try {
-            PackageInfo cpPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, 0);
-            cpVersionCode = cpPackageInfo.versionCode;
-        } catch (PackageManager.NameNotFoundException ignored) {
+            final PackageInfo cpPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME, 0);
+            cpVersionCode = PackageInfoCompat.getLongVersionCode(cpPackageInfo);
+        } catch (final PackageManager.NameNotFoundException ignored) {
         }
 
         try {
-            PackageInfo brokerHostPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.BROKER_HOST_APP_PACKAGE_NAME, 0);
-            brokerHostVersionCode = brokerHostPackageInfo.versionCode;
-        } catch (PackageManager.NameNotFoundException ignored) {
+            final PackageInfo brokerHostPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.BROKER_HOST_APP_PACKAGE_NAME, 0);
+            brokerHostVersionCode = PackageInfoCompat.getLongVersionCode(brokerHostPackageInfo);
+        } catch (final PackageManager.NameNotFoundException ignored) {
         }
 
         return authVersionCode >= AUTHENTICATOR_LLT_VERSION_CODE
@@ -528,8 +529,8 @@ class AcquireTokenRequest {
 
     /**
      * Handles the silent flow. Will always lookup local cache. If there is a valid AT in local cache, will use it. If
-     * AT in local cache is already expired, will try RT in the local cache. If RT requst failed, then use saml assertion passed in the 
-     * request to acquire RT and AT. If this too fails and if we can switch to broker for auth, 
+     * AT in local cache is already expired, will try RT in the local cache. If RT requst failed, then use saml assertion passed in the
+     * request to acquire RT and AT. If this too fails and if we can switch to broker for auth,
      * will switch to broker for authentication.
      */
     private AuthenticationResult acquireTokenSilentFlow(final AuthenticationRequest authenticationRequest)
@@ -591,7 +592,7 @@ class AcquireTokenRequest {
         Logger.v(TAG + methodName, "Try to silently get token using SAML Assertion.");
         final AcquireTokenSilentHandler acquireTokenSilentHandler = new AcquireTokenSilentHandler(mContext,
                 authenticationRequest, mTokenCacheAccessor);
-        
+
         return acquireTokenSilentHandler.getAccessTokenUsingAssertion();
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -41,6 +41,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
 
+import androidx.core.content.pm.PackageInfoCompat;
+
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
@@ -781,7 +783,7 @@ class BrokerProxy implements IBrokerProxy {
     public String getBrokerAppVersion(final String brokerAppPackageName) throws NameNotFoundException {
         final PackageInfo packageInfo = mContext.getPackageManager().getPackageInfo(brokerAppPackageName, 0);
 
-        return "VersionName=" + packageInfo.versionName + ";VersonCode=" + packageInfo.versionCode + ".";
+        return "VersionName=" + packageInfo.versionName + ";VersonCode=" + PackageInfoCompat.getLongVersionCode(packageInfo) + ".";
     }
 
     private Bundle getBrokerOptions(final AuthenticationRequest request) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ v.Next
 - [MINOR] Changes to Broker Validation to allow setting whether to trust debug brokers (prod brokers are always trusted).
 - [PATCH] Update common dependency to 3.1.0 (#1583)
 - [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1584)
+- [PATCH] Fixes deprecated PackageInfo.signatures (#1587)
 
 Version 3.1.2
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ v.Next
 - [PATCH] Fixes for MFA setup using Authenticator app.(#1579)
 - [MINOR] Changes to Broker Validation to allow setting whether to trust debug brokers (prod brokers are always trusted).
 - [PATCH] Update common dependency to 3.1.0 (#1583)
+- [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1584)
 
 Version 3.1.2
 -------------


### PR DESCRIPTION
Replaced the deprecated `PackageInfo.signatures` with `PackageInfo.signingInfo`. Created a utility method across code and tests for compatibility reasons.

Work Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1226178
Issue: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/issues/851