### PR TITLE
Updating JSON version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version Next
 -------------
+- [PATCH] Updating JSON version (#1766)
 
 Version 4.8.2
 -------------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -56,7 +56,7 @@ ext {
     equalsVerifierVersion = "3.6.1"
     jsonGeneratorVersion = "0.4.7"
     jsonSchemaFriendVersion = "0.12.2"
-    jsonVersion = "20200518"
+    jsonVersion = "20231013"
     junitJupiterEngineVersion = "5.7.2"
     junitVintageEngineVersion = "5.7.2"
     dbusJavaVersion = "3.3.0"


### PR DESCRIPTION
### Summary
This PR addresses the CVE, "Denial of Service in JSON-java": https://github.com/advisories/GHSA-rm7j-f5g5-27vv
We need to bump up our JSON dependency version to 20231013 to resolve this CVE on our side.
