### PR TITLE
[CyberEO] Add sbom-generation task to adal vsts-release pipeline

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -152,9 +152,8 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: commonVersion, changing: true)
 
     // 'dist' flavor dependencies
-    //TODO: we will have to change transitive to true once common4j is published
     distApi("com.microsoft.identity:common:${commonVersion}") {
-        transitive = false
+        transitive = true
     }
 
     // Android Instrumented Test Dependencies

--- a/azure-pipelines/vsts-releases/adal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/adal-vsts-release.yml
@@ -43,7 +43,6 @@ jobs:
       sqAnalysisBreakBuildIfQualityGateFailed: false
   - task: Gradle@2
     displayName: Publish to VSTS
-    enabled: false
     inputs:
       tasks: adal:publish
       publishJUnitResults: false

--- a/azure-pipelines/vsts-releases/adal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/adal-vsts-release.yml
@@ -43,6 +43,7 @@ jobs:
       sqAnalysisBreakBuildIfQualityGateFailed: false
   - task: Gradle@2
     displayName: Publish to VSTS
+    enabled: false
     inputs:
       tasks: adal:publish
       publishJUnitResults: false

--- a/azure-pipelines/vsts-releases/adal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/adal-vsts-release.yml
@@ -9,6 +9,14 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
 pr: none
 
+resources:
+  repositories:
+    - repository: common
+      type: github
+      name: AzureAD/microsoft-authentication-library-common-for-android
+      ref: dev
+      endpoint: ANDROID_GITHUB
+
 jobs:
 - job: build_publish
   displayName: Publish adal to internal feed
@@ -38,4 +46,21 @@ jobs:
     inputs:
       tasks: adal:publish
       publishJUnitResults: false
+  - template: azure-pipelines/templates/steps/generate-sbom.yml@common
+    parameters:
+      project: adal
+      buildDropPath: $(Build.SourcesDirectory)/adal/build/
+      configuration: distReleaseRuntimeClasspath
+  - task: CopyFiles@2
+    name: CopyFiles1
+    displayName: Copy Files to Artifact Staging Directory
+    inputs:
+      SourceFolder: adal\build\
+      TargetFolder: $(build.artifactstagingdirectory)
+  - task: PublishPipelineArtifact@1
+    name: PublishPipelineArtifact1
+    displayName: 'Publish Artifact: adal Release'
+    inputs:
+      ArtifactName: adalRelease
+      TargetPath: $(Build.ArtifactStagingDirectory)
 ...

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ allprojects {
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
+
+    dependencyLocking {
+        lockAllConfigurations()
+    }
 }
 
 


### PR DESCRIPTION
### What
Adding tasks to generate and publish SBOM ([Software bill of materials](https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/softwarebillofmaterials)) manifest file.

### Why
This is a requirement as part of the [Cyber EO](https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/overview).

### How
Added a new template to generate-sbom manifest to the vsts-release pipeline. The template was added as part of this common [PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1653) which has details for what it does.

### Testing
Successfully completed test run of the pipeline and generated sbom manifest as pipeline artifact
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=857559&view=results

### Other
ADO Feature: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1695893/
Similar PR for Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1653