### PR TITLE
Adding CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Each line is a file pattern followed by one or more owners.
+# Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+*    @AzureAD/androididentity


### PR DESCRIPTION
Setting @AzureAD/androididentity as the default owner for all the code in this repository.
More details about github code owners and CODEOWNERS file: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
