### PR TITLE
Set BuildConfig.VERSON_NAME to be project.version to set it to correct version number

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -70,13 +70,13 @@ android {
         debug {
             testCoverageEnabled false
             debuggable true
-            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
+            buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
         }
         release {
             minifyEnabled false
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
-            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
+            buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,6 @@ org.gradle.daemon=true
 # See https://stackoverflow.com/questions/56075455/expiring-daemon-because-jvm-heap-space-is-exhausted
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:ReservedCodeCacheSize=512m
 
-# This the TSL versionName...
-versionName=1.5.9
-
 # For OneAuth default abiSelection
 abiSelection=x86_64
 


### PR DESCRIPTION
### What
Updating build.gradle file to correctly set VERSON_NAME in the generated BuildConfig.java. to `project.version` (currently `versionName`)

### Why
The `versionName` in Build.gradle is coming from global scope and gets read from gradle.properties where it is defined as `"1.5.9"` for TSL version. This makes it incorrectly set the VERSION_NAME in generated BuildConfig.java under BuildConfig.VERSION_NAME field. This field is used to set the x-client-ver header in ests requests to pass on the ADAL version. because it is being set to 1.5.9 this skews our telemetry as well as makes it difficult in terms of debugging the logs.

### How
Setting the VERSION_NAME to `project.version` which is set in the build.gradle by reading the version.properties file. This way the correct version number as defined in version.properties file will be set and passed to ests.

### Testing
Verified locally generated Build.Config file the version name is set correctly and not 1.5.9
![image](https://user-images.githubusercontent.com/75644120/142042479-c361993e-0834-430d-96ea-b71b2322dc0b.png)


### Related PRs
msal: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1553