### PR TITLE
Disregard errors in iframe loading

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -169,7 +169,15 @@ abstract class BasicWebViewClient extends WebViewClient {
     public void onReceivedError(@NonNull final WebView view,
                                 @NonNull final WebResourceRequest request,
                                 @NonNull WebResourceError error) {
-        sendErrorResponse(error.getErrorCode(), error.getDescription().toString());
+        final String methodName = "onReceivedError (23)";
+        final boolean isForMainFrame = request.isForMainFrame();
+
+        com.microsoft.identity.common.logging.Logger.warn(TAG + methodName, "WebResourceError - isForMainFrame? " + isForMainFrame);
+        com.microsoft.identity.common.logging.Logger.warnPII(TAG + methodName, "Failing url: " + request.getUrl());
+
+        if (request.isForMainFrame()) {
+            sendErrorResponse(error.getErrorCode(), error.getDescription().toString());
+        }
     }
 
     private void sendErrorResponse(final int errorCode,

--- a/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BasicWebViewClient.java
@@ -175,7 +175,7 @@ abstract class BasicWebViewClient extends WebViewClient {
         com.microsoft.identity.common.logging.Logger.warn(TAG + methodName, "WebResourceError - isForMainFrame? " + isForMainFrame);
         com.microsoft.identity.common.logging.Logger.warnPII(TAG + methodName, "Failing url: " + request.getUrl());
 
-        if (request.isForMainFrame()) {
+        if (isForMainFrame) {
             sendErrorResponse(error.getErrorCode(), error.getDescription().toString());
         }
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ v.Next
 - [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1584)
 - [PATCH] Fixes deprecated PackageInfo.signatures (#1587)
 - [PATCH] Deprecated ADAL namespaced AuthenticationSettings#setSecretKey(), #getSecretKey() (#1586)
+- [PATCH] Disregard pageload errors for the non-primary frame during interactive auth (#1603)
 - Picks up common@3.2.0
 
 Version 3.1.2


### PR DESCRIPTION
Impetus
- https://portal.microsofticm.com/imp/v3/incidents/details/239658713/home

Summary:
Suppose an ADFS sign-in page is customized to include an iframe of custom content; page load errors inside of that frame should not prevent a user from being able to sign-in. This change drops events from the "non-primary frame".

This change needed only on the API 23 overload, as the default behavior prior to this override was to drop these events.

Testing:
Manual testing against a real-life ADFS instance with this problem. See above linked IcM.

Related PR in Common:
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1357