### PR TITLE
Update common dep and bump up version to 4.0.0-RC1

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -147,11 +147,11 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.5', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.0-RC2', changing: true)
 
     // 'dist' flavor dependencies
     //TODO: we will have to change transitive to true once common4j is published
-    distApi("com.microsoft.identity:common:3.4.5") {
+    distApi("com.microsoft.identity:common:4.0.0-RC2") {
         transitive = false
     }
 

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=3.1.3
+versionName=4.0.0-RC1
 versionCode=1


### PR DESCRIPTION
### In this change

- Updating the common dep to point to 4.0.0-RC2
- Updating the common submodule to point to 4.0.0-RC2 (branch release/4.0.0)
- Bumping up the version to 4.0.0-RC1
