### PR TITLE
Target, compile SDK, AGP and gradle versions increased

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -54,7 +54,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         multiDexEnabled true
@@ -190,7 +190,8 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.compile
+    configurations.implementation.setCanBeResolved(true)
+    classpath += configurations.implementation
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     classpath += configurations.javadocDeps
     exclude '**/*.aidl'
@@ -206,10 +207,11 @@ task javadoc(type: Javadoc) {
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
+    classifier 'javadoc'
     from javadoc.destinationDir
-    destinationDir = reporting.file("$project.buildDir/outputs/jar/")
+    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
 }
 
 // For publishing to the remote maven repo.
@@ -323,7 +325,7 @@ pmd {
     reportsDir = file("$project.buildDir/outputs/")
 }
 
-task pmd(type: Pmd) {
+tasks.register('pmd', Pmd) {
     description 'Run pmd'
     group 'verification'
 
@@ -344,7 +346,7 @@ checkstyle {
     reportsDir = file("$project.buildDir/outputs/")
 }
 
-task checkstyle(type: Checkstyle) {
+tasks.register('checkstyle', Checkstyle) {
     configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")
 
     configProperties.checkstyleConfigDir = checkstyleConfigDir
@@ -355,7 +357,7 @@ task checkstyle(type: Checkstyle) {
     classpath = files()
 }
 
-tasks.whenTaskAdded { task ->
+tasks.configureEach { task ->
     if (task.name == 'assembleDebug' || task.name == 'assembleRelease') {
         task.dependsOn 'checkstyle', 'pmd', 'lint'
     }

--- a/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
+++ b/adal/src/androidTest/java/com/microsoft/aad/adal/AcquireTokenSilentHandlerTest.java
@@ -66,6 +66,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import static androidx.test.InstrumentationRegistry.getContext;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -101,8 +102,7 @@ public final class AcquireTokenSilentHandlerTest {
 
         System.setProperty(
                 "org.mockito.android.target",
-                ApplicationProvider
-                        .getApplicationContext()
+                getApplicationContext()
                         .getCacheDir()
                         .getPath()
         );
@@ -130,7 +130,7 @@ public final class AcquireTokenSilentHandlerTest {
     @SmallTest
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     public void testRefreshTokenFailedNoNetworkAppIsInactive() {
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         mockContext.setAppInactive();
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -157,7 +157,7 @@ public final class AcquireTokenSilentHandlerTest {
     @SmallTest
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     public void testRefreshTokenFailedNoNetworkDeviceIsIdle() {
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         mockContext.setDeviceInIdleMode();
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
@@ -184,7 +184,7 @@ public final class AcquireTokenSilentHandlerTest {
     @Test
     public void testRefreshTokenWebRequestHasError() throws IOException {
 
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
         final String resource = "resource";
@@ -231,8 +231,8 @@ public final class AcquireTokenSilentHandlerTest {
     // Verify if regular RT exists, if the RT is not MRRT, we only redeem token with the regular RT. 
     @Test
     public void testRegularRT() throws IOException, JSONException {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         final String resource = "resource";
         final String clientId = "clientId";
 
@@ -293,8 +293,8 @@ public final class AcquireTokenSilentHandlerTest {
     // Test the current cache that does not mark RT as MRRT even it's MRRT.
     @Test
     public void testRegularRTExistsMRRTForSameClientIdExist() throws IOException, JSONException {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         final String resource = "resource";
         final String clientId = "clientId";
 
@@ -357,8 +357,8 @@ public final class AcquireTokenSilentHandlerTest {
      */
     @Test
     public void testMRRTSuccessNoFoCI() throws IOException, JSONException {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         final String resource = "resource";
         final String clientId = "clientId";
 
@@ -414,7 +414,7 @@ public final class AcquireTokenSilentHandlerTest {
     @Test
     public void testFRTSuccess() throws IOException, JSONException {
 
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
 
         // note: if only FRT exists, cache key will be hard-coded to 1
@@ -479,7 +479,7 @@ public final class AcquireTokenSilentHandlerTest {
     @Test
     public void testFRTFailedWithInvalidGrant() throws IOException, JSONException {
 
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         final ITokenCacheStore mockCache = new DefaultTokenCacheStore(mockContext);
         mockCache.removeAll();
 
@@ -525,8 +525,8 @@ public final class AcquireTokenSilentHandlerTest {
     @Test
     public void testFRTRequestFailedFallBackMRRTRequest() throws IOException, JSONException {
 
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getApplicationContext());
         final String clientId = "clientId";
         final String familyClientId = "familyClientId";
 
@@ -592,8 +592,8 @@ public final class AcquireTokenSilentHandlerTest {
      */
     @Test
     public void testFRTRequestFailFallBackToMRTMRTRequestFail() throws IOException, JSONException {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getApplicationContext());
         mockCache.removeAll();
         final String clientId = "clientId";
         final String familyClientId = "familyClientId";
@@ -673,8 +673,8 @@ public final class AcquireTokenSilentHandlerTest {
      */
     @Test
     public void testMRRTRequestFailsTryFRT() throws JSONException, IOException {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockCache = new DefaultTokenCacheStore(getApplicationContext());
         mockCache.removeAll();
         final String clientId = "clientId";
         final String resource = "resource";
@@ -758,7 +758,7 @@ public final class AcquireTokenSilentHandlerTest {
      */
     @Test
     public void testRefreshTokenRequestNotReturnErrorCode() throws IOException, JSONException {
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
         final AuthenticationRequest authenticationRequest = getAuthenticationRequest(VALID_AUTHORITY, "resource", "clientid", false);
@@ -800,7 +800,7 @@ public final class AcquireTokenSilentHandlerTest {
      */
     @Test
     public void testRefreshTokenWithInteractionRequiredCacheNotCleared() throws IOException, JSONException {
-        FileMockContext mockContext = new FileMockContext(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
         ITokenCacheStore mockCache = getCacheForRefreshToken(TEST_IDTOKEN_USERID, TEST_IDTOKEN_UPN);
 
         final AuthenticationRequest authenticationRequest = getAuthenticationRequest(VALID_AUTHORITY, "resource", "clientid", false);
@@ -834,8 +834,8 @@ public final class AcquireTokenSilentHandlerTest {
 
     @Test
     public void testMRRTItemNotContainRT() {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         final String resource = "resource";
         final String clientId = "clientId";
 
@@ -871,8 +871,8 @@ public final class AcquireTokenSilentHandlerTest {
 
     @Test
     public void testAllTokenItemNotContainRT() {
-        FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         final String resource = "resource";
         final String clientId = "clientId";
 
@@ -934,8 +934,8 @@ public final class AcquireTokenSilentHandlerTest {
 
     @Test
     public void testRTExistedInPreferredCache() throws IOException, JSONException {
-        final FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         clearCache(mockedCache);
 
         updateAuthorityMetadataCache();
@@ -996,8 +996,8 @@ public final class AcquireTokenSilentHandlerTest {
 
     @Test
     public void testMRRTExistInPreferredLocation() throws IOException, JSONException {
-        final FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         clearCache(mockedCache);
 
         updateAuthorityMetadataCache();
@@ -1056,8 +1056,8 @@ public final class AcquireTokenSilentHandlerTest {
 
     @Test
     public void testFRTExistedInPreferredLocation() throws IOException, JSONException {
-        final FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         clearCache(mockedCache);
 
         updateAuthorityMetadataCache();
@@ -1123,8 +1123,8 @@ public final class AcquireTokenSilentHandlerTest {
      */
     @Test
     public void testTokenPresentForPassedInAuthorityAndOtherAliasedHost() throws IOException, JSONException {
-        final FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         clearCache(mockedCache);
 
         updateAuthorityMetadataCache();
@@ -1188,8 +1188,8 @@ public final class AcquireTokenSilentHandlerTest {
 
     @Test
     public void testTokenForAliasedAuthorityPresent() throws IOException, JSONException {
-        final FileMockContext mockContext = new FileMockContext(getContext());
-        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getContext());
+        final FileMockContext mockContext = new FileMockContext(getApplicationContext());
+        final ITokenCacheStore mockedCache = new DefaultTokenCacheStore(getApplicationContext());
         clearCache(mockedCache);
 
         updateAuthorityMetadataCache();
@@ -1291,7 +1291,7 @@ public final class AcquireTokenSilentHandlerTest {
 
     // No Family client id set in the cache. Only regular RT token cache entry
     private ITokenCacheStore getCacheForRefreshToken(String userId, String displayableId) {
-        DefaultTokenCacheStore cache = new DefaultTokenCacheStore(getContext());
+        DefaultTokenCacheStore cache = new DefaultTokenCacheStore(getApplicationContext());
         cache.removeAll();
         Calendar expiredTime = new GregorianCalendar();
         Logger.d("Test", "Time now:" + expiredTime.toString());

--- a/azure-pipelines/maven-release/adal-maven-release.yml
+++ b/azure-pipelines/maven-release/adal-maven-release.yml
@@ -28,7 +28,7 @@ jobs:
     projectVersion: $(AdalVersion)
     checkoutSubmodules: recursive
     envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
-    gradleAssembleReleaseTask: adal:clean adal:assembleDist adal:javadocJar
+    gradleAssembleReleaseTask: adal:clean adal:assembleDistRelease adal:javadocJar
     gradleGeneratePomFiletask: adal:generatePomFileForAdalPublication
     aarSourceFolder: adal/build/outputs/aar
     jarSourceFolder: adal/build/outputs/jar

--- a/azure-pipelines/pull-request-validation/pr-adal.yml
+++ b/azure-pipelines/pull-request-validation/pr-adal.yml
@@ -32,6 +32,12 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
+  - task: JavaToolInstaller@0
+    displayName: Use Java 11
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: x64
+      jdkSourceOption: PreInstalled
   - task: CmdLine@1
     displayName: Set Office MVN Access Token in Environment
     inputs:
@@ -67,8 +73,8 @@ jobs:
     inputs:
       tasks: clean adal:assembleLocal
       publishJUnitResults: false
-      jdkArchitecture: x86
-      sqAnalysisBreakBuildIfQualityGateFailed: false
+      jdkArchitecture: x64
+      jdkVersion: 1.11
 - job: lint
   displayName: Lint
   cancelTimeoutInMinutes: 1
@@ -87,6 +93,7 @@ jobs:
     inputs:
       tasks: clean adal:lintLocalDebug
       publishJUnitResults: false
+      jdkVersion: 1.11
 
 - job: spotbugs
   displayName: SpotBugs

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+vNext
+-------------
+- [MINOR] Target, compile SDK, AGP and gradle versions increased (#1755)
+
 Version 4.7.5
 -------------
 - [PATCH] Update YubiKit version to 2.3.0 (#1744)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,8 +5,9 @@ ext {
     minSdkVersion = 16
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 30
-    compileSdkVersion = 30
+    targetSdkVersion = 34
+    compileSdkVersion = 34
+    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins
@@ -68,7 +69,7 @@ ext {
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.3.0"
     yubikitPivVersion = "2.3.0"
-    powerliftAndroidVersion="1.0.0"
+    powerliftAndroidVersion="1.0.3"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,19 +5,18 @@ ext {
     minSdkVersion = 16
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 34
+    targetSdkVersion = 33
     compileSdkVersion = 34
-    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '4.2.2'
+    gradleVersion = '7.4.2'
     kotlinVersion = '1.7.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
 
     //Java Language Support
-    coreLibraryDesugaringVersion = "1.0.9"
+    coreLibraryDesugaringVersion = "1.1.5"
 
     // Libraries
     androidxTestRunnerVersion = "1.4.0"
@@ -35,7 +34,7 @@ ext {
     junitVersion = "4.12"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"
-    lombokVersion = "1.18.12"
+    lombokVersion = "1.18.22"
     materialVersion = "1.0.0"
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -42,7 +42,7 @@ if (project.hasProperty("buildApplicationId")) {
 println "Using application Id " + destApplicationId
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
 
     compileOptions {
         // Flag to enable support for the new language APIs

--- a/userappwithbroker/build.gradle
+++ b/userappwithbroker/build.gradle
@@ -42,7 +42,7 @@ if (project.hasProperty("buildApplicationId")) {
 println "Using application Id " + destApplicationId
 
 android {
-    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
+    compileSdk rootProject.ext.compileSdkVersion
 
     compileOptions {
         // Flag to enable support for the new language APIs

--- a/userappwithbroker/src/main/AndroidManifest.xml
+++ b/userappwithbroker/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
- Target sdk version changed to 33
- Compile sdk version changed to 34
- AGP version changed to 7.4.2
- Gradle distribution url changed to 7.5

After changing above versions, I had to update other dependencies for compatibility

- Powerlift version changed to 1.0.3
- Bouncy castle version changed to 1.69
- robolectric version to 4.9
- Also, with new gradle versions, some of the properties used in gradle were deprecated (naming conventions changed). So, made those changes
- With gradle version changes, we should not be having a package name in AndroidManifest.xml.. instead, should add a namespace property in build.gradle. https://developer.android.com/build/publish-library/prep-lib-release#choose-namespace
- For apps targeting Android 14, Android restricts apps from sending implicit intents to internal app components. So , added exported attribute.  https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents
- Renamed the assemble dist release aar name to contain the version number. Starting gradle version 7, gradle generates adal-dist-release.aar. But we want to publish adal-5.0.0.aar