### PR TITLE
Update maven release parameters to point to correct folders

### DIFF
--- a/azure-pipelines/maven-release/adal-maven-release.yml
+++ b/azure-pipelines/maven-release/adal-maven-release.yml
@@ -30,9 +30,9 @@ jobs:
     envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
     gradleAssembleReleaseTask: adal:clean adal:assembleDist adal:javadocJar
     gradleGeneratePomFiletask: adal:generatePomFileForAdalPublication
-    aarSourceFolder: C:\Temp\s\adal\outputs\aar
-    jarSourceFolder: C:\Temp\s\adal\outputs\jar
-    pomSourceFolder: C:\Temp\s\adal\publications\adal
+    aarSourceFolder: adal\outputs\aar
+    jarSourceFolder: adal\outputs\jar
+    pomSourceFolder: adal\publications\adal
     gpgAar: true
     gpgSourcesJar: true
     gpgJavadocJar: true


### PR DESCRIPTION
### What 
Update maven release parameters to point to correct folders

### Why
We no longer publish the artifacts in C:\temp directory.
Instead, the build artifacts go to default project directory.

