### PR TITLE
Set target sdk and compile sdk to34

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -131,7 +131,7 @@ android {
     useLibrary 'android.test.mock'
 }
 
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "0.0.+"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "13.0.1"
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -131,7 +131,7 @@ android {
     useLibrary 'android.test.mock'
 }
 
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "13.0.1"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "0.0.+"
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -189,7 +189,7 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.compile
+    classpath += configurations.implementation
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     classpath += configurations.javadocDeps
     exclude '**/*.aidl'

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.6.0
+versionName=4.7.1
 versionCode=1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 4.7.1
+VNext
 -------------
 - [PATCH] Update YubiKit version to 2.3.0 (#1744)
 - [PATCH] Fix Adal StorageHelper Decrypt crash (#1751)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
-VNext
+Version 4.7.1
 -------------
 - [MAJOR] Consolidate Storage Supplier (breaking change introduced in common) #1729
 - [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#1732)
 - [MINOR] Removing thumbprint check from PkeyAuthChallenge (#1733)
+- [PATCH] Update common @13.0.1
+- [PATCH] Version 4.7.0 was built with common which had lint errors, updated to consume common after resolving errors
 
 Version 4.6.0
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ VNext
 -------------
 - [PATCH] Update YubiKit version to 2.3.0 (#1744)
 - [PATCH] Fix Adal StorageHelper Decrypt crash (#1751)
+- [PATCH] Updated target and compile SDK versions to 34 (#1747)
 
 Version 4.7.3
 -------------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -7,11 +7,10 @@ ext {
     automationAppMinSDKVersion = 21
     targetSdkVersion = 34
     compileSdkVersion = 34
-    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '4.2.2'
+    gradleVersion = '7.4.2'
     kotlinVersion = '1.7.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,8 +5,9 @@ ext {
     minSdkVersion = 16
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 30
-    compileSdkVersion = 30
+    targetSdkVersion = 34
+    compileSdkVersion = 34
+    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins
@@ -68,7 +69,7 @@ ext {
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.3.0"
     yubikitPivVersion = "2.3.0"
-    powerliftAndroidVersion="1.0.0"
+    powerliftAndroidVersion="1.0.3"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -42,7 +42,7 @@ if (project.hasProperty("buildApplicationId")) {
 println "Using application Id " + destApplicationId
 
 android {
-    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
         // Flag to enable support for the new language APIs

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -42,7 +42,7 @@ if (project.hasProperty("buildApplicationId")) {
 println "Using application Id " + destApplicationId
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
 
     compileOptions {
         // Flag to enable support for the new language APIs

--- a/userappwithbroker/src/main/AndroidManifest.xml
+++ b/userappwithbroker/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
- Increasing the targetSDK and compileSDK to 34
- After increasing the targetSDK, it gave some errors like exported attribute must be added when there is an intent filter. So I added that.
- PowerliftSDK version to the latest '1.0.3' as this one has fixes for target and compile sdk to be 34.
