### PR TITLE
Exclude common to be pulled from testUtils dependency

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -171,6 +171,7 @@ dependencies {
     testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     testLocalImplementation project(':testutils')
     testDistImplementation("com.microsoft.identity:testutils:0.0.+") {
+        exclude module: 'common'
         exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
     }
 


### PR DESCRIPTION
Excluding common to be pulled in from testutils as transitive dependency, since we specify the common version separately.
This sometime causes failure in daily build due to version conflicts.
