### PR TITLE
Update gson version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 v.Next
 ----------
-
+- [PATCH] Update gson version to 2.8.9
 Version 4.0.1
 -------------
 - [MINOR] Migrate BaseController to common4j (#1636)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 v.Next
 ----------
 - [PATCH] Update gson version to 2.8.9
+
 Version 4.0.1
 -------------
 - [MINOR] Migrate BaseController to common4j (#1636)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -29,7 +29,7 @@ ext {
     constraintLayoutVersion = "1.1.3"
     dexmakerMockitoVersion = "2.19.0"
     espressoCoreVersion = "3.1.0"
-    gsonVersion = "2.8.5"
+    gsonVersion = "2.8.9"
     junitVersion = "4.12"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"


### PR DESCRIPTION
**What**
Upgrading gson version used from 2.8.5 -> 2.8.9 

**Why**
Vulnerability reported here in the existing version https://identitydivision.visualstudio.com/Engineering/_componentGovernance/181889/alert/6139944?typeId=9846578
and recommendation is update to 2.8.9

**How**
Updating the value of gsonVersion field to 2.8.9, which is used in build.gradle
**Test**
Ran UTs locally and triggered build here https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=891750&view=results. This does not have component governance task run. I am figuring out how it can be run in this branch.

**Other**
This will only address distDebugCompileClasspath, distDebugRuntimeClasspath, distReleaseCompileClasspath, distReleaseRuntimeClasspath.
Similar changes in msal, broker, common and android-complete.
Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1694
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/1838
MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1603
Android Complete: https://github.com/AzureAD/android-complete/pull/130