### PR TITLE
Accommodate changes due to common4j migration

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -39,9 +39,10 @@ import androidx.core.content.pm.PackageInfoCompat;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
-import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAuthorizationErrorResponse;
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationErrorResponse;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationErrorResponse;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;

--- a/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
+++ b/adal/src/telemetry/java/com/microsoft/aad/adal/TelemetryUtils.java
@@ -55,14 +55,14 @@ public final class TelemetryUtils {
     }
 
     public static class CliTelemInfo
-            extends com.microsoft.identity.common.internal.telemetry.CliTelemInfo {
+            extends com.microsoft.identity.common.java.telemetry.CliTelemInfo {
         // Looking for this class? It's moved! (See parent class)
 
         public CliTelemInfo() {
             super();
         }
 
-        private CliTelemInfo(final com.microsoft.identity.common.internal.telemetry.CliTelemInfo in) {
+        private CliTelemInfo(final com.microsoft.identity.common.java.telemetry.CliTelemInfo in) {
             super(in);
         }
 
@@ -89,7 +89,7 @@ public final class TelemetryUtils {
 
     public static CliTelemInfo parseXMsCliTelemHeader(final String headerValue) {
         return new CliTelemInfo(
-                com.microsoft.identity.common.internal.telemetry.CliTelemInfo.fromXMsCliTelemHeader(
+                com.microsoft.identity.common.java.telemetry.CliTelemInfo.fromXMsCliTelemHeader(
                         headerValue
                 )
         );


### PR DESCRIPTION
Related PR: AzureAD/microsoft-authentication-library-common-for-android#1424

We move classes around, we need to update here too.
