### PR TITLE
Add ability to provide common version using project property

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -131,6 +131,8 @@ android {
     useLibrary 'android.test.mock'
 }
 
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "0.0.+"
+
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 
@@ -147,11 +149,11 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.5', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: commonVersion, changing: true)
 
     // 'dist' flavor dependencies
     //TODO: we will have to change transitive to true once common4j is published
-    distApi("com.microsoft.identity:common:3.4.5") {
+    distApi("com.microsoft.identity:common:${commonVersion}") {
         transitive = false
     }
 


### PR DESCRIPTION
Add ability to provide common version using project property

Related PR in Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/1788
