### PR TITLE
update javadoc task to use configurations.compile for classpath

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -183,7 +183,7 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.api
+    classpath += configurations.compile
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     classpath += configurations.javadocDeps
     exclude '**/*.aidl'


### PR DESCRIPTION
Fixing the following gradle error with javadoc task
```
Could not determine the dependencies of task ':adal:javadoc'.
> Resolving dependency configuration 'api' is not allowed as it is defined as 'canBeResolved=false'.
  Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'api' should be resolved.

```
By replacing the configurations.api dependency with configurations.compile, which is resolvable