### PR TITLE
run credscan and Polichek  as its own pipeline

### DIFF
--- a/azure-pipelines/pull-request-validation/credscan.yml
+++ b/azure-pipelines/pull-request-validation/credscan.yml
@@ -19,15 +19,5 @@ resources:
     endpoint: ANDROID_GITHUB
 
 jobs:
-- job: Phase_1
-  displayName: Phase 1
-  cancelTimeoutInMinutes: 1
-  pool:
-    name: Hosted Windows 2019 with VS2019
-  steps:
-  - checkout: self
-    clean: true
-    submodules: recursive
-    persistCredentials: True
-  - template: azure-pipelines/templates/steps/credscan-policheck.yml@common
+- template: azure-pipelines/templates/steps/credscan-policheck.yml@common
 ...

--- a/azure-pipelines/pull-request-validation/credscan.yml
+++ b/azure-pipelines/pull-request-validation/credscan.yml
@@ -1,0 +1,33 @@
+# File: azure-pipelines\pull-request-validation\credscan.yml
+# Description: Run Credscan and PoliCheck
+name: $(date:yyyyMMdd)$(rev:.r)
+
+trigger:
+  branches:
+    include:
+    - dev
+    - master
+    - release/*
+  batch: True
+
+resources:
+  repositories:
+  - repository: common
+    type: github
+    name: AzureAD/microsoft-authentication-library-common-for-android
+    ref: dev
+    endpoint: ANDROID_GITHUB
+
+jobs:
+- job: Phase_1
+  displayName: Phase 1
+  cancelTimeoutInMinutes: 1
+  pool:
+    name: Hosted Windows 2019 with VS2019
+  steps:
+  - checkout: self
+    clean: true
+    submodules: recursive
+    persistCredentials: True
+  - template: azure-pipelines/templates/steps/credscan-policheck.yml@common
+...

--- a/azure-pipelines/pull-request-validation/pr-adal.yml
+++ b/azure-pipelines/pull-request-validation/pr-adal.yml
@@ -22,8 +22,8 @@ resources:
     endpoint: ANDROID_GITHUB
 
 jobs:
-- job: Phase_1
-  displayName: Phase 1
+- job: build_test
+  displayName: Build & Test
   cancelTimeoutInMinutes: 1
   pool:
     name: Hosted Windows 2019 with VS2019

--- a/azure-pipelines/pull-request-validation/pr-adal.yml
+++ b/azure-pipelines/pull-request-validation/pr-adal.yml
@@ -32,9 +32,6 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
-  - template: azure-pipelines/templates/steps/credscan-policheck.yml@common
-    parameters:
-      policheckCmdLineArgsDir: adal
   - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: Gradle@1
     name: Gradle1
@@ -47,6 +44,4 @@ jobs:
   - template: azure-pipelines/templates/steps/spotbugs.yml@common
     parameters:
       project: adal
-  - task: ComponentGovernanceComponentDetection@0
-    displayName: Component Detection
 ...

--- a/azure-pipelines/vsts-releases/adal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/adal-vsts-release.yml
@@ -9,17 +9,6 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
 pr: none
 
-resources:
-  repositories:
-  - repository: self
-    type: git
-    ref: master
-  - repository: common
-    type: github
-    name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: dev
-    endpoint: ANDROID_GITHUB
-
 jobs:
 - job: Phase_1
   displayName: Phase 1
@@ -36,9 +25,6 @@ jobs:
     inputs:
       filename: echo
       arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN]$(mvnAccessToken)'
-  - template: azure-pipelines/templates/steps/credscan-policheck.yml@common
-    parameters:
-      policheckCmdLineArgsDir: adal
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble Release

--- a/azure-pipelines/vsts-releases/adal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/adal-vsts-release.yml
@@ -10,8 +10,8 @@ trigger: none
 pr: none
 
 jobs:
-- job: Phase_1
-  displayName: Phase 1
+- job: build_publish
+  displayName: Publish adal to internal feed
   cancelTimeoutInMinutes: 1
   pool:
     name: Hosted Windows 2019 with VS2019


### PR DESCRIPTION
The CredScan task is a repo wide assessment, it doesn't need to run as a task under each pipeline within a repo it can run once as its own pipeline...once per each repo.

Update credscan, policheck and publish results to v3

Related PR:
AzureAD/microsoft-authentication-library-common-for-android/pull/1437
AzureAD/ad-accounts-for-android/pull/1609
AzureAD/microsoft-authentication-library-for-android#1449
Pipeline
https://identitydivision.visualstudio.com/Engineering/_build?definitionScope=%5CAndroid%5CPull%20Request%20Validations%5CCredScan