### PR TITLE
Handle security exception when binding service to broker app

### DIFF
--- a/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/BrokerAccountServiceHandler.java
@@ -359,7 +359,15 @@ final class BrokerAccountServiceHandler {
         }
         final CallbackExecutor<BrokerAccountServiceConnection> callbackExecutor = new CallbackExecutor<>(callback);
         mPendingConnections.put(connection, callbackExecutor);
-        final boolean serviceBound = context.bindService(brokerAccountServiceToBind, connection, Context.BIND_AUTO_CREATE);
+
+        boolean serviceBound = false;
+        try {
+            // Handle exception when Context#bindService fails.
+            serviceBound = context.bindService(brokerAccountServiceToBind, connection, Context.BIND_AUTO_CREATE);
+        } catch (SecurityException exception) {
+            Logger.e(TAG + methodName, "SecurityException when binding service to broker app.", exception);
+        }
+
         Logger.v(TAG + methodName, "The status for brokerAccountService bindService call is: " + Boolean.valueOf(serviceBound));
         if (brokerEvent != null) {
             brokerEvent.setBrokerAccountServiceBindingSucceed(serviceBound);

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ v.Next
 - [PATCH] Disregard pageload errors for the non-primary frame during interactive auth (#1603)
 - [PATCH] Updates Nimbus version 8.2 -> 9.9 (#1600)
 - [PATCH] Fix for ADAL cache replication to Msal/Common-Cache (#1616)
+- [PATCH] Fix SecurityException thrown when binding service to broker app (#1665)
 
 Version 3.1.3
 -------------


### PR DESCRIPTION
## What does this PR do?

- Adds handling of `SecurityException` thrown when binding service to broker app.

See https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1207523
