### PR TITLE
Fix Adal StorageHelper Decrypt Dev

### DIFF
--- a/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/StorageHelperTests.java
@@ -128,15 +128,8 @@ public class StorageHelperTests extends AndroidTestHelper {
             IOException, GeneralSecurityException {
         final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final StorageHelper storageHelper = new StorageHelper(context);
-        assertThrowsException(
-                IllegalArgumentException.class,
-                "is not valid, it must be greater of equal to 0",
-                new AndroidTestHelper.ThrowableRunnable() {
-                    @Override
-                    public void run() throws GeneralSecurityException, IOException, AuthenticationException {
-                        storageHelper.decrypt("E1bad64");
-                    }
-                });
+
+        assertEquals("E1bad64", storageHelper.decrypt("E1bad64"));
 
         assertThrowsException(
                 IllegalArgumentException.class,

--- a/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
+++ b/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
@@ -254,14 +254,23 @@ public class StorageHelper {
 
         int encodeVersionLength = encryptedBlob.charAt(0) - 'a';
         if (encodeVersionLength <= 0) {
-            throw new IllegalArgumentException(String.format(
-                    "Encode version length: '%s' is not valid, it must be greater of equal to 0",
-                    encodeVersionLength));
+            final String message = String.format(
+                    "Encode version length: '%s' is not valid, it must be greater of equal to 0. " +
+                            "Assuming string is not encrypted. Returning input blob.",
+                    encodeVersionLength
+            );
+            Logger.w(TAG + methodName, message);
+            return encryptedBlob;
         }
+
         if (!encryptedBlob.substring(1, 1 + encodeVersionLength).equals(ENCODE_VERSION)) {
-            throw new IllegalArgumentException(String.format(
-                    "Encode version received was: '%s', Encode version supported is: '%s'", encryptedBlob,
-                    ENCODE_VERSION));
+            final String message = String.format(
+                    "Unsupported encode version received. Encode version supported is: %s. " +
+                            "Assuming string is not encrypted. Returning input blob.",
+                    ENCODE_VERSION
+            );
+            Logger.w(TAG + methodName, message);
+            return encryptedBlob;
         }
 
         final byte[] bytes = Base64

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 VNext
 -------------
 - [PATCH] Update YubiKit version to 2.3.0 (#1744)
+- [PATCH] Fix Adal StorageHelper Decrypt crash (#1751)
 
 Version 4.7.3
 -------------


### PR DESCRIPTION
Please make sure every Pull Request has the following information:
Details here: https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1748

This PR has same fix as in above PR.

The real reason of encryptedBlob coming as unencrypted is not known yet. A possibility is all these entries are old entries.


* A reference to a related issue in your repository (mandatory)
* A description of the changes proposed in the pull request
* @mentions of the person required for reviewing proposed changes (optional)
