### PR TITLE
Iambmelt/update 3.1.3 sub to 3.4.5

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.0.6', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:3.4.5-RC1") {
+    distApi("com.microsoft.identity:common:3.4.5-RC2") {
         transitive = false
     }
 


### PR DESCRIPTION
Updated common submodule pointer to `release/3.4.5@HEAD` and sets dep version to `3.4.5-RC2`
