### PR TITLE
Add linting

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -170,10 +170,10 @@ dependencies {
     testImplementation ("org.robolectric:robolectric:$rootProject.ext.robolectricVersion")
     testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     testLocalImplementation project(':testutils')
-    testDistImplementation("com.microsoft.identity:testutils:0.0.+") {
-        exclude module: 'common'
-        exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
-    }
+//    testDistImplementation("com.microsoft.identity:testutils:0.0.+") {
+//        exclude module: 'common'
+//        exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
+//    }
 
     // Javadoc Dependencies
     javadocDeps "androidx.annotation:annotation:$rootProject.ext.annotationVersion"
@@ -358,9 +358,9 @@ tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
         task.dependsOn 'checkstyle', 'pmd', 'lint'
     }
-    
+
     if (task.name == 'assembleLocal') {
-        task.dependsOn 'lintLocalDebug', 'pmd'
+        task.dependsOn 'lintLocalDebug'
     }
 }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -356,13 +356,9 @@ task checkstyle(type: Checkstyle) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
-        task.dependsOn 'checkstyle', 'pmd'
+        task.dependsOn 'checkstyle', 'pmd', 'lint'
     }
-
-    if (task.name.contains('assemble')) {
-        task.dependsOn 'lint'
-    }
-
+    
     if (task.name == 'assembleLocal') {
         task.dependsOn 'lintLocalDebug', 'pmd'
     }

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -362,5 +362,9 @@ tasks.whenTaskAdded { task ->
     if (task.name.contains('assemble')) {
         task.dependsOn 'lint'
     }
+
+    if (task.name == 'assembleLocal') {
+        task.dependsOn 'lintLocalDebug', 'pmd'
+    }
 }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -356,7 +356,11 @@ task checkstyle(type: Checkstyle) {
 
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
-        task.dependsOn 'checkstyle', 'pmd', 'lint'
+        task.dependsOn 'checkstyle', 'pmd'
+    }
+
+    if (task.name.contains('assemble')) {
+        task.dependsOn 'lint'
     }
 }
 

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "com.dorongold.task-tree" version "1.5"
     id 'com.microsoft.identity.buildsystem' version '0.1.0'
     id 'com.android.library'
     id 'pmd'
@@ -170,10 +171,10 @@ dependencies {
     testImplementation ("org.robolectric:robolectric:$rootProject.ext.robolectricVersion")
     testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     testLocalImplementation project(':testutils')
-//    testDistImplementation("com.microsoft.identity:testutils:0.0.+") {
-//        exclude module: 'common'
-//        exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
-//    }
+    testDistImplementation("com.microsoft.identity:testutils:0.0.+") {
+        exclude module: 'common'
+        exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
+    }
 
     // Javadoc Dependencies
     javadocDeps "androidx.annotation:annotation:$rootProject.ext.annotationVersion"
@@ -360,7 +361,6 @@ tasks.whenTaskAdded { task ->
     }
 
     if (task.name == 'assembleLocal') {
-        task.dependsOn 'lintLocalDebug'
+        task.finalizedBy 'lintLocalDebug'
     }
 }
-


### PR DESCRIPTION
Currently, we don't run linting for adal at PR level. This change will enable it whenever "assembleLocal" is called.