### PR TITLE
Remove RC tag from version for 4.1.0

### DIFF
--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.1.0-RC1
+versionName=4.1.0
 versionCode=1


### PR DESCRIPTION
Removing RC tag from version for 4.1.0 to prepare final release.
