### PR TITLE
rename file

### DIFF
--- a/azure-pipelines/pull-request-validation/security-compliance-check-adal.yml
+++ b/azure-pipelines/pull-request-validation/security-compliance-check-adal.yml
@@ -1,4 +1,4 @@
-# File: azure-pipelines\pull-request-validation\credscan.yml
+# File: azure-pipelines\pull-request-validation\security-compliance-check-adal.yml
 # Description: Run Credscan and PoliCheck
 name: $(date:yyyyMMdd)$(rev:.r)
 
@@ -19,5 +19,5 @@ resources:
     endpoint: ANDROID_GITHUB
 
 jobs:
-- template: azure-pipelines/templates/steps/credscan-policheck.yml@common
+- template: azure-pipelines/templates/steps/security-compliance-check.yml@common
 ...


### PR DESCRIPTION
The CredScan task is a repo wide assessment, it doesn't need to run as a task under each pipeline within a repo it can run once as its own pipeline...once per each repo.

Update credscan, policheck and publish results to v3

Related PR:
AzureAD/microsoft-authentication-library-common-for-android/pull/1437
AzureAD/ad-accounts-for-android/pull/1609
AzureAD/microsoft-authentication-library-for-android#1449
Pipeline
https://identitydivision.visualstudio.com/Engineering/_build?definitionScope=%5CAndroid%5CPull%20Request%20Validations%5CCredScan