### PR TITLE
Release Work for ADAL@3.1.3

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.0.6', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:3.4.4-RC1") {
+    distApi("com.microsoft.identity:common:3.4.5-RC1") {
         transitive = false
     }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.0.6', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:3.0.6") {
+    distApi("com.microsoft.identity:common:3.4.4-RC1") {
         transitive = false
     }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -55,12 +55,13 @@ android {
         debug {
             testCoverageEnabled false
             debuggable true
-
+            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
         }
         release {
             minifyEnabled false
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
+            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
         }
     }
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenRequestTest.java
@@ -1324,7 +1324,7 @@ public final class AcquireTokenRequestTest {
                         + mockContext.getPackageName()
                         + "/"
                         + URLEncoder.encode(
-                        AuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE,
+                        AuthenticationConstants.Broker.COMPANY_PORTAL_APP_RELEASE_SIGNATURE,
                         AuthenticationConstants.ENCODING_UTF8
                 );
 
@@ -2379,7 +2379,7 @@ public final class AcquireTokenRequestTest {
 
     private String getEncodedTestingSignature() throws NoSuchAlgorithmException {
         final MessageDigest md = MessageDigest.getInstance("SHA");
-        md.update(Base64.decode(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE, Base64.NO_WRAP));
+        md.update(Base64.decode(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_RELEASE_SIGNATURE, Base64.NO_WRAP));
         final byte[] testingSignature = md.digest();
         return Base64.encodeToString(testingSignature, Base64.NO_WRAP);
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BasicWebViewClientTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BasicWebViewClientTests.java
@@ -24,8 +24,6 @@ package com.microsoft.aad.adal;
 
 import android.content.Context;
 import android.content.Intent;
-import android.net.http.SslError;
-import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
@@ -40,14 +38,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -49,6 +49,7 @@ import junit.framework.Assert;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -105,7 +106,7 @@ public final class BrokerAccountServiceTest {
 
     @After
     public void tearDown() throws Exception {
-        AuthenticationSettings.INSTANCE.setBrokerSignature(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE);
+        AuthenticationSettings.INSTANCE.setBrokerSignature(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_RELEASE_SIGNATURE);
         AuthenticationSettings.INSTANCE.setUseBroker(false);
     }
 
@@ -302,6 +303,7 @@ public final class BrokerAccountServiceTest {
      * {@link BrokerProxy#canSwitchToBroker(String)} will return true.
      */
     @Test
+    @Ignore
     public void testBrokerProxySwitchBrokerPermissionNotGranted()
             throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
         final Context context = getMockContext();
@@ -324,6 +326,7 @@ public final class BrokerAccountServiceTest {
      * {@link BrokerProxy#canSwitchToBroker(String)} will return false if there is no valid broker app exists.
      */
     @Test
+    @Ignore
     public void testBrokerProxySwitchToBrokerInvalidBrokerPackageName()
             throws PackageManager.NameNotFoundException, NoSuchAlgorithmException {
         final Context context = getMockContext();

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -56,6 +56,7 @@ import junit.framework.Assert;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
@@ -224,6 +225,7 @@ public class BrokerProxyTests {
     }
 
     @Test
+    @Ignore
     public void testCanSwitchToBrokerNoAccountChooserActivity() throws NameNotFoundException {
         String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
         String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
@@ -246,6 +248,7 @@ public class BrokerProxyTests {
     }
 
     @Test
+    @Ignore
     public void testCanSwitchToBrokerWithAccountChooser() throws NameNotFoundException {
         String authenticatorType = AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
         String brokerPackage = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
@@ -354,6 +357,7 @@ public class BrokerProxyTests {
     }
 
     @Test
+    @Ignore
     public void testCanSwitchToBrokerMissingBrokerPermission()
             throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
             IllegalAccessException, InvocationTargetException, NoSuchFieldException, NameNotFoundException {

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
@@ -299,12 +299,18 @@ public class TokenCacheAccessorTests {
         assertEquals(MOONCAKE_AUTHORITY, mTokenCacheAccessor.getAuthorityUrlWithPreferredCache());
     }
 
+    /**
+     * This test asserts that the MSAL cache is updated by writes to the ADAL cache.
+     * The ADAL class {@link TokenCacheAccessor} receives an instance of the cache supplied by the host
+     * app. If the caller has set an instance of {@link DefaultTokenCacheStore}, then ADAL should write a
+     * matching ID, AT, and Account to the MSAL cache for migration/SSO purposes.
+     */
     @Test
     public void testMsalCacheIsUpdated() throws ServiceException, MalformedURLException {
-        // First assert the cache initialization is using the default authority
+        // Assert our cache is configured for WW
         assertEquals(WORLDWIDE_AUTHORITY, mTokenCacheAccessor.getAuthorityUrlWithPreferredCache());
 
-        // Create a Request and Result that use differing authorities
+        // Create a request to WW
         final AuthenticationRequest request =
                 new AuthenticationRequest(
                         WORLDWIDE_AUTHORITY,

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
@@ -69,6 +69,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -292,7 +293,7 @@ public class TokenCacheAccessorTests {
         result.setAuthority(MOONCAKE_AUTHORITY);
         result.setClientInfo(new ClientInfo(MOCK_CLIENT_INFO));
         result.setResponseReceived(System.currentTimeMillis());
-        result.setExpiresIn(System.currentTimeMillis());
+        result.setExpiresIn(TimeUnit.HOURS.toSeconds(1));
 
         // Save this to the cache
         mTokenCacheAccessor.updateTokenCache(request, result);
@@ -346,7 +347,7 @@ public class TokenCacheAccessorTests {
         result.setAuthority(WORLDWIDE_AUTHORITY);
         result.setClientInfo(new ClientInfo(MOCK_CLIENT_INFO));
         result.setResponseReceived(System.currentTimeMillis());
-        result.setExpiresIn(System.currentTimeMillis());
+        result.setExpiresIn(TimeUnit.HOURS.toSeconds(1));
 
         // Save this to the cache
         mTokenCacheAccessor.updateTokenCache(request, result);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
@@ -96,6 +96,26 @@ public class TokenCacheAccessorTests {
     private static final String MOCK_UTID = "mock_utid";
     private static final String MOCK_CLIENT_INFO = createRawClientInfo(MOCK_UID, MOCK_UTID);
 
+    public static final String REDIRECT = "https://localhost:2000";
+    public static final String WW_MSO = "login.microsoftonline.com";
+    public static final String WW_PREFERRED_CACHE = "login.windows.net";
+    public static final String LOGIN_MICROSOFTONLINE_COM = "login.microsoftonline.com";
+    public static final String LOGIN_WINDOWS_NET = "login.windows.net";
+    public static final String LOGIN_MICROSOFT_COM = "login.microsoft.com";
+    public static final String STS_WINDOWS_NET = "sts.windows.net";
+    public static final String LOGIN_PARTNER_MICROSOFTONLINE_CN = "login.partner.microsoftonline.cn";
+    public static final String LOGIN_CHINACLOUDAPI_CN = "login.chinacloudapi.cn";
+
+    public static final String RESOURCE = "a_resource";
+    public static final String CLIENT = "12345";
+    public static final String MOCK_AT = "mock_at";
+    public static final String MOCK_RT = "mock_rt";
+    public static final String USERID_1 = "userid1";
+    public static final String GIVEN_NAME = "givenName";
+    public static final String FAMILY_NAME = "familyName";
+    public static final String IDENTITY = "identity";
+    public static final String TID = "tid";
+
     static String createRawClientInfo(final String uid, final String utid) {
         final String claims = "{\"uid\":\"" + uid + "\",\"utid\":\"" + utid + "\"}";
 
@@ -209,13 +229,12 @@ public class TokenCacheAccessorTests {
         // First assert the cache initialization is using the default authority
         assertEquals(WORLDWIDE_AUTHORITY, mTokenCacheAccessor.getAuthorityUrlWithPreferredCache());
 
-        // Create a Request and Result that use differing authorities
         final AuthenticationRequest request =
                 new AuthenticationRequest(
                         WORLDWIDE_AUTHORITY,
-                        "a_resource",
-                        "12345",
-                        "https://localhost:2000",
+                        RESOURCE,
+                        CLIENT,
+                        REDIRECT,
                         "",
                         PromptBehavior.Auto,
                         "",
@@ -224,21 +243,21 @@ public class TokenCacheAccessorTests {
                         null
                 );
         final AuthenticationResult result = new AuthenticationResult(
-                "mock_at",
-                "mock_rt",
+                MOCK_AT,
+                MOCK_RT,
                 new Date(System.currentTimeMillis() + (3600 * 1000)),
                 false,
                 new UserInfo(
-                        "userid1",
-                        "givenName",
-                        "familyName",
-                        "identity",
-                        "userid1"
+                        USERID_1,
+                        GIVEN_NAME,
+                        FAMILY_NAME,
+                        IDENTITY,
+                        USERID_1
                 ),
-                "tid",
+                TID,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
                 null,
-                "12345"
+                CLIENT
         );
 
         result.setAuthority(MOONCAKE_AUTHORITY);
@@ -250,13 +269,13 @@ public class TokenCacheAccessorTests {
         AzureActiveDirectory.putCloud(
                 new URL(WORLDWIDE_AUTHORITY).getHost(),
                 new AzureActiveDirectoryCloud(
-                        "login.microsoftonline.com",
-                        "login.windows.net",
+                        WW_MSO,
+                        WW_PREFERRED_CACHE,
                         Arrays.asList(
-                                "login.microsoftonline.com",
-                                "login.windows.net",
-                                "login.microsoft.com",
-                                "sts.windows.net"
+                                LOGIN_MICROSOFTONLINE_COM,
+                                LOGIN_WINDOWS_NET,
+                                LOGIN_MICROSOFT_COM,
+                                STS_WINDOWS_NET
                         )
                 )
         );
@@ -264,11 +283,11 @@ public class TokenCacheAccessorTests {
         AzureActiveDirectory.putCloud(
                 new URL(MOONCAKE_AUTHORITY).getHost(),
                 new AzureActiveDirectoryCloud(
-                        "login.partner.microsoftonline.cn",
-                        "login.partner.microsoftonline.cn",
+                        LOGIN_PARTNER_MICROSOFTONLINE_CN,
+                        LOGIN_PARTNER_MICROSOFTONLINE_CN,
                         Arrays.asList(
-                                "login.partner.microsoftonline.cn",
-                                "login.chinacloudapi.cn"
+                                LOGIN_PARTNER_MICROSOFTONLINE_CN,
+                                LOGIN_CHINACLOUDAPI_CN
                         )
                 )
         );
@@ -288,9 +307,9 @@ public class TokenCacheAccessorTests {
         final AuthenticationRequest request =
                 new AuthenticationRequest(
                         WORLDWIDE_AUTHORITY,
-                        "a_resource",
-                        "12345",
-                        "https://localhost:2000",
+                        RESOURCE,
+                        CLIENT,
+                        REDIRECT,
                         "",
                         PromptBehavior.Auto,
                         "",
@@ -299,21 +318,21 @@ public class TokenCacheAccessorTests {
                         null
                 );
         final AuthenticationResult result = new AuthenticationResult(
-                "mock_at",
-                "mock_rt",
+                MOCK_AT,
+                MOCK_RT,
                 new Date(System.currentTimeMillis() + (3600 * 1000)),
                 false,
                 new UserInfo(
-                        "userid1",
-                        "givenName",
-                        "familyName",
-                        "identity",
-                        "userid1"
+                        USERID_1,
+                        GIVEN_NAME,
+                        FAMILY_NAME,
+                        IDENTITY,
+                        USERID_1
                 ),
-                "tid",
+                TID,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
                 null,
-                "12345"
+                CLIENT
         );
 
         result.setAuthority(WORLDWIDE_AUTHORITY);
@@ -325,13 +344,13 @@ public class TokenCacheAccessorTests {
         AzureActiveDirectory.putCloud(
                 new URL(WORLDWIDE_AUTHORITY).getHost(),
                 new AzureActiveDirectoryCloud(
-                        "login.microsoftonline.com",
-                        "login.windows.net",
+                        LOGIN_MICROSOFTONLINE_COM,
+                        LOGIN_WINDOWS_NET,
                         Arrays.asList(
-                                "login.microsoftonline.com",
-                                "login.windows.net",
-                                "login.microsoft.com",
-                                "sts.windows.net"
+                                LOGIN_MICROSOFTONLINE_COM,
+                                LOGIN_WINDOWS_NET,
+                                LOGIN_MICROSOFT_COM,
+                                STS_WINDOWS_NET
                         )
                 )
         );
@@ -359,17 +378,17 @@ public class TokenCacheAccessorTests {
 
         // Assert the presence of the account
         final AccountRecord accountRecord = msalCache.getAccount(
-                "login.windows.net",
-                "12345",
-                "mock_uid.mock_utid",
-                "mock_utid"
+                LOGIN_WINDOWS_NET,
+                CLIENT,
+                MOCK_UID + "." + MOCK_UTID,
+                MOCK_UTID
         );
 
         Assert.assertNotNull(accountRecord);
 
         // The RT
         final ICacheRecord cacheRecord = msalCache.load(
-                "12345",
+                CLIENT,
                 null,
                 accountRecord,
                 new BearerAuthenticationSchemeInternal()
@@ -378,12 +397,12 @@ public class TokenCacheAccessorTests {
         final IdTokenRecord idToken = cacheRecord.getIdToken();
         final RefreshTokenRecord refreshToken = cacheRecord.getRefreshToken();
 
-        Assert.assertEquals("mock_utid", idToken.getRealm());
-        Assert.assertEquals("12345", idToken.getClientId());
+        Assert.assertEquals(MOCK_UTID, idToken.getRealm());
+        Assert.assertEquals(CLIENT, idToken.getClientId());
         Assert.assertEquals(accountRecord.getHomeAccountId(), idToken.getHomeAccountId());
 
-        Assert.assertEquals("login.windows.net", refreshToken.getEnvironment());
-        Assert.assertEquals("12345", refreshToken.getClientId());
+        Assert.assertEquals(LOGIN_WINDOWS_NET, refreshToken.getEnvironment());
+        Assert.assertEquals(CLIENT, refreshToken.getClientId());
         Assert.assertEquals(accountRecord.getHomeAccountId(), refreshToken.getHomeAccountId());
     }
 }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
@@ -219,7 +219,8 @@ public class TokenCacheAccessorTests {
         );
 
 
-        // Populate a mock Instance Discovery
+        // Populate a mock Instance Discovery containing entries for the common authority as
+        // well as one instance for Mooncake.
         AzureActiveDirectory.putCloud(
                 new URL(WORLDWIDE_AUTHORITY).getHost(),
                 new AzureActiveDirectoryCloud(

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/TokenCacheAccessorTests.java
@@ -217,6 +217,34 @@ public class TokenCacheAccessorTests {
                 WORLDWIDE_AUTHORITY,
                 UUID.randomUUID().toString()
         );
+
+
+        // Populate a mock Instance Discovery
+        AzureActiveDirectory.putCloud(
+                new URL(WORLDWIDE_AUTHORITY).getHost(),
+                new AzureActiveDirectoryCloud(
+                        WW_MSO,
+                        WW_PREFERRED_CACHE,
+                        Arrays.asList(
+                                LOGIN_MICROSOFTONLINE_COM,
+                                LOGIN_WINDOWS_NET,
+                                LOGIN_MICROSOFT_COM,
+                                STS_WINDOWS_NET
+                        )
+                )
+        );
+
+        AzureActiveDirectory.putCloud(
+                new URL(MOONCAKE_AUTHORITY).getHost(),
+                new AzureActiveDirectoryCloud(
+                        LOGIN_PARTNER_MICROSOFTONLINE_CN,
+                        LOGIN_PARTNER_MICROSOFTONLINE_CN,
+                        Arrays.asList(
+                                LOGIN_PARTNER_MICROSOFTONLINE_CN,
+                                LOGIN_CHINACLOUDAPI_CN
+                        )
+                )
+        );
     }
 
     @After
@@ -265,33 +293,6 @@ public class TokenCacheAccessorTests {
         result.setResponseReceived(System.currentTimeMillis());
         result.setExpiresIn(System.currentTimeMillis());
 
-        // Populate a mock Instance Discovery
-        AzureActiveDirectory.putCloud(
-                new URL(WORLDWIDE_AUTHORITY).getHost(),
-                new AzureActiveDirectoryCloud(
-                        WW_MSO,
-                        WW_PREFERRED_CACHE,
-                        Arrays.asList(
-                                LOGIN_MICROSOFTONLINE_COM,
-                                LOGIN_WINDOWS_NET,
-                                LOGIN_MICROSOFT_COM,
-                                STS_WINDOWS_NET
-                        )
-                )
-        );
-
-        AzureActiveDirectory.putCloud(
-                new URL(MOONCAKE_AUTHORITY).getHost(),
-                new AzureActiveDirectoryCloud(
-                        LOGIN_PARTNER_MICROSOFTONLINE_CN,
-                        LOGIN_PARTNER_MICROSOFTONLINE_CN,
-                        Arrays.asList(
-                                LOGIN_PARTNER_MICROSOFTONLINE_CN,
-                                LOGIN_CHINACLOUDAPI_CN
-                        )
-                )
-        );
-
         // Save this to the cache
         mTokenCacheAccessor.updateTokenCache(request, result);
 
@@ -339,21 +340,6 @@ public class TokenCacheAccessorTests {
         result.setClientInfo(new ClientInfo(MOCK_CLIENT_INFO));
         result.setResponseReceived(System.currentTimeMillis());
         result.setExpiresIn(System.currentTimeMillis());
-
-        // Populate a mock Instance Discovery
-        AzureActiveDirectory.putCloud(
-                new URL(WORLDWIDE_AUTHORITY).getHost(),
-                new AzureActiveDirectoryCloud(
-                        LOGIN_MICROSOFTONLINE_COM,
-                        LOGIN_WINDOWS_NET,
-                        Arrays.asList(
-                                LOGIN_MICROSOFTONLINE_COM,
-                                LOGIN_WINDOWS_NET,
-                                LOGIN_MICROSOFT_COM,
-                                STS_WINDOWS_NET
-                        )
-                )
-        );
 
         // Save this to the cache
         mTokenCacheAccessor.updateTokenCache(request, result);

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -500,6 +500,7 @@ class AcquireTokenRequest {
         PackageManager packageManager = mContext.getPackageManager();
         int authVersionCode = Integer.MAX_VALUE;
         int cpVersionCode = Integer.MAX_VALUE;
+        int brokerHostVersionCode = Integer.MAX_VALUE;
 
         try {
             PackageInfo authPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, 0);
@@ -513,7 +514,15 @@ class AcquireTokenRequest {
         } catch (PackageManager.NameNotFoundException ignored) {
         }
 
-        return authVersionCode >= AUTHENTICATOR_LLT_VERSION_CODE && cpVersionCode >= CP_LLT_VERSION_CODE;
+        try {
+            PackageInfo brokerHostPackageInfo = packageManager.getPackageInfo(AuthenticationConstants.Broker.BROKER_HOST_APP_PACKAGE_NAME, 0);
+            brokerHostVersionCode = brokerHostPackageInfo.versionCode;
+        } catch (PackageManager.NameNotFoundException ignored) {
+        }
+
+        return authVersionCode >= AUTHENTICATOR_LLT_VERSION_CODE
+                && cpVersionCode >= CP_LLT_VERSION_CODE
+                && brokerHostVersionCode >= CP_LLT_VERSION_CODE;
 
     }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -57,6 +57,7 @@ import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
 import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
 
@@ -89,7 +90,6 @@ import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_USER
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE;
-import static com.microsoft.aad.adal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_SIGNATURE;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.BROKER_REQUEST;
 import static com.microsoft.aad.adal.AuthenticationConstants.Broker.CALLER_CACHEKEY_PREFIX;
@@ -399,19 +399,12 @@ public class AuthenticationActivity extends DualScreenActivity {
                 return true;
             }
 
+            final BrokerValidator brokerValidator = new BrokerValidator(this);
+
             final String signature = info.getCurrentSignatureForPackage(packageName);
 
-            Logger.verbose(TAG + methodName, "Checking broker signature.");
-            Logger.verbosePII(
-                    TAG + methodName,
-                    "Check signature for " + packageName
-                            + " signature:" + signature
-                            + " brokerSignature:" + AuthenticationSettings.INSTANCE.getBrokerSignature()
-            );
-
-            return signature.equals(AuthenticationSettings.INSTANCE.getBrokerSignature())
-                    || signature
-                    .equals(AZURE_AUTHENTICATOR_APP_SIGNATURE);
+            return brokerValidator.verifySignature(packageName) ||
+                    signature.equals(AuthenticationSettings.INSTANCE.getBrokerSignature());
         }
 
         return false;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationConstants.java
@@ -715,29 +715,6 @@ public final class AuthenticationConstants {
         public static final String CHALLENGE_REQUEST_CERT_AUTH_DELIMETER = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CHALLENGE_REQUEST_CERT_AUTH_DELIMETER;
 
         /**
-         * Apk packagename that will install AD-Authenticator. It is used to
-         * query if this app installed or not from package manager.
-         */
-        public static final String COMPANY_PORTAL_APP_PACKAGE_NAME = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-
-        /**
-         * Signature info for Intune Company portal app that installs authenticator
-         * component.
-         */
-        public static final String COMPANY_PORTAL_APP_SIGNATURE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE;
-
-        /**
-         * Signature info for Azure authenticator app that installs authenticator
-         * component.
-         */
-        public static final String AZURE_AUTHENTICATOR_APP_SIGNATURE = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_SIGNATURE;
-
-        /**
-         * Azure Authenticator app signature hash.
-         */
-        public static final String AZURE_AUTHENTICATOR_APP_PACKAGE_NAME = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
-
-        /**
          * The value for pkeyauth redirect.
          */
         public static final String PKEYAUTH_REDIRECT = com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PKEYAUTH_REDIRECT;

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -176,46 +176,8 @@ public class AuthenticationContext {
         mValidateAuthority = validateAuthority;
 
         if (null != tokenCacheStore) {
-            mTokenCacheStore = wrapCache(tokenCacheStore);
+            mTokenCacheStore = new DelegatingCache(mContext, tokenCacheStore);
         }
-    }
-
-    private ITokenCacheStore wrapCache(@NonNull final ITokenCacheStore originalCache) {
-        return new ITokenCacheStore() {
-            @Override
-            public synchronized TokenCacheItem getItem(final String key) {
-                return originalCache.getItem(key);
-            }
-
-            @Override
-            public synchronized Iterator<TokenCacheItem> getAll() {
-                return originalCache.getAll();
-            }
-
-            @Override
-            public synchronized boolean contains(final String key) {
-                return originalCache.contains(key);
-            }
-
-            @Override
-            public synchronized void setItem(final String key, final TokenCacheItem item) {
-                originalCache.setItem(key, item);
-            }
-
-            @Override
-            public synchronized void removeItem(final String key) {
-                originalCache.removeItem(key);
-            }
-
-            @Override
-            public synchronized void removeAll() {
-                // Clear our original cache
-                originalCache.removeAll();
-
-                // clear our replica cache
-                getMsalOAuth2TokenCache(mContext).clearAll();
-            }
-        };
     }
 
     /**

--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerProxy.java
@@ -894,11 +894,8 @@ class BrokerProxy implements IBrokerProxy {
 
                 // For new broker with PRT support, both company portal and
                 // azure authenticator will be able to support multi-user.
-                if (authenticator.packageName
-                        .equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
-                        || authenticator.packageName
-                        .equalsIgnoreCase(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME)
-                        || authenticator.packageName
+                final BrokerValidator brokerValidator = new BrokerValidator(mContext);
+                if (brokerValidator.isValidBrokerPackage(authenticator.packageName) || authenticator.packageName
                         .equalsIgnoreCase(AuthenticationSettings.INSTANCE.getBrokerPackageName())) {
                     // Existing broker logic only connects to broker for token
                     // requests if account exists. New version can allow to

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -165,7 +165,11 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
             json = null != json ? json : "";
             String decrypted = decrypt(key, json);
             if (decrypted != null) {
-                return mGson.fromJson(decrypted, TokenCacheItem.class);
+                try {
+                    return mGson.fromJson(decrypted, TokenCacheItem.class);
+                } catch (JsonSyntaxException exception) {
+                    Logger.e(TAG, "Fail to parse Json. ", exception.getMessage(), ARGUMENT_EXCEPTION, exception);
+                }
             }
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -102,7 +102,12 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
             }
         }
 
-        mPrefs = new SharedPreferencesFileManager(mContext, SHARED_PREFERENCE_NAME);
+        mPrefs = SharedPreferencesFileManager.getSharedPreferences(
+                mContext,
+                SHARED_PREFERENCE_NAME,
+                Context.MODE_PRIVATE,
+                null
+        );
 
         // Check upfront when initializing DefaultTokenCacheStore. 
         // If it's under API 18 and secretkey is not provided, we should fail upfront to inform 

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -233,7 +233,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
                 try {
                     final TokenCacheItem tokenCacheItem = mGson.fromJson(decryptedValue, TokenCacheItem.class);
                     tokens.add(tokenCacheItem);
-                } catch (JsonSyntaxException exception){
+                } catch (final JsonSyntaxException exception) {
                     Logger.e(TAG, "Fail to parse Json. ", exception.getMessage(), ARGUMENT_EXCEPTION, exception);
                 }
             }

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -30,6 +30,7 @@ import android.os.Build;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
@@ -45,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
+import static com.microsoft.aad.adal.ADALError.ARGUMENT_EXCEPTION;
 
 /**
  * Store/Retrieve TokenCacheItem from SharedPreferencesFileManager.
@@ -227,8 +230,12 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
 
             final String decryptedValue = decrypt(tokenKey, tokenValue);
             if (decryptedValue != null) {
-                final TokenCacheItem tokenCacheItem = mGson.fromJson(decryptedValue, TokenCacheItem.class);
-                tokens.add(tokenCacheItem);
+                try {
+                    final TokenCacheItem tokenCacheItem = mGson.fromJson(decryptedValue, TokenCacheItem.class);
+                    tokens.add(tokenCacheItem);
+                } catch (JsonSyntaxException exception){
+                    Logger.e(TAG, "Fail to parse Json. ", exception.getMessage(), ARGUMENT_EXCEPTION, exception);
+                }
             }
         }
 

--- a/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DefaultTokenCacheStore.java
@@ -167,7 +167,7 @@ public class DefaultTokenCacheStore implements ITokenCacheStore, ITokenStoreQuer
             if (decrypted != null) {
                 try {
                     return mGson.fromJson(decrypted, TokenCacheItem.class);
-                } catch (JsonSyntaxException exception) {
+                } catch (final JsonSyntaxException exception) {
                     Logger.e(TAG, "Fail to parse Json. ", exception.getMessage(), ARGUMENT_EXCEPTION, exception);
                 }
             }

--- a/adal/src/main/java/com/microsoft/aad/adal/DelegatingCache.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DelegatingCache.java
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.aad.adal;
+
+import static com.microsoft.aad.adal.TokenCacheAccessor.getMsalOAuth2TokenCache;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import java.util.Iterator;
+
+class DelegatingCache implements ITokenCacheStore {
+
+    private final Context mContext;
+    private final ITokenCacheStore mDelegate;
+
+    DelegatingCache(@NonNull final Context context,
+                    @NonNull final ITokenCacheStore delegate) {
+        mContext = context;
+        mDelegate = delegate;
+    }
+
+    public ITokenCacheStore getDelegateCache() {
+        return mDelegate;
+    }
+
+    @Override
+    public TokenCacheItem getItem(final String key) {
+        return mDelegate.getItem(key);
+    }
+
+    @Override
+    public Iterator<TokenCacheItem> getAll() {
+        return mDelegate.getAll();
+    }
+
+    @Override
+    public boolean contains(final String key) {
+        return mDelegate.contains(key);
+    }
+
+    @Override
+    public void setItem(final String key, final TokenCacheItem item) {
+        mDelegate.setItem(key, item);
+    }
+
+    @Override
+    public void removeItem(final String key) {
+        mDelegate.removeItem(key);
+    }
+
+    @Override
+    public void removeAll() {
+        // Clear our original cache
+        mDelegate.removeAll();
+
+        // clear our replica cache
+        getMsalOAuth2TokenCache(mContext).clearAll();
+    }
+}

--- a/adal/src/main/java/com/microsoft/aad/adal/DelegatingCache.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/DelegatingCache.java
@@ -30,17 +30,31 @@ import androidx.annotation.NonNull;
 
 import java.util.Iterator;
 
+/**
+ * An implementation of {@link ITokenCacheStore} that delegates to a constructor-provided instance.
+ */
 class DelegatingCache implements ITokenCacheStore {
 
     private final Context mContext;
     private final ITokenCacheStore mDelegate;
 
+    /**
+     * Constructs a new instance of {@link DelegatingCache}.
+     *
+     * @param context  The application {@link Context} of the initializing app.
+     * @param delegate The cache to which method invocations on this cache will delegate.
+     */
     DelegatingCache(@NonNull final Context context,
                     @NonNull final ITokenCacheStore delegate) {
         mContext = context;
         mDelegate = delegate;
     }
 
+    /**
+     * Gets the cache to which this cache is delegating.
+     *
+     * @return The delegate cache.
+     */
     public ITokenCacheStore getDelegateCache() {
         return mDelegate;
     }

--- a/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/TokenCacheAccessor.java
@@ -98,10 +98,11 @@ class TokenCacheAccessor {
         sharedSSOCaches.add(msalOAuth2TokenCache);
         mCommonCache = new ADALOAuth2TokenCache(appContext, sharedSSOCaches);
 
-        if (mTokenCacheStore instanceof DefaultTokenCacheStore) {
+        if (mTokenCacheStore instanceof DelegatingCache) {
+            final ITokenCacheStore delegate = ((DelegatingCache) mTokenCacheStore).getDelegateCache();
             //If the default token cache is in use... delegate token operations to unified cache in common
             //If not using default token cache then sharing SSO state between ADAL & MSAL cache implementations will not be possible anyway
-            mUseCommonCache = true;
+            mUseCommonCache = delegate instanceof DefaultTokenCacheStore;
         }
     }
 

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=3.1.2
+versionName=3.1.3-RC1
 versionCode=1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 3.1.3
+-------------
+- Adds exception handling for ADAL cache crash on malformed JSON (#1606)
+- Implements a fix for ADAL cache replication (#1616)
+
 Version 3.1.2
 -------------
 - Android changes for SDK30, see [the android developers notice](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
-# Project-wide Gradle settings.
+ariaTenantTokenProd="b6618d4b5d24466a9d2d0d8cde8cd6e4-ddcec952-23e9-4765-b4fb-f823ec69c6e3-7966"
+ariaTenantTokenTest="1e8435186fa849b28b1a402fb5074ff1-0b91a9ec-efad-440c-b92c-ac4cb55ba0ff-7490"
 
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
+android.useAndroidX=true
+android.enableJetifier=true
 
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
+# https://office.visualstudio.com/Outlook%20Mobile/_wiki/wikis/Outlook-Mobile.wiki/3780/Android-Studio-Gradle-Performance-tips-and-tricks
+org.gradle.parallel=true
+org.gradle.daemon=true
 
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# See https://stackoverflow.com/questions/56075455/expiring-daemon-because-jvm-heap-space-is-exhausted
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:ReservedCodeCacheSize=512m
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# This the TSL versionName...
+versionName=1.5.9
+
+# For OneAuth default abiSelection
+abiSelection=x86_64

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,8 +8,11 @@ ext {
     buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '3.3.3'
+    gradleVersion = '4.1.0'
     androidMavenGradlePluginVersion = "1.4.1"
+
+    //Java Language Support
+    coreLibraryDesugaringVersion = "1.0.9"
 
     // Libraries
     androidxTestCoreVersion = "1.2.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 23 06:25:42 PDT 2018
+#Fri Jul 02 15:52:51 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Sets `common` submodule pointer to `HEAD` of `release/3.4.5`

Still to do for this release:
- ~Update gradle version to match `common`~ c8498ab90d7fd61fd8f3633fa86e8163ba433386
- ~Pull in @shahzaibj's changes from https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1578 to unbreak `master` branch build with latest `common`~ d22ccf3b424ed3294609111cc604a4a3348338db
- ~Update gradle dependency to `common@3.4.5`~ 6bf5f520a2450a571253048cc8889cdb1bed1fc1
- ~Update ADAL version strings~ 54e49c7cee2d07d7616b6ff38f07662462a40f02
- ~Update ADAL changelog~ 586d0a09b29e607328b8a477b7c0c30eff4143ff
- ~Pull in changes from PR https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1606~
    * via 9b178cce4b8f74f5eeb5a8d446a122544438ca55
    * via 1de649a42c625525585765cb18fb5cb96c40013a
    * via fcbbdad62e081a40e5af00b80c6b75b5a7c308c1
    * via 5bfb209bf2230e9ca1ab2601cadb82e873c57e4d
- ~Pull in changes from PR https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1616~
    * via 9e0dc2bed2fec14b80553d333a1b4df51fe63645
    * via 04ef4808114cdad285177bba52ebfc50d317c8fc
    * via 517db8f9ec444fa0bfbb59cf05fc77c231f978ac
    * via 2f70ae3128bf0a5b2b645910a635c0e58704b29c
    * via 3b69fa73be9890480067949aedf3946877cf2aa3
    * via 57d4a532815aa4453b76cba34835482730841dc0
    * via b3ece828ef05700a5e6bf1916f51d83da14a25b8
    * via d28db750e91b879ed14a6e81753fadd6a95a9636
    * via 53ca97bc2d5477f1d4fb8924e57c154174bcd691
