### PR TITLE
Update build artifacts path for maven release pipeline

### DIFF
--- a/azure-pipelines/maven-release/adal-maven-release.yml
+++ b/azure-pipelines/maven-release/adal-maven-release.yml
@@ -34,6 +34,6 @@ jobs:
     jarSourceFolder: adal/outputs/jar
     pomSourceFolder: adal/publications/adal
     gpgAar: true
-    gpgSourcesJar: true
+    gpgSourcesJar: false
     gpgJavadocJar: true
     gpgJar: false

--- a/azure-pipelines/maven-release/adal-maven-release.yml
+++ b/azure-pipelines/maven-release/adal-maven-release.yml
@@ -30,9 +30,9 @@ jobs:
     envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
     gradleAssembleReleaseTask: adal:clean adal:assembleDist adal:javadocJar
     gradleGeneratePomFiletask: adal:generatePomFileForAdalPublication
-    aarSourceFolder: C:\Temp\s\adal\outputs\aar
-    jarSourceFolder: C:\Temp\s\adal\outputs\jar
-    pomSourceFolder: C:\Temp\s\adal\publications\adal
+    aarSourceFolder: adal/outputs/aar
+    jarSourceFolder: adal/outputs/jar
+    pomSourceFolder: adal/publications/adal
     gpgAar: true
     gpgSourcesJar: true
     gpgJavadocJar: true


### PR DESCRIPTION
- removed C:\temp from the artifact path as we no longer publish to c:\temp directory
-  Fix path separators for maven pipeline to match Linux style
