### PR TITLE
Fix Adal decrypt crash

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
@@ -32,6 +32,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.Suppress;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -128,15 +129,8 @@ public class StorageHelperTests extends AndroidTestHelper {
             IOException, GeneralSecurityException {
         final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final StorageHelper storageHelper = new StorageHelper(context);
-        assertThrowsException(
-                IllegalArgumentException.class,
-                "is not valid, it must be greater of equal to 0",
-                new AndroidTestHelper.ThrowableRunnable() {
-                    @Override
-                    public void run() throws GeneralSecurityException, IOException, AuthenticationException {
-                        storageHelper.decrypt("E1bad64");
-                    }
-                });
+
+        Assert.assertEquals("E1bad64", storageHelper.decrypt("E1bad64"));
 
         assertThrowsException(
                 IllegalArgumentException.class,

--- a/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
@@ -254,14 +254,23 @@ public class StorageHelper {
 
         int encodeVersionLength = encryptedBlob.charAt(0) - 'a';
         if (encodeVersionLength <= 0) {
-            throw new IllegalArgumentException(String.format(
-                    "Encode version length: '%s' is not valid, it must be greater of equal to 0",
-                    encodeVersionLength));
+            final String message = String.format(
+                    "Encode version length: '%s' is not valid, it must be greater of equal to 0. " +
+                            "Assuming string is not encrypted. Returning input blob.",
+                    encodeVersionLength
+            );
+            Logger.w(TAG + methodName, message);
+            return encryptedBlob;
         }
+
         if (!encryptedBlob.substring(1, 1 + encodeVersionLength).equals(ENCODE_VERSION)) {
-            throw new IllegalArgumentException(String.format(
-                    "Encode version received was: '%s', Encode version supported is: '%s'", encryptedBlob,
-                    ENCODE_VERSION));
+            final String message = String.format(
+                    "Unsupported encode version received. Encode version supported is: %s. " +
+                            "Assuming string is not encrypted. Returning input blob.",
+                    ENCODE_VERSION
+            );
+            Logger.w(TAG + methodName, message);
+            return encryptedBlob;
         }
 
         final byte[] bytes = Base64

--- a/adal/versioning/version.properties
+++ b/adal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.6.0
+versionName=4.6.1
 versionCode=1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 4.6.1
+-------------
+- [PATCH] Fix crash due to IllegalArgumentException in StorageHelper.decrypt (#1748)
+
 Version 4.6.0
 -------------
 - [MINOR] Remove dependency from common's storagehelper #1725


### PR DESCRIPTION
Please make sure every Pull Request has the following information:

* A reference to a related issue in your repository (mandatory)
Quick fix for incident https://portal.microsofticm.com/imp/v3/incidents/details/409516968/home
* A description of the changes proposed in the pull request

Crash stack
java.lang.IllegalArgumentException: Encode version received was <PII>
at com.microsoft.aad.adal.StorageHelper.decrypt(SourceFile:22)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.DefaultTokenCacheStore.decrypt(SourceFile:2)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.DefaultTokenCacheStore.getItem(SourceFile:3)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.DelegatingCache.getItem(SourceFile:1)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.TokenCacheAccessor.getRegularRefreshTokenCacheItem(SourceFile:3)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.TokenCacheAccessor.getATFromCache(SourceFile:1)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenSilentHandler.getAccessToken(SourceFile:4)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilentLocally(SourceFile:3)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenRequest.acquireTokenSilentFlow(SourceFile:4)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilent(SourceFile:3)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenRequest.performAcquireTokenRequest(SourceFile:1)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenRequest.access$200(SourceFile:1)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at com.microsoft.aad.adal.AcquireTokenRequest$1.run(SourceFile:4)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
07-21 18:18:48.494 16573 16779 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:1012)


Fix is that if we are unable to decode the blob, we assume it's not encrypted and return. This is same as what's there common's StorageHelper, the code which Adal also used previously.

@shahzaibj @rpdome 

Since Office is using 4.6.0, I created a hotfix in Adal on top of it.

* @mentions of the person required for reviewing proposed changes (optional)

