### PR TITLE
Replacing SHA-1 used in broker validation with SHA-512

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AndroidTestHelper.java
@@ -84,7 +84,7 @@ public class AndroidTestHelper {
 
         for (Signature signature : PackageHelper.getSignatures(context)) {
             mTestSignature = signature.toByteArray();
-            MessageDigest md = MessageDigest.getInstance("SHA");
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
             md.update(mTestSignature);
             mTestTag = Base64.encodeToString(md.digest(), Base64.DEFAULT);
             break;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerAccountServiceTest.java
@@ -398,7 +398,7 @@ public final class BrokerAccountServiceTest {
         String signatureTag;
         for (final Signature signature : PackageHelper.getSignatures(info)) {
             signatureByte = signature.toByteArray();
-            MessageDigest md = MessageDigest.getInstance("SHA");
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
             md.update(signatureByte);
             signatureTag = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
             return new SignatureData(new Signature(signatureByte), signatureTag);

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/BrokerProxyTests.java
@@ -139,7 +139,7 @@ public class BrokerProxyTests {
         // until it finds the correct one for ADAL broker.
         for (Signature signature : PackageHelper.getSignatures(info)) {
             mTestSignature = signature.toByteArray();
-            MessageDigest md = MessageDigest.getInstance("SHA");
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
             md.update(mTestSignature);
             mTestTag = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
             break;

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/HttpDialogTests.java
@@ -76,7 +76,7 @@ public class HttpDialogTests {
         // until it finds the correct one for ADAL broker.
         for (Signature signature : PackageHelper.getSignatures(mContext)) {
             mTestSignature = signature.toByteArray();
-            MessageDigest md = MessageDigest.getInstance("SHA");
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
             md.update(mTestSignature);
             mTestTag = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
             break;

--- a/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AcquireTokenRequest.java
@@ -763,7 +763,7 @@ class AcquireTokenRequest {
             base64URLEncodePackagename = URLEncoder.encode(mContext.getPackageName(),
                     AuthenticationConstants.ENCODING_UTF8);
             base64URLEncodeSignature = URLEncoder.encode(
-                    packageHelper.getCurrentSignatureForPackage(mContext.getPackageName()),
+                    packageHelper.getSha1SignatureForPackage(mContext.getPackageName()),
                     AuthenticationConstants.ENCODING_UTF8);
         } catch (final UnsupportedEncodingException e) {
             Logger.e(TAG + methodName, ADALError.ENCODING_IS_NOT_SUPPORTED.getDescription(), e.getMessage(), ADALError.ENCODING_IS_NOT_SUPPORTED, e);

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -401,7 +401,7 @@ public class AuthenticationActivity extends DualScreenActivity {
 
             final BrokerValidator brokerValidator = new BrokerValidator(this);
 
-            final String signature = info.getCurrentSignatureForPackage(packageName);
+            final String signature = info.getCurrentSignatureForPackage(packageName, true);
 
             return brokerValidator.verifySignature(packageName) ||
                     signature.equals(AuthenticationSettings.INSTANCE.getBrokerSignature());

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationActivity.java
@@ -322,7 +322,7 @@ public class AuthenticationActivity extends DualScreenActivity {
             mCallingPackage = getCallingPackage();
             mCallingUID = info.getUIDForPackage(mCallingPackage);
 
-            final String signatureDigest = info.getCurrentSignatureForPackage(mCallingPackage);
+            final String signatureDigest = info.getSha1SignatureForPackage(mCallingPackage);
             mStartUrl = getBrokerStartUrl(mStartUrl, mCallingPackage, signatureDigest);
 
             if (!isCallerBrokerInstaller()) {
@@ -402,7 +402,7 @@ public class AuthenticationActivity extends DualScreenActivity {
 
             final BrokerValidator brokerValidator = new BrokerValidator(this);
 
-            final String signature = info.getCurrentSignatureForPackage(packageName, true);
+            final String signature = info.getSha512SignatureForPackage(packageName);
 
             return brokerValidator.verifySignature(packageName) ||
                     signature.equals(AuthenticationSettings.INSTANCE.getBrokerSignature());

--- a/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java
@@ -52,7 +52,6 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -61,7 +60,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.microsoft.aad.adal.TokenCacheAccessor.getMsalOAuth2TokenCache;
 import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
 
 /**
@@ -268,7 +266,7 @@ public class AuthenticationContext {
 
         // First available signature. Applications can be signed with multiple
         // signatures.
-        final String signatureDigest = packageHelper.getCurrentSignatureForPackage(packageName);
+        final String signatureDigest = packageHelper.getSha1SignatureForPackage(packageName);
         final String redirectUri = PackageHelper.getBrokerRedirectUrl(packageName, signatureDigest);
         Logger.v(TAG + methodName, "Get expected redirect Uri. ", "Broker redirectUri:" + redirectUri + " packagename:" + packageName
                 + " signatureDigest:" + signatureDigest, null);

--- a/adal/src/test/java/com/microsoft/aad/adal/MockPackageManager.java
+++ b/adal/src/test/java/com/microsoft/aad/adal/MockPackageManager.java
@@ -1,0 +1,597 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.aad.adal;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.ChangedPackages;
+import android.content.pm.FeatureInfo;
+import android.content.pm.InstrumentationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
+import android.content.pm.PermissionGroupInfo;
+import android.content.pm.PermissionInfo;
+import android.content.pm.ProviderInfo;
+import android.content.pm.ResolveInfo;
+import android.content.pm.ServiceInfo;
+import android.content.pm.SharedLibraryInfo;
+import android.content.pm.Signature;
+import android.content.pm.VersionedPackage;
+import android.content.res.Resources;
+import android.content.res.XmlResourceParser;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.os.UserHandle;
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+public class MockPackageManager extends PackageManager {
+
+    final Signature mockedSignature;
+
+    public MockPackageManager(final String encodedSignature) {
+        mockedSignature = new Signature(Base64.decode(encodedSignature, Base64.NO_WRAP));
+    }
+
+    public Signature getMockedSignature() {
+        return mockedSignature;
+    }
+
+    @Override
+    public PackageInfo getPackageInfo(String packageName, int flags) {
+        SigningInfoShadow.setSignatures(new Signature[]{mockedSignature});
+        final PackageInfo packageInfo = new PackageInfo();
+        packageInfo.signatures = new Signature[]{mockedSignature};
+        return packageInfo;
+    }
+
+    @Override
+    public PackageInfo getPackageInfo(@NonNull VersionedPackage versionedPackage, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public String[] currentToCanonicalPackageNames(@NonNull String[] packageNames) {
+        return new String[0];
+    }
+
+    @Override
+    public String[] canonicalToCurrentPackageNames(@NonNull String[] packageNames) {
+        return new String[0];
+    }
+
+    @Nullable
+    @Override
+    public Intent getLaunchIntentForPackage(@NonNull String packageName) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Intent getLeanbackLaunchIntentForPackage(@NonNull String packageName) {
+        return null;
+    }
+
+    @Override
+    public int[] getPackageGids(@NonNull String packageName) throws NameNotFoundException {
+        return new int[0];
+    }
+
+    @Override
+    public int[] getPackageGids(@NonNull String packageName, int flags) throws NameNotFoundException {
+        return new int[0];
+    }
+
+    @Override
+    public int getPackageUid(@NonNull String packageName, int flags) throws NameNotFoundException {
+        return 0;
+    }
+
+    @Override
+    public PermissionInfo getPermissionInfo(@NonNull String permName, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<PermissionInfo> queryPermissionsByGroup(@NonNull String permissionGroup, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public PermissionGroupInfo getPermissionGroupInfo(@NonNull String permName, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<PermissionGroupInfo> getAllPermissionGroups(int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public ApplicationInfo getApplicationInfo(@NonNull String packageName, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public ActivityInfo getActivityInfo(@NonNull ComponentName component, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public ActivityInfo getReceiverInfo(@NonNull ComponentName component, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public ServiceInfo getServiceInfo(@NonNull ComponentName component, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public ProviderInfo getProviderInfo(@NonNull ComponentName component, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<PackageInfo> getInstalledPackages(int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<PackageInfo> getPackagesHoldingPermissions(@NonNull String[] permissions, int flags) {
+        return null;
+    }
+
+    @Override
+    public int checkPermission(@NonNull String permName, @NonNull String packageName) {
+        return 0;
+    }
+
+    @Override
+    public boolean isPermissionRevokedByPolicy(@NonNull String permName, @NonNull String packageName) {
+        return false;
+    }
+
+    @Override
+    public boolean addPermission(@NonNull PermissionInfo info) {
+        return false;
+    }
+
+    @Override
+    public boolean addPermissionAsync(@NonNull PermissionInfo info) {
+        return false;
+    }
+
+    @Override
+    public void removePermission(@NonNull String permName) {
+
+    }
+
+    @Override
+    public int checkSignatures(@NonNull String packageName1, @NonNull String packageName2) {
+        return 0;
+    }
+
+    @Override
+    public int checkSignatures(int uid1, int uid2) {
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public String[] getPackagesForUid(int uid) {
+        return new String[0];
+    }
+
+    @Nullable
+    @Override
+    public String getNameForUid(int uid) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ApplicationInfo> getInstalledApplications(int flags) {
+        return null;
+    }
+
+    @Override
+    public boolean isInstantApp() {
+        return false;
+    }
+
+    @Override
+    public boolean isInstantApp(@NonNull String packageName) {
+        return false;
+    }
+
+    @Override
+    public int getInstantAppCookieMaxBytes() {
+        return 0;
+    }
+
+    @NonNull
+    @Override
+    public byte[] getInstantAppCookie() {
+        return new byte[0];
+    }
+
+    @Override
+    public void clearInstantAppCookie() {
+
+    }
+
+    @Override
+    public void updateInstantAppCookie(@Nullable byte[] cookie) {
+
+    }
+
+    @Nullable
+    @Override
+    public String[] getSystemSharedLibraryNames() {
+        return new String[0];
+    }
+
+    @NonNull
+    @Override
+    public List<SharedLibraryInfo> getSharedLibraries(int flags) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public ChangedPackages getChangedPackages(int sequenceNumber) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public FeatureInfo[] getSystemAvailableFeatures() {
+        return new FeatureInfo[0];
+    }
+
+    @Override
+    public boolean hasSystemFeature(@NonNull String featureName) {
+        return false;
+    }
+
+    @Override
+    public boolean hasSystemFeature(@NonNull String featureName, int version) {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public ResolveInfo resolveActivity(@NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ResolveInfo> queryIntentActivities(@NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ResolveInfo> queryIntentActivityOptions(@Nullable ComponentName caller, @Nullable Intent[] specifics, @NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ResolveInfo> queryBroadcastReceivers(@NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public ResolveInfo resolveService(@NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ResolveInfo> queryIntentServices(@NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ResolveInfo> queryIntentContentProviders(@NonNull Intent intent, int flags) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public ProviderInfo resolveContentProvider(@NonNull String authority, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<ProviderInfo> queryContentProviders(@Nullable String processName, int uid, int flags) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public InstrumentationInfo getInstrumentationInfo(@NonNull ComponentName className, int flags) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public List<InstrumentationInfo> queryInstrumentation(@NonNull String targetPackage, int flags) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getDrawable(@NonNull String packageName, int resid, @Nullable ApplicationInfo appInfo) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getActivityIcon(@NonNull ComponentName activityName) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getActivityIcon(@NonNull Intent intent) throws NameNotFoundException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getActivityBanner(@NonNull ComponentName activityName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getActivityBanner(@NonNull Intent intent) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getDefaultActivityIcon() {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getApplicationIcon(@NonNull ApplicationInfo info) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getApplicationIcon(@NonNull String packageName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getApplicationBanner(@NonNull ApplicationInfo info) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getApplicationBanner(@NonNull String packageName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getActivityLogo(@NonNull ComponentName activityName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getActivityLogo(@NonNull Intent intent) throws NameNotFoundException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getApplicationLogo(@NonNull ApplicationInfo info) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Drawable getApplicationLogo(@NonNull String packageName) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getUserBadgedIcon(@NonNull Drawable drawable, @NonNull UserHandle user) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Drawable getUserBadgedDrawableForDensity(@NonNull Drawable drawable, @NonNull UserHandle user, @Nullable Rect badgeLocation, int badgeDensity) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public CharSequence getUserBadgedLabel(@NonNull CharSequence label, @NonNull UserHandle user) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public CharSequence getText(@NonNull String packageName, int resid, @Nullable ApplicationInfo appInfo) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public XmlResourceParser getXml(@NonNull String packageName, int resid, @Nullable ApplicationInfo appInfo) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public CharSequence getApplicationLabel(@NonNull ApplicationInfo info) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Resources getResourcesForActivity(@NonNull ComponentName activityName) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Resources getResourcesForApplication(@NonNull ApplicationInfo app) throws NameNotFoundException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Resources getResourcesForApplication(@NonNull String packageName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public void verifyPendingInstall(int id, int verificationCode) {
+
+    }
+
+    @Override
+    public void extendVerificationTimeout(int id, int verificationCodeAtTimeout, long millisecondsToDelay) {
+
+    }
+
+    @Override
+    public void setInstallerPackageName(@NonNull String targetPackage, @Nullable String installerPackageName) {
+
+    }
+
+    @Nullable
+    @Override
+    public String getInstallerPackageName(@NonNull String packageName) {
+        return null;
+    }
+
+    @Override
+    public void addPackageToPreferred(@NonNull String packageName) {
+
+    }
+
+    @Override
+    public void removePackageFromPreferred(@NonNull String packageName) {
+
+    }
+
+    @NonNull
+    @Override
+    public List<PackageInfo> getPreferredPackages(int flags) {
+        return null;
+    }
+
+    @Override
+    public void addPreferredActivity(@NonNull IntentFilter filter, int match, @Nullable ComponentName[] set, @NonNull ComponentName activity) {
+
+    }
+
+    @Override
+    public void clearPackagePreferredActivities(@NonNull String packageName) {
+
+    }
+
+    @Override
+    public int getPreferredActivities(@NonNull List<IntentFilter> outFilters, @NonNull List<ComponentName> outActivities, @Nullable String packageName) {
+        return 0;
+    }
+
+    @Override
+    public void setComponentEnabledSetting(@NonNull ComponentName componentName, int newState, int flags) {
+
+    }
+
+    @Override
+    public int getComponentEnabledSetting(@NonNull ComponentName componentName) {
+        return 0;
+    }
+
+    @Override
+    public void setApplicationEnabledSetting(@NonNull String packageName, int newState, int flags) {
+
+    }
+
+    @Override
+    public int getApplicationEnabledSetting(@NonNull String packageName) {
+        return 0;
+    }
+
+    @Override
+    public boolean isSafeMode() {
+        return false;
+    }
+
+    @Override
+    public void setApplicationCategoryHint(@NonNull String packageName, int categoryHint) {
+
+    }
+
+    @NonNull
+    @Override
+    public PackageInstaller getPackageInstaller() {
+        return null;
+    }
+
+    @Override
+    public boolean canRequestPackageInstalls() {
+        return false;
+    }
+}

--- a/adal/src/test/java/com/microsoft/aad/adal/PackageHelperCurrentSignatureTests.java
+++ b/adal/src/test/java/com/microsoft/aad/adal/PackageHelperCurrentSignatureTests.java
@@ -45,14 +45,19 @@ import static org.junit.Assert.assertEquals;
 public class PackageHelperCurrentSignatureTests {
     static final String ENCODED_SIGNATURE = "MIIGDjCCA/agAwIBAgIEUiDePDANBgkqhkiG9w0BAQsFADCByDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjErMCkGA1UECxMiV2luZG93cyBJbnR1bmUgU2lnbmluZyBmb3IgQW5kcm9pZDFFMEMGA1UEAxM8TWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIChEbyBOb3QgVHJ1c3QpMB4XDTEzMDgzMDE4MDIzNloXDTM2MTAyMTE4MDIzNlowgcgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xKzApBgNVBAsTIldpbmRvd3MgSW50dW5lIFNpZ25pbmcgZm9yIEFuZHJvaWQxRTBDBgNVBAMTPE1pY3Jvc29mdCBDb3Jwb3JhdGlvbiBUaGlyZCBQYXJ0eSBNYXJrZXRwbGFjZSAoRG8gTm90IFRydXN0KTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKl5psvH2mb9nmMz1QdQRX3UFJrl4ARRp9Amq4HC1zXFL6oCzhq6ZkuOGFoPPwTSVseBJsw4FSaX21sDWISpx/cjpg7RmJvNwf0IC6BUxDaQMpeo4hBKErKzqgyXa2T9GmVpkSb2TLpL8IpLtkxih8+GB6/09DkXR10Ir+cE+Pdkd/4iV44oKLxTbLprX1Rspcu07p/4JS6jO5vgDVV9OqRLLcAwrlewqua9oTDbAp/mDldztp//Z+8XiY6j/AJCKFvn+cA4s6s5kYj/jsK4/wt9nfo5aD9vRzE2j2IIH1T0Qj6NLTNxB7+Ij6dykE8QHJ7Vd/Y5af9QZwXyyPdSvwqhvKafS0baSqy1gLaNLA/gc/1Sh/ASXaDEhKHHAsLChkVFCE7cPwKPnBHudNBmS6HQ6Zo3UMwYVQVe7u+6jjvfo4gqmZglMhhzhauekNrHV91E+GkY3NGH2cHDEbpbl0JAAdWsI4jtJSN8c9Y8lSX00D7KdQ2NJhYl7mJsS10/3Ex1HYr8nDRq/IlAhGdSVC/qc9RktfYiYcmfZ/Iel5n+KkQt1svrF1TDCHYg/bcC7BhCwlaoa4Nu0hvLHvSbrsnB+gKtovCCilswPwCnDdAYmSMnwsAtBwJXqxD6HXbBCNX4A+qUrR+sYhmFa8jIVzAXa4I3iTvVQkTvrf9YriP7AgMBAAEwDQYJKoZIhvcNAQELBQADggIBAEdMG13+y2OvUHP1lHP22CNXk5e2lVgKZaEEWdxqGFZPuNsXsrHjAMOM4ocmyPUYAlscZsSRcMffMlBqbTyXIDfjkICwuJ+QdD7ySEKuLA1iWFMpwa30PSeZP4H0AlF9RkFhl/J9a9Le+5LdQihicHaTD2DEqCAQvR2RhonBr4vOV2bDnVParhaAEIMzwg2btj4nz8R/S0Nnx1O0YEHoXzbDRYHfL9ZfERp+9I8rtvWhRQRdhh9JNUbSPS6ygFZO67VECfxCOZ1MzPY9YEEdCcpPt5rgMEKVh7VPH14zsBuky2Opf6rGGS1m1Q26edG9dPtnAYax5AIkUG6cI3tW957qmUVSnIvlMzt6+OMYSKf5R5fdPdRlH1l8hak9vMxO2l344HyD0vAmbk01dw44PhIfuoq2qNAIt3lweEhZna8m5s9r1NEaRTf1BrVHXloAM+sipd5vQNs6oezSCicU7vwvUH1hIz0FOiCsLPTyxlfHk3ESS5QsivJS82TLSIb9HLX07OyENRRm8cVZdDbz6rRR+UWn1ZNEM9q56IZ+nCIOCbTjYlw1oZFowJDCL1IH8i7nhKVGBWf7TfukucDzh8ThOgMyyv6rIPutnssxQqQ7ed6iivc1y4Graihrr9n2HODRo3iUCXi+G4kfdmMwp2iwJz+Kjhyuqf7lhdOld6cs";
     private String testSignature;
+    private String testSignatureSha512;
     private Signature mockedSignature;
 
     @Before
     public void setUp() throws Exception {
         mockedSignature = new Signature(Base64.decode(ENCODED_SIGNATURE, Base64.NO_WRAP));
-        MessageDigest md = MessageDigest.getInstance("SHA");
-        md.update(mockedSignature.toByteArray());
-        testSignature = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
+        MessageDigest mdSha = MessageDigest.getInstance("SHA");
+        mdSha.update(mockedSignature.toByteArray());
+        testSignature = Base64.encodeToString(mdSha.digest(), Base64.NO_WRAP);
+        MessageDigest mdSha512 = MessageDigest.getInstance("SHA-512");
+        mdSha512.update(mockedSignature.toByteArray());
+        testSignatureSha512 = Base64.encodeToString(mdSha512.digest(), Base64.NO_WRAP);
+
     }
 
     @Test
@@ -60,8 +65,18 @@ public class PackageHelperCurrentSignatureTests {
         SigningInfoShadow.setSignatures(new Signature[]{mockedSignature});
         PackageInfo packageInfo = new PackageInfo();
         packageInfo.signatures = new Signature[]{mockedSignature};
-        String signature = PackageHelper.getCurrentSignatureForPackage(packageInfo);
+        String signature = PackageHelper.getCurrentSignatureForPackage(packageInfo, false);
         // assert
         assertEquals("should be same info", testSignature, signature);
+    }
+
+    @Test
+    public void testGetCurrentSignature512ForPackage() {
+        SigningInfoShadow.setSignatures(new Signature[]{mockedSignature});
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.signatures = new Signature[]{mockedSignature};
+        String signature512 = PackageHelper.getCurrentSignatureForPackage(packageInfo, true);
+        // assert
+        assertEquals("should be same info", testSignatureSha512, signature512);
     }
 }

--- a/adal/src/test/java/com/microsoft/aad/adal/PackageHelperCurrentSignatureTests.java
+++ b/adal/src/test/java/com/microsoft/aad/adal/PackageHelperCurrentSignatureTests.java
@@ -22,8 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.aad.adal;
 
-import android.content.pm.PackageInfo;
-import android.content.pm.Signature;
 import android.util.Base64;
 
 import com.microsoft.identity.common.internal.broker.PackageHelper;
@@ -35,6 +33,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -43,40 +42,41 @@ import static org.junit.Assert.assertEquals;
         SigningInfoShadow.class
 })
 public class PackageHelperCurrentSignatureTests {
+    static final String TEST_PACKAGE_NAME = "foo";
     static final String ENCODED_SIGNATURE = "MIIGDjCCA/agAwIBAgIEUiDePDANBgkqhkiG9w0BAQsFADCByDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjErMCkGA1UECxMiV2luZG93cyBJbnR1bmUgU2lnbmluZyBmb3IgQW5kcm9pZDFFMEMGA1UEAxM8TWljcm9zb2Z0IENvcnBvcmF0aW9uIFRoaXJkIFBhcnR5IE1hcmtldHBsYWNlIChEbyBOb3QgVHJ1c3QpMB4XDTEzMDgzMDE4MDIzNloXDTM2MTAyMTE4MDIzNlowgcgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24xKzApBgNVBAsTIldpbmRvd3MgSW50dW5lIFNpZ25pbmcgZm9yIEFuZHJvaWQxRTBDBgNVBAMTPE1pY3Jvc29mdCBDb3Jwb3JhdGlvbiBUaGlyZCBQYXJ0eSBNYXJrZXRwbGFjZSAoRG8gTm90IFRydXN0KTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKl5psvH2mb9nmMz1QdQRX3UFJrl4ARRp9Amq4HC1zXFL6oCzhq6ZkuOGFoPPwTSVseBJsw4FSaX21sDWISpx/cjpg7RmJvNwf0IC6BUxDaQMpeo4hBKErKzqgyXa2T9GmVpkSb2TLpL8IpLtkxih8+GB6/09DkXR10Ir+cE+Pdkd/4iV44oKLxTbLprX1Rspcu07p/4JS6jO5vgDVV9OqRLLcAwrlewqua9oTDbAp/mDldztp//Z+8XiY6j/AJCKFvn+cA4s6s5kYj/jsK4/wt9nfo5aD9vRzE2j2IIH1T0Qj6NLTNxB7+Ij6dykE8QHJ7Vd/Y5af9QZwXyyPdSvwqhvKafS0baSqy1gLaNLA/gc/1Sh/ASXaDEhKHHAsLChkVFCE7cPwKPnBHudNBmS6HQ6Zo3UMwYVQVe7u+6jjvfo4gqmZglMhhzhauekNrHV91E+GkY3NGH2cHDEbpbl0JAAdWsI4jtJSN8c9Y8lSX00D7KdQ2NJhYl7mJsS10/3Ex1HYr8nDRq/IlAhGdSVC/qc9RktfYiYcmfZ/Iel5n+KkQt1svrF1TDCHYg/bcC7BhCwlaoa4Nu0hvLHvSbrsnB+gKtovCCilswPwCnDdAYmSMnwsAtBwJXqxD6HXbBCNX4A+qUrR+sYhmFa8jIVzAXa4I3iTvVQkTvrf9YriP7AgMBAAEwDQYJKoZIhvcNAQELBQADggIBAEdMG13+y2OvUHP1lHP22CNXk5e2lVgKZaEEWdxqGFZPuNsXsrHjAMOM4ocmyPUYAlscZsSRcMffMlBqbTyXIDfjkICwuJ+QdD7ySEKuLA1iWFMpwa30PSeZP4H0AlF9RkFhl/J9a9Le+5LdQihicHaTD2DEqCAQvR2RhonBr4vOV2bDnVParhaAEIMzwg2btj4nz8R/S0Nnx1O0YEHoXzbDRYHfL9ZfERp+9I8rtvWhRQRdhh9JNUbSPS6ygFZO67VECfxCOZ1MzPY9YEEdCcpPt5rgMEKVh7VPH14zsBuky2Opf6rGGS1m1Q26edG9dPtnAYax5AIkUG6cI3tW957qmUVSnIvlMzt6+OMYSKf5R5fdPdRlH1l8hak9vMxO2l344HyD0vAmbk01dw44PhIfuoq2qNAIt3lweEhZna8m5s9r1NEaRTf1BrVHXloAM+sipd5vQNs6oezSCicU7vwvUH1hIz0FOiCsLPTyxlfHk3ESS5QsivJS82TLSIb9HLX07OyENRRm8cVZdDbz6rRR+UWn1ZNEM9q56IZ+nCIOCbTjYlw1oZFowJDCL1IH8i7nhKVGBWf7TfukucDzh8ThOgMyyv6rIPutnssxQqQ7ed6iivc1y4Graihrr9n2HODRo3iUCXi+G4kfdmMwp2iwJz+Kjhyuqf7lhdOld6cs";
-    private String testSignature;
-    private String testSignatureSha512;
-    private Signature mockedSignature;
+
+    private MockPackageManager mockPackageManager;
 
     @Before
     public void setUp() throws Exception {
-        mockedSignature = new Signature(Base64.decode(ENCODED_SIGNATURE, Base64.NO_WRAP));
-        MessageDigest mdSha = MessageDigest.getInstance("SHA");
-        mdSha.update(mockedSignature.toByteArray());
-        testSignature = Base64.encodeToString(mdSha.digest(), Base64.NO_WRAP);
-        MessageDigest mdSha512 = MessageDigest.getInstance("SHA-512");
-        mdSha512.update(mockedSignature.toByteArray());
-        testSignatureSha512 = Base64.encodeToString(mdSha512.digest(), Base64.NO_WRAP);
-
+        mockPackageManager = new MockPackageManager(ENCODED_SIGNATURE);
     }
 
     @Test
-    public void testGetCurrentSignatureForPackage() {
-        SigningInfoShadow.setSignatures(new Signature[]{mockedSignature});
-        PackageInfo packageInfo = new PackageInfo();
-        packageInfo.signatures = new Signature[]{mockedSignature};
-        String signature = PackageHelper.getCurrentSignatureForPackage(packageInfo, false);
-        // assert
-        assertEquals("should be same info", testSignature, signature);
+    public void testGetCurrentSignatureForPackageSha1() {
+        try {
+            MessageDigest mdSha = MessageDigest.getInstance("SHA");
+            mdSha.update(mockPackageManager.getMockedSignature().toByteArray());
+            final String testSignature = Base64.encodeToString(mdSha.digest(), Base64.NO_WRAP);
+            String signature = new PackageHelper(mockPackageManager).getSha1SignatureForPackage(TEST_PACKAGE_NAME);
+            // assert
+            assertEquals("should be same info", testSignature, signature);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
-    public void testGetCurrentSignature512ForPackage() {
-        SigningInfoShadow.setSignatures(new Signature[]{mockedSignature});
-        PackageInfo packageInfo = new PackageInfo();
-        packageInfo.signatures = new Signature[]{mockedSignature};
-        String signature512 = PackageHelper.getCurrentSignatureForPackage(packageInfo, true);
-        // assert
-        assertEquals("should be same info", testSignatureSha512, signature512);
+    public void testGetCurrentSignatureForPackageSha512() {
+        try {
+            MessageDigest mdSha = MessageDigest.getInstance("SHA-512");
+            mdSha.update(mockPackageManager.getMockedSignature().toByteArray());
+            final String testSignature = Base64.encodeToString(mdSha.digest(), Base64.NO_WRAP);
+            String signature = new PackageHelper(mockPackageManager).getSha512SignatureForPackage(TEST_PACKAGE_NAME);
+            // assert
+            assertEquals("should be same info", testSignature, signature);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 VNext
 -------------
 - [MAJOR] Consolidate Storage Supplier (breaking change introduced in common) #1729
+- [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#1732)
 
 Version 4.6.0
 -------------


### PR DESCRIPTION
### Summary
This is the first of a few rounds of PRs that address the use of SHA-1 in our libraries. This set of PRs focuses on replacing SHA-1 usage in the broker verification logic with SHA-512. 

Main changes in ADAL:
- isCallerBrokerInstaller method updated with SHA-512 for validation.
- Many tests (mostly integration) updated to use a demo SHA-512 signature hash. 

### Testing
- General logging in and logging out with msalTestApp and Authenticator/Company Portal/BrokerHost as broker.
- Getting SSO Token (via BrokerHost broker api) 
- Device Token (via BrokerHost broker api) 
- Device signout unit tests passing

### Related PRs
- Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2019
- Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2251
- MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1826