### PR TITLE
Adding CredMan version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version Next
 -------------
+- [PATCH] Adding Credential Manager version (for compilation only) (#1772)
 
 Version 4.8.3
 -------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Version Next
 -------------
-- [PATCH] Adding Credential Manager version (for compilation only) (#1772)
+- [PATCH] Adding Credential Manager version (for common, but note that ADAL will not include the passkey feature) (#1772)
 
 Version 4.8.3
 -------------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -78,6 +78,7 @@ ext {
     openTelemetryVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     lifecycleKtxVersion="2.5.1"
+    AndroidCredentialsVersion="1.2.0"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"


### PR DESCRIPTION
### Summary
Please see the main common PR for details regarding Credential Manager and the passkey feature: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2267
Note that the passkey feature is not going to be available for ADAL, but this PR is necessary to avoid any compilation errors when taking in the new version of common. (So the library will include CredMan by consuming common, but it has it's own set of classes for WebView and configurations, so it will not get the passkey feature from common).