### PR TITLE
Enable Auth Client custom build plugin for Adal

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -1,9 +1,22 @@
-apply plugin: 'com.android.library'
-apply plugin: 'pmd'
-apply plugin: 'checkstyle'
-apply plugin: 'maven-publish'
+plugins {
+    id 'com.microsoft.identity.buildsystem' version '0.1.0'
+    id 'com.android.library'
+    id 'pmd'
+    id 'checkstyle'
+    id 'maven-publish'
+}
+
 apply from: 'versioning/version_tasks.gradle'
-apply plugin: 'maven'
+
+def desugarCode = false
+
+if(project.hasProperty("sugar")){
+    desugarCode = sugar.toBoolean()
+}
+
+buildSystem {
+    desugar = desugarCode
+}
 
 group = 'com.microsoft.aad'
 
@@ -28,14 +41,6 @@ allprojects {
             }
         }
         mavenCentral()
-    }
-}
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
     }
 }
 


### PR DESCRIPTION
Enabling Auth Client Custom Build Plugin for Adal library. This will allow us to enable spotBugs task for any changes in Adal
I have also updated the syntax for how we apply plugin. By using plugins  block as we re doing in msal and common libs already, and it seems to be the recommended way https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application

Verifications done:
Verified running the spotbugs task locally, it ran successfully.


