### PR TITLE
Fadi/test 1610899

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -627,7 +627,11 @@ public final class AuthenticationContextTest {
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
         final JWT decodedToken = JWTParser.parse(callback.getAuthenticationResult().getAccessToken());
-        Assert.assertNotNull(decodedToken.getJWTClaimsSet().getClaim("deviceid"));
+        final Object deviceIdClaim = decodedToken.getJWTClaimsSet().getClaim("deviceid");
+        Assert.assertNotNull(deviceIdClaim);
+
+        // Adal gets device id from token
+        Assert.assertEquals("761b45e9-2080-4573-bebb-b43d435ce1af", (String) deviceIdClaim);
     }
 
     @Test

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -52,6 +52,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.content.pm.Signature;
 import android.os.Build;
 import android.os.Bundle;
@@ -72,6 +74,8 @@ import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredenti
 import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -95,6 +99,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -142,6 +147,8 @@ public final class AuthenticationContextTest {
     private static final int EXPIRES_ON_ADJUST_MINS = 10;
 
     static final String TEST_IDTOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiJlNzBiMTE1ZS1hYzBhLTQ4MjMtODVkYS04ZjRiN2I0ZjAwZTYiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwibmJmIjoxMzc2NDI4MzEwLCJleHAiOjEzNzY0NTcxMTAsInZlciI6IjEuMCIsInRpZCI6IjMwYmFhNjY2LThkZjgtNDhlNy05N2U2LTc3Y2ZkMDk5NTk2MyIsIm9pZCI6IjRmODU5OTg5LWEyZmYtNDExZS05MDQ4LWMzMjIyNDdhYzYyYyIsInVwbiI6ImFkbWluQGFhbHRlc3RzLm9ubWljcm9zb2Z0LmNvbSIsInVuaXF1ZV9uYW1lIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwic3ViIjoiVDU0V2hGR1RnbEJMN1VWYWtlODc5UkdhZEVOaUh5LXNjenNYTmFxRF9jNCIsImZhbWlseV9uYW1lIjoiU2VwZWhyaSIsImdpdmVuX25hbWUiOiJBZnNoaW4ifQ.";
+
+    static final String TEST_ACCESS_TOKEN_WITH_DEVICE_ID = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyIsImtpZCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyJ9.eyJhdWQiOiJodHRwczovL2dyYXBoLndpbmRvd3MubmV0IiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhLyIsImlhdCI6MTY3MzgzNTUyNywibmJmIjoxNjczODM1NTI3LCJleHAiOjE2NzM4NDAwOTMsImFjciI6IjEiLCJhaW8iOiJBVFFBeS84VEFBQUFqTlBGYnQyakZHdmJMOGw2dUMvdG5lYUEvL0FKQWJTazhOS1NiVWJ5WWt0bTZmSHQwa2IxR0JFNXhRYThsTVVUIiwiYW1yIjpbInB3ZCIsInJzYSJdLCJhcHBpZCI6IjRiMGRiOGMyLTlmMjYtNDQxNy04YmRlLTNmMGUzNjU2ZjhlMCIsImFwcGlkYWNyIjoiMCIsImRldmljZWlkIjoiNzYxYjQ1ZTktMjA4MC00NTczLWJlYmItYjQzZDQzNWNlMWFmIiwiZmFtaWx5X25hbWUiOiJCYXNpYyBVc2VyIDEiLCJnaXZlbl9uYW1lIjoiQ2xvdWQgSURMQUIiLCJpcGFkZHIiOiI2OC4yMjYuNjcuMTIiLCJuYW1lIjoiQ2xvdWQgSURMQUIgQmFzaWMgVXNlciAxIiwib2lkIjoiNTk3Zjg2Y2QtMTNmMy00NGMwLWJlY2UtYTFlNzdiYTQzMjI4IiwicHVpZCI6IjEwMDMyMDAwOUM2NkIyMDUiLCJyaCI6IjAuQVJ3QWtxMUY5bzNqR2syMUVOR3dtblNveWdJQUFBQUFBQUFBd0FBQUFBQUFBQUFjQUNRLiIsInNjcCI6IkFncmVlbWVudC5SZWFkLkFsbCBBZ3JlZW1lbnQuUmVhZFdyaXRlLkFsbCBBZ3JlZW1lbnRBY2NlcHRhbmNlLlJlYWQgQWdyZWVtZW50QWNjZXB0YW5jZS5SZWFkLkFsbCBBcHBDYXRhbG9nLlJlYWRXcml0ZS5BbGwgQXVkaXRMb2cuUmVhZC5BbGwgQm9va2luZ3MuTWFuYWdlLkFsbCBCb29raW5ncy5SZWFkLkFsbCBCb29raW5ncy5SZWFkV3JpdGUuQWxsIEJvb2tpbmdzQXBwb2ludG1lbnQuUmVhZFdyaXRlLkFsbCBDYWxlbmRhcnMuUmVhZCBDYWxlbmRhcnMuUmVhZC5TaGFyZWQgQ2FsZW5kYXJzLlJlYWRXcml0ZSBDYWxlbmRhcnMuUmVhZFdyaXRlLlNoYXJlZCBDb250YWN0cy5SZWFkIENvbnRhY3RzLlJlYWQuU2hhcmVkIENvbnRhY3RzLlJlYWRXcml0ZSBDb250YWN0cy5SZWFkV3JpdGUuU2hhcmVkIERldmljZS5Db21tYW5kIERldmljZS5SZWFkIERldmljZU1hbmFnZW1lbnRBcHBzLlJlYWQuQWxsIERldmljZU1hbmFnZW1lbnRBcHBzLlJlYWRXcml0ZS5BbGwgRGV2aWNlTWFuYWdlbWVudENvbmZpZ3VyYXRpb24uUmVhZC5BbGwgRGV2aWNlTWFuYWdlbWVudENvbmZpZ3VyYXRpb24uUmVhZFdyaXRlLkFsbCBEZXZpY2VNYW5hZ2VtZW50TWFuYWdlZERldmljZXMuUHJpdmlsZWdlZE9wZXJhdGlvbnMuQWxsIERldmljZU1hbmFnZW1lbnRNYW5hZ2VkRGV2aWNlcy5SZWFkLkFsbCBEZXZpY2VNYW5hZ2VtZW50TWFuYWdlZERldmljZXMuUmVhZFdyaXRlLkFsbCBEZXZpY2VNYW5hZ2VtZW50UkJBQy5SZWFkLkFsbCBEZXZpY2VNYW5hZ2VtZW50UkJBQy5SZWFkV3JpdGUuQWxsIERldmljZU1hbmFnZW1lbnRTZXJ2aWNlQ29uZmlnLlJlYWQuQWxsIERldmljZU1hbmFnZW1lbnRTZXJ2aWNlQ29uZmlnLlJlYWRXcml0ZS5BbGwgRGlyZWN0b3J5LkFjY2Vzc0FzVXNlci5BbGwgRGlyZWN0b3J5LlJlYWQuQWxsIERpcmVjdG9yeS5SZWFkV3JpdGUuQWxsIEVBUy5BY2Nlc3NBc1VzZXIuQWxsIEVkdUFkbWluaXN0cmF0aW9uLlJlYWQgRWR1QWRtaW5pc3RyYXRpb24uUmVhZFdyaXRlIEVkdUFzc2lnbm1lbnRzLlJlYWQgRWR1QXNzaWdubWVudHMuUmVhZEJhc2ljIEVkdUFzc2lnbm1lbnRzLlJlYWRXcml0ZSBFZHVBc3NpZ25tZW50cy5SZWFkV3JpdGVCYXNpYyBFZHVSb3N0ZXIuUmVhZCBFZHVSb3N0ZXIuUmVhZEJhc2ljIEVkdVJvc3Rlci5SZWFkV3JpdGUgRmlsZXMuUmVhZCBGaWxlcy5SZWFkLkFsbCBGaWxlcy5SZWFkLlNlbGVjdGVkIEZpbGVzLlJlYWRXcml0ZSBGaWxlcy5SZWFkV3JpdGUuQWxsIEZpbGVzLlJlYWRXcml0ZS5BcHBGb2xkZXIgRmlsZXMuUmVhZFdyaXRlLlNlbGVjdGVkIEZpbmFuY2lhbHMuUmVhZFdyaXRlLkFsbCBHcm91cC5SZWFkLkFsbCBHcm91cC5SZWFkV3JpdGUuQWxsIElkZW50aXR5UHJvdmlkZXIuUmVhZC5BbGwgSWRlbnRpdHlQcm92aWRlci5SZWFkV3JpdGUuQWxsIElkZW50aXR5Umlza0V2ZW50LlJlYWQuQWxsIE1haWwuUmVhZCBNYWlsLlJlYWQuU2hhcmVkIE1haWwuUmVhZFdyaXRlIE1haWwuUmVhZFdyaXRlLlNoYXJlZCBNYWlsLlNlbmQgTWFpbC5TZW5kLlNoYXJlZCBNYWlsYm94U2V0dGluZ3MuUmVhZCBNYWlsYm94U2V0dGluZ3MuUmVhZFdyaXRlIE1lbWJlci5SZWFkLkhpZGRlbiBOb3Rlcy5DcmVhdGUgTm90ZXMuUmVhZCBOb3Rlcy5SZWFkLkFsbCBOb3Rlcy5SZWFkV3JpdGUgTm90ZXMuUmVhZFdyaXRlLkFsbCBOb3Rlcy5SZWFkV3JpdGUuQ3JlYXRlZEJ5QXBwIFBlb3BsZS5SZWFkIFBlb3BsZS5SZWFkLkFsbCBQcml2aWxlZ2VkQWNjZXNzLlJlYWRXcml0ZS5BenVyZUFEIFByaXZpbGVnZWRBY2Nlc3MuUmVhZFdyaXRlLkF6dXJlUmVzb3VyY2VzIFJlcG9ydHMuUmVhZC5BbGwgU2VjdXJpdHlFdmVudHMuUmVhZC5BbGwgU2VjdXJpdHlFdmVudHMuUmVhZFdyaXRlLkFsbCBTaXRlcy5GdWxsQ29udHJvbC5BbGwgU2l0ZXMuTWFuYWdlLkFsbCBTaXRlcy5SZWFkLkFsbCBTaXRlcy5SZWFkV3JpdGUuQWxsIFN1YnNjcmlwdGlvbi5SZWFkLkFsbCBUYXNrcy5SZWFkIFRhc2tzLlJlYWQuU2hhcmVkIFRhc2tzLlJlYWRXcml0ZSBUYXNrcy5SZWFkV3JpdGUuU2hhcmVkIFVzZXIuRXhwb3J0LkFsbCBVc2VyLkludml0ZS5BbGwgVXNlci5SZWFkIFVzZXIuUmVhZC5BbGwgVXNlci5SZWFkQmFzaWMuQWxsIFVzZXIuUmVhZFdyaXRlIFVzZXIuUmVhZFdyaXRlLkFsbCBVc2VyQWN0aXZpdHkuUmVhZFdyaXRlLkNyZWF0ZWRCeUFwcCBVc2VyVGltZWxpbmVBY3Rpdml0eS5Xcml0ZS5DcmVhdGVkQnlBcHAiLCJzdWIiOiJPZzgyUWk1OTJqLTlzUEQwZnM5dEJDeWpXMGlUSzVNY1ozT2VUbDlFbDlRIiwidGVuYW50X3JlZ2lvbl9zY29wZSI6Ik5BIiwidGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIiwidW5pcXVlX25hbWUiOiJpZGxhYjFAbXNpZGxhYjQub25taWNyb3NvZnQuY29tIiwidXBuIjoiaWRsYWIxQG1zaWRsYWI0Lm9ubWljcm9zb2Z0LmNvbSIsInV0aSI6IjRLakI1T3BzVFVXSDRScEtGX1VpQUEiLCJ2ZXIiOiIxLjAiLCJ4bXNfY2MiOlsiQ1AxIl19.UsxmiVwSy8oUbWnYF8Cp0niClgJVNpvxtK7IOz73sHdkY28FYA8zIdMPKBdOX5CufIUn59d78X4WevEPrK9USaeD67c7S0W76HUmRjgfVjqqOhNj15rPwYTHhpYbI_7hOw_Lo68H2q5V7joZx59sosW2Vy3zawob02EaQpvHh_cQp6cMF-oJt5JT8J4iQblo03KndRZVaNh_n3oVDQmMaEzur4tBB4lnUAoaExE6hNFOWi25h59PNctiPRGEBe17MrJqTNuey8zICsCnCrTG9yVe1GVEZ2aF2JXH-JsqTxxoCA7JVnpU4CwxN3ONLYeg-mLYwDtYxybelSvVV-LitA";
 
     static final String TEST_IDTOKEN_USERID = "4f859989-a2ff-411e-9048-c322247ac62c";
 
@@ -581,6 +588,46 @@ public final class AuthenticationContextTest {
 
         final AuthenticationRequest authenticationRequest2 = (AuthenticationRequest) request2;
         assertEquals("Prompt param is same", PromptBehavior.REFRESH_SESSION, authenticationRequest2.getPrompt());
+    }
+
+    @Test
+    public void testTokenContainsDeviceId() throws InterruptedException, IOException, ParseException, PackageManager.NameNotFoundException {
+        FileMockContext mockContext = new FileMockContext(getInstrumentation().getContext());
+        ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
+        final AuthenticationContext context = getAuthenticationContext(mockContext,
+                VALID_AUTHORITY, false, mockCache);
+
+        final MockActivity testActivity = new MockActivity();
+        final CountDownLatch signal = new CountDownLatch(1);
+        testActivity.mSignal = signal;
+        MockAuthenticationCallback callback = new MockAuthenticationCallback(signal);
+        final String response = "{\"id_token\":\""
+                + TEST_IDTOKEN
+                + "\",\"access_token\":\"" + TEST_ACCESS_TOKEN_WITH_DEVICE_ID + "\",\"token_type\":\"Bearer\",\"expires_in\":\"-10\",\"expires_on\":\"1368768616\",\"refresh_token\":\"refresh112\",\"scope\":\"*\",\"deviceid\":\"1234\", \"client_info\":\"" + Util.TEST_CLIENT_INFO + "\"}";
+
+        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+        HttpUrlConnectionFactory.setMockedHttpUrlConnection(mockedConnection);
+        Util.prepareMockedUrlConnection(mockedConnection);
+        Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
+        Mockito.when(mockedConnection.getInputStream()).thenReturn(Util.createInputStream(response));
+        Mockito.when(mockedConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        final PackageManager mockedPackageManager = Mockito.mock(PackageManager.class);
+        final PackageInfo mockPackageInfo = new PackageInfo();
+        mockPackageInfo.setLongVersionCode(Long.MAX_VALUE);
+        Mockito.when(mockedPackageManager.getPackageInfo(Mockito.anyString(), Mockito.anyInt())).thenReturn(mockPackageInfo);
+        mockContext.setMockedPackageManager(mockedPackageManager);
+
+        // Call acquire token which will try refresh token based on cache
+        context.acquireToken(testActivity.getTestActivity(), "resource", "clientid", "redirectUri",
+                TEST_IDTOKEN_UPN, PromptBehavior.Auto, null, "{\"access_token\":{\"deviceid\":{\"essential\":true}}}", callback);
+        signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
+
+        final JWT decodedToken = JWTParser.parse(callback.getAuthenticationResult().getAccessToken());
+        Assert.assertNotNull(decodedToken.getJWTClaimsSet().getClaim("deviceid"));
     }
 
     @Test
@@ -1996,7 +2043,6 @@ public final class AuthenticationContextTest {
      */
     @Test
     public void testAcquireTokenCacheLookup() throws InterruptedException {
-
         final FileMockContext mockContext = new FileMockContext(getInstrumentation().getContext());
         final String tokenToTest = "accessToken=" + UUID.randomUUID();
         final String resource = "Resource" + UUID.randomUUID();

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AuthenticationContextTest.java
@@ -626,7 +626,10 @@ public final class AuthenticationContextTest {
                 TEST_IDTOKEN_UPN, PromptBehavior.Auto, null, "{\"access_token\":{\"deviceid\":{\"essential\":true}}}", callback);
         signal.await(CONTEXT_REQUEST_TIME_OUT, TimeUnit.MILLISECONDS);
 
-        final JWT decodedToken = JWTParser.parse(callback.getAuthenticationResult().getAccessToken());
+        final String accessToken = callback.getAuthenticationResult().getAccessToken();
+        Assert.assertEquals(TEST_ACCESS_TOKEN_WITH_DEVICE_ID, accessToken);
+
+        final JWT decodedToken = JWTParser.parse(accessToken);
         final Object deviceIdClaim = decodedToken.getJWTClaimsSet().getClaim("deviceid");
         Assert.assertNotNull(deviceIdClaim);
 

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/MockDeviceCertProxy.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/MockDeviceCertProxy.java
@@ -24,6 +24,7 @@
 package com.microsoft.aad.adal;
 
 import com.microsoft.identity.common.java.challengehandlers.IDeviceCertificate;
+import com.microsoft.identity.common.java.exception.ClientException;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -58,12 +59,6 @@ public class MockDeviceCertProxy implements IDeviceCertificate {
         sValidIssuer = false;
     }
 
-    @Override
-    public X509Certificate getCertificate() {
-        return sCertificate;
-    }
-
-    @Override
     public PrivateKey getPrivateKey() {
         return sPrivateKey;
     }
@@ -78,9 +73,19 @@ public class MockDeviceCertProxy implements IDeviceCertificate {
     }
 
     @Override
+    public byte[] sign(String algorithm, byte[] dataToBeSigned) throws ClientException {
+        throw new UnsupportedOperationException("This is not supported in MockDeviceCertProxy");
+    }
+
+    @Override
     public boolean isValidIssuer(List<String> certAuthorities) {
         // TODO Auto-generated method stub
         return sValidIssuer;
+    }
+
+    @Override
+    public X509Certificate getX509() {
+        return sCertificate;
     }
 
     static final void setCertificate(final X509Certificate certificate) {


### PR DESCRIPTION
This PR includes an added test in ADAL to allow removal of this manual E2E test case by replacing it with a component test https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1610899.

Note that the component test is not meant to cover this entire E2E test case, just the adal client side request/response handling, as the Broker behavior for this flow is already tested in msal UI automation.