### PR TITLE
updated changelog to note Java 8 bump due to YubiKit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v.Next
 ----------
+- [MAJOR] Added YubiKit SDK to common, which requires host apps that use ADAL to upgrade to Java Version 8 (#1689)
 - [PATCH] Update gson version to 2.8.9
 - [MINOR] Remove PKeyAuth support from ADAL (#1685)
 


### PR DESCRIPTION
Note: Please approve this common PR first: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1737
Due to the addition of YubiKit SDK, all host apps that consume libraries that use common will need to support Java Version 8, which is a MAJOR change.
