### PR TITLE
Update androidx appcompat version from 1.0.2 -> 1.1.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v.Next
 ----------
+- [PATCH] Update androidx appcompat version from 1.0.2 -> 1.1.0 (#1691)
 - [MAJOR] Added YubiKit SDK to common, which requires host apps that use ADAL to upgrade to Java Version 8 (#1689)
 - [PATCH] Update gson version to 2.8.9
 - [MINOR] Remove PKeyAuth support from ADAL (#1685)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -24,7 +24,7 @@ ext {
     androidxTestCoreVersion = "1.2.0"
     androidxJunitVersion = "1.1.1"
     annotationVersion = "1.0.0"
-    appCompatVersion = "1.0.2"
+    appCompatVersion = "1.1.0"
     browserVersion = "1.0.0"
     constraintLayoutVersion = "1.1.3"
     dexmakerMockitoVersion = "2.19.0"


### PR DESCRIPTION
Upgrading androidx appcompat version from 1.0.2 -> [1.1.0](https://developer.android.com/jetpack/androidx/releases/appcompat#version_110_3).
This dependency was updated in the [common repo](https://github.com/AzureAD/microsoft-authentication-library-common-for-android) as part of this [PR:#1725](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1725)
Which broke the [consumers of common pipeline](https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1393&_a=summary); as the consumer of commons are still referring to older versions and need to be upgraded as well.
- Also updating the common submodule to point to latest dev.
