### PR TITLE
Final Release Work for ADAL 3.1.3

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.0.6', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:3.4.5-RC2") {
+    distApi("com.microsoft.identity:common:3.4.5") {
         transitive = false
     }
 

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=3.1.3-RC1
+versionName=3.1.3
 versionCode=1

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation "com.google.android.material:material:$rootProject.ext.materialVersion"
 
     localImplementation(project(':adal'))
-    distImplementation("com.microsoft.aad:adal:3.1.0") {
+    distImplementation("com.microsoft.aad:adal:3.1.3-RC1") {
         exclude module: 'support-v4'
         exclude module: 'android'
     }


### PR DESCRIPTION
- Removes RC tagging
- Updates dep version to `common@3.4.5` (prod)
- Updates submodule pointer to common release branch (using `HEAD` of `release/3.4.5`)

What to do with this branch (@AdamBJohnsonx)
- Once `common@3.4.5` is available via Maven Central, this PR can successfully build/merge/deploy