### PR TITLE
Return null in tests when asked for the cache dir, instead of crashing

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/FileMockContext.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/FileMockContext.java
@@ -114,6 +114,11 @@ class FileMockContext extends MockContext {
     }
 
     @Override
+    public File getCacheDir() {
+        return null;
+    }
+
+    @Override
     public Object getSystemService(String name) {
         if (name.equalsIgnoreCase("account")) {
             if (mMockedAccountManager == null) {


### PR DESCRIPTION
This goes along with https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1623/files
