### PR TITLE
bump up RC version to 4.0.0-RC2, update common dep

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -147,10 +147,10 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.0-RC2', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.0-RC3', changing: true)
 
     // 'dist' flavor dependencies
-    distApi("com.microsoft.identity:common:4.0.0-RC2") {
+    distApi("com.microsoft.identity:common:4.0.0-RC3") {
         transitive = true
     }
 

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.0.0-RC1
+versionName=4.0.0-RC2
 versionCode=1


### PR DESCRIPTION
### In this change

- Bump up RC version to 4.0.0-RC2
- Update Common dep to 4.0.0-RC3
- Update common submodule to head of  release/4.0.0
