### PR TITLE
added yubikit version to versions.gradle

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 v.Next
 ----------
-- [PATCH] Add YubiKit version variable to versions.gradle (#1689)
 - [PATCH] Update gson version to 2.8.9
 - [MINOR] Remove PKeyAuth support from ADAL (#1685)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v.Next
 ----------
+- [PATCH] Add YubiKit version variable to versions.gradle (#1689)
 - [PATCH] Update gson version to 2.8.9
 - [MINOR] Remove PKeyAuth support from ADAL (#1685)
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -46,6 +46,7 @@ ext {
     uiAutomatorVersion = "2.2.0"
     mseberaApacheHttpClientVersion = "4.5.8"
     msal4jVersion = "1.10.0"
+    yubikitAndroidVersion = "2.0.0"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"


### PR DESCRIPTION
## Related PR
Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729

## Summary
yubikitAndroidVersion is added to ADAL versions.gradle in order to be consistent with Common, MSAL, and Broker.
Please see [this PR for Common](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729) for a more detailed description of YubiKit additions being added to all the repos. 