### PR TITLE
Adding YubiKit Versions and Keyboard Flag

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -131,7 +131,7 @@ android {
     useLibrary 'android.test.mock'
 }
 
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "5.0.9-CBATest"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "0.0.+"
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -131,7 +131,7 @@ android {
     useLibrary 'android.test.mock'
 }
 
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "0.0.+"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "5.0.8-CBATest"
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -131,7 +131,7 @@ android {
     useLibrary 'android.test.mock'
 }
 
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "5.0.8-CBATest"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "5.0.9-CBATest"
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"

--- a/adal/src/main/AndroidManifest.xml
+++ b/adal/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application>
         <activity
             android:name="com.microsoft.aad.adal.AuthenticationActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout" />
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout|keyboard" />
     </application>
 
 </manifest>

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.1.0
+versionName=4.1.1-CBATest
 versionCode=1

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.1.1-CBATest
+versionName=4.1.2-CBATest
 versionCode=1

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.1.2-CBATest
+versionName=4.1.0
 versionCode=1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 v.Next
 ----------
 - [PATCH] Update androidx appcompat version from 1.0.2 -> 1.1.0 (#1691)
-- [MAJOR] Added YubiKit SDK to common, which requires host apps that use ADAL to upgrade to Java Version 8 (#1689)
+- [MINOR] Added keyboard flag to configChanges in Manifest for YubiKey compatibility. (#1699)
 
 Version 4.1.0
 -------------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -46,7 +46,8 @@ ext {
     uiAutomatorVersion = "2.2.0"
     mseberaApacheHttpClientVersion = "4.5.8"
     msal4jVersion = "1.10.0"
-    yubikitAndroidVersion = "2.0.0"
+    yubikitAndroidVersion = "2.1.0"
+    yubikitPivVersion = "2.1.0"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"


### PR DESCRIPTION
### Summary
YubiKit versions (Android and Piv) are added to versions file.
`keyboard` is added to `configChanges` of AuthenticationActivity within Manifest.
See [the main PR for Common](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1814) for more details as to why these changes need to be made.