### PR TITLE
adal update Docker Build Agents 

### DIFF
--- a/azure-pipelines/auth-client/instrumented-test.yml
+++ b/azure-pipelines/auth-client/instrumented-test.yml
@@ -6,7 +6,7 @@ trigger:
 - main
 
 pool:
- name: DockerBuildAgents
+ name: DockerBuildAgents2
 
 resources:
  repositories:

--- a/azure-pipelines/auth-client/instrumented-test.yml
+++ b/azure-pipelines/auth-client/instrumented-test.yml
@@ -6,7 +6,7 @@ trigger:
 - main
 
 pool:
- name: DockerBuildAgents2
+ name: 1ESDockerBuild
 
 resources:
  repositories:

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -3,7 +3,7 @@ echo =============================================
 echo Starting ADB Daemon
 echo =============================================
 adb start-server
-emulator @test -no-window -no-audio -wipe-data &
+emulator @test -no-window -no-audio -no-snapshot -wipe-data &
 sleep 30
 gradle -version
 echo =============================================


### PR DESCRIPTION
Custom self-hosted AzureDevOps pools have the potential to be a surface area of attack for malicious actors.
To reduce the risk associated with custom pools we will need to use 1ES Hosted Pools.
https://www.1eswiki.com/wiki/1ES_hosted_AzureDevOps_Agents