### PR TITLE
Add the ability to control the userappwithbroker's application id

### DIFF
--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -20,12 +20,26 @@ def adalVersion = "3.1.2"
 def commonVersion = "0.0.+"
 
 if (project.hasProperty("distAdalVersion")) {
+    println "Overriding adal version to dist property " + distAdalVersion
     adalVersion = distAdalVersion
 }
 
+println "Building with adal " + adalVersion
+
 if (project.hasProperty("distCommonVersion")) {
+    println "Overriding common version to dist property " + distCommonVersion
     commonVersion = distCommonVersion
 }
+
+println "Building with common " + commonVersion
+
+def destApplicationId = "com.microsoft.aad.adal.userappwithbroker"
+if (project.hasProperty("buildApplicationId")) {
+    println "Overriding applicationId to " + buildApplicationId
+    destApplicationId = buildApplicationId
+}
+
+println "Using application Id " + destApplicationId
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -38,9 +52,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+   
+
     defaultConfig {
         multiDexEnabled true
-        applicationId "com.microsoft.aad.adal.userappwithbroker"
+        applicationId destApplicationId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
     }

--- a/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
+++ b/userappwithbroker/src/main/java/com/microsoft/aad/adal/example/userappwithbroker/Constants.java
@@ -96,6 +96,10 @@ public class Constants {
         Regular(BuildConfig.REGULAR_REDIDRECT_URI),
         Regular2("msauth://com.microsoft.aad.adal.userappwithbroker/L8kGVGYgNOaxbhn9Y7vR%2F6LIEG8%3D"),
         Mooncake("msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D"),
+        Mooncake1( "msauth://com.microsoft.aad.adal.userappwithbroker/QK0hWtPIQviyU3IX8AhunaS0IY4%3D"),
+        Mooncake2( "msauth://com.microsoft.aad.adal.userappwithbroker/L8kGVGYgNOaxbhn9Y7vR%2F6LIEG8%3D"),
+        Mooncake3( "msauth://com.microsoft.aad.adal.userappwithbroker/IcB5PxIyvbLkbFVtBI%2FitkW%2Fejk%3D"),
+        Mooncake4( "msauth://com.microsoft.aad.adal.userappwithbroker/2%2BQqCWt1ilKg0IrfKT6CkdMpPqk%3D"),
         Broker("urn:ietf:wg:oauth:2.0:oob"),
         LABS("msauth://com.microsoft.aad.adal.userappwithbroker/2%2BQqCWt1ilKg0IrfKT6CkdMpPqk%3D"),
         LABSDEBUG("msauth://com.microsoft.aad.adal.userappwithbroker/1wIqXSqBj7w%2bh11ZifsnqwgyKrY%3d");


### PR DESCRIPTION
Since we have to override the version of the client id to run https://identitydivision.visualstudio.com/IDDP/_workitems/edit/345163 make it easier to to:

You can produce builds with different client ids by:

```
gradle userappwithbroker:assembleDistDebug -PbuildApplicationId=com.msft.identity.client.sample.local
```