### PR TITLE
Updating publishing tasks

### DIFF
--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -122,13 +122,20 @@ android {
         disable 'PackageManagerGetSignatures'
     }
 
-    libraryVariants.all { variant ->
-        variant.outputs.all {
-            outputFileName = "${archivesBaseName}-${version}.aar"
-        }
-    }
+//    libraryVariants.all { variant ->
+//        variant.outputs.all {
+//            outputFileName = "${archivesBaseName}-${version}.aar"
+//        }
+//    }
 
     useLibrary 'android.test.mock'
+
+    publishing {
+        singleVariant('distRelease') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
@@ -181,106 +188,79 @@ dependencies {
     javadocDeps "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"
 }
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier 'sources'
-    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
-}
-
-task javadoc(type: Javadoc) {
-    failOnError false
-    source = android.sourceSets.main.java.srcDirs
-    configurations.implementation.setCanBeResolved(true)
-    classpath += configurations.implementation
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.javadocDeps
-    exclude '**/*.aidl'
-
-    if (JavaVersion.current().isJava8Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addStringOption('Xdoclint:none', '-quiet')
-            }
-        }
-    }
-
-    destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
-}
-
-tasks.register('javadocJar', Jar) {
-    dependsOn javadoc
-    classifier 'javadoc'
-    from javadoc.destinationDir
-    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
-}
+//task sourcesJar(type: Jar) {
+//    from android.sourceSets.main.java.srcDirs
+//    classifier 'sources'
+//    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
+//}
+//
+//task javadoc(type: Javadoc) {
+//    failOnError false
+//    source = android.sourceSets.main.java.srcDirs
+//    configurations.implementation.setCanBeResolved(true)
+//    classpath += configurations.implementation
+//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+//    classpath += configurations.javadocDeps
+//    exclude '**/*.aidl'
+//
+//    if (JavaVersion.current().isJava8Compatible()) {
+//        allprojects {
+//            tasks.withType(Javadoc) {
+//                options.addStringOption('Xdoclint:none', '-quiet')
+//            }
+//        }
+//    }
+//
+//    destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
+//}
+//
+//tasks.register('javadocJar', Jar) {
+//    dependsOn javadoc
+//    classifier 'javadoc'
+//    from javadoc.destinationDir
+//    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
+//}
 
 // For publishing to the remote maven repo.
 publishing {
     publications {
         adal(MavenPublication) {
+            afterEvaluate {
+                from components.distRelease
+            }
             groupId 'com.microsoft.aad'
             artifactId 'adal'
             //Edit the 'version' here for VSTS RC build
             version = project.version
 
-            pom.withXml {
-                // Custom values
-
-                // Name
-                asNode().appendNode('name', 'adal')
-
-                // Description
-                asNode().appendNode(
-                        'description',
-                        'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-                )
-
-                // URL
-                asNode().appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android')
-
-                // Inception Year
-                asNode().appendNode('inceptionYear', '2014')
-
-                // Licenses
-                asNode().appendNode('licenses').appendNode('license').appendNode('name', 'MIT License')
-
-                // Developers
-                def developerNode = asNode().appendNode('developers').appendNode('developer')
-                developerNode.appendNode('id', 'microsoft')
-                developerNode.appendNode('name', 'Microsoft')
-
-                // SCM
-                asNode().appendNode('scm').appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master')
-
-                // Properties
-                def propertiesNode = asNode().appendNode('properties')
-                propertiesNode.appendNode('branch', 'master')
-                propertiesNode.appendNode('version', project.version)
-
-                def dependenciesNode = asNode().appendNode('dependencies')
-
-                def deps = configurations.implementation.allDependencies.asList()
-                if (project.version.toString().endsWith("SNAPSHOT")) {
-                    deps.addAll(configurations.snapshotApi.allDependencies.asList())
-                } else {
-                    deps.addAll(configurations.distApi.allDependencies.asList())
-                }
-
-                //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                deps.each {
-                    if (it.group != null && it.name != null) {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
+            pom {
+                name = 'adal'
+                description = 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+                url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
+                developers {
+                    developer {
+                        id = 'microsoft'
+                        name = 'Microsoft'
                     }
                 }
-
+                licenses {
+                    license {
+                        name = 'MIT License'
+                    }
+                }
+                inceptionYear = '2014'
+                scm {
+                    url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master'
+                }
+                properties = [
+                        branch : 'master',
+                        version: project.version
+                ]
             }
 
-            artifact(sourcesJar)
-            artifact(javadocJar)
-            artifact("$buildDir/outputs/aar/adal-${project.version}.aar")
+//            artifact(sourcesJar)
+//            artifact(javadocJar)
+//            artifact("$buildDir/outputs/aar/adal-${project.version}.aar")
         }
 
     }
@@ -315,10 +295,10 @@ def getTimestamp() {
     return date.format('yyyyMMdd.HHmm')
 }
 
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
+//artifacts {
+//    archives javadocJar
+//    archives sourcesJar
+//}
 
 pmd {
     ignoreFailures = false

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -235,85 +235,30 @@ publishing {
             //Edit the 'version' here for VSTS RC build
             version = project.version
 
-            pom.withXml {
-                // Custom values
-
-                // Name
-                asNode().appendNode('name', 'adal')
-
-                // Description
-                asNode().appendNode(
-                        'description',
-                        'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-                )
-
-                // URL
-                asNode().appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android')
-
-                // Inception Year
-                asNode().appendNode('inceptionYear', '2014')
-
-                // Licenses
-                asNode().appendNode('licenses').appendNode('license').appendNode('name', 'MIT License')
-
-                // Developers
-                def developerNode = asNode().appendNode('developers').appendNode('developer')
-                developerNode.appendNode('id', 'microsoft')
-                developerNode.appendNode('name', 'Microsoft')
-
-                // SCM
-                asNode().appendNode('scm').appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master')
-
-                // Properties
-                def propertiesNode = asNode().appendNode('properties')
-                propertiesNode.appendNode('branch', 'master')
-                propertiesNode.appendNode('version', project.version)
-
-                def dependenciesNode = asNode().appendNode('dependencies')
-
-                def deps = configurations.implementation.allDependencies.asList()
-                if (project.version.toString().endsWith("SNAPSHOT")) {
-                    deps.addAll(configurations.snapshotApi.allDependencies.asList())
-                } else {
-                    deps.addAll(configurations.distApi.allDependencies.asList())
-                }
-
-                //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                deps.each {
-                    if (it.group != null && it.name != null) {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
+            pom {
+                name = 'adal'
+                description = 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+                url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
+                developers {
+                    developer {
+                        id = 'microsoft'
+                        name = 'Microsoft'
                     }
                 }
-
+                licenses {
+                    license {
+                        name = 'MIT License'
+                    }
+                }
+                inceptionYear = '2014'
+                scm {
+                    url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master'
+                }
+                properties = [
+                        branch : 'master',
+                        version: project.version
+                ]
             }
-
-//            pom {
-//                name = 'adal'
-//                description = 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-//                url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
-//                developers {
-//                    developer {
-//                        id = 'microsoft'
-//                        name = 'Microsoft'
-//                    }
-//                }
-//                licenses {
-//                    license {
-//                        name = 'MIT License'
-//                    }
-//                }
-//                inceptionYear = '2014'
-//                scm {
-//                    url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master'
-//                }
-//                properties = [
-//                        branch : 'master',
-//                        version: project.version
-//                ]
-//            }
 
 //            artifact(sourcesJar)
 //            artifact(javadocJar)

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -233,30 +233,85 @@ publishing {
             //Edit the 'version' here for VSTS RC build
             version = project.version
 
-            pom {
-                name = 'adal'
-                description = 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
-                url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
-                developers {
-                    developer {
-                        id = 'microsoft'
-                        name = 'Microsoft'
+            pom.withXml {
+                // Custom values
+
+                // Name
+                asNode().appendNode('name', 'adal')
+
+                // Description
+                asNode().appendNode(
+                        'description',
+                        'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+                )
+
+                // URL
+                asNode().appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android')
+
+                // Inception Year
+                asNode().appendNode('inceptionYear', '2014')
+
+                // Licenses
+                asNode().appendNode('licenses').appendNode('license').appendNode('name', 'MIT License')
+
+                // Developers
+                def developerNode = asNode().appendNode('developers').appendNode('developer')
+                developerNode.appendNode('id', 'microsoft')
+                developerNode.appendNode('name', 'Microsoft')
+
+                // SCM
+                asNode().appendNode('scm').appendNode('url', 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master')
+
+                // Properties
+                def propertiesNode = asNode().appendNode('properties')
+                propertiesNode.appendNode('branch', 'master')
+                propertiesNode.appendNode('version', project.version)
+
+                def dependenciesNode = asNode().appendNode('dependencies')
+
+                def deps = configurations.implementation.allDependencies.asList()
+                if (project.version.toString().endsWith("SNAPSHOT")) {
+                    deps.addAll(configurations.snapshotApi.allDependencies.asList())
+                } else {
+                    deps.addAll(configurations.distApi.allDependencies.asList())
+                }
+
+                //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                deps.each {
+                    if (it.group != null && it.name != null) {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
                     }
                 }
-                licenses {
-                    license {
-                        name = 'MIT License'
-                    }
-                }
-                inceptionYear = '2014'
-                scm {
-                    url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master'
-                }
-                properties = [
-                        branch : 'master',
-                        version: project.version
-                ]
+
             }
+
+//            pom {
+//                name = 'adal'
+//                description = 'Azure active directory library for Android gives you the ability to add Windows Azure Active Directory authentication to your application with just a few lines of additional code. Using our ADAL SDKs you can quickly and easily extend your existing application to all the employees that use Windows Azure AD and Active Directory on-premises using Active Directory Federation Services, including Office365 customers.'
+//                url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android'
+//                developers {
+//                    developer {
+//                        id = 'microsoft'
+//                        name = 'Microsoft'
+//                    }
+//                }
+//                licenses {
+//                    license {
+//                        name = 'MIT License'
+//                    }
+//                }
+//                inceptionYear = '2014'
+//                scm {
+//                    url = 'https://github.com/AzureAD/azure-activedirectory-library-for-android/tree/master'
+//                }
+//                properties = [
+//                        branch : 'master',
+//                        version: project.version
+//                ]
+//            }
 
 //            artifact(sourcesJar)
 //            artifact(javadocJar)

--- a/adal/build.gradle
+++ b/adal/build.gradle
@@ -122,12 +122,6 @@ android {
         disable 'PackageManagerGetSignatures'
     }
 
-//    libraryVariants.all { variant ->
-//        variant.outputs.all {
-//            outputFileName = "${archivesBaseName}-${version}.aar"
-//        }
-//    }
-
     useLibrary 'android.test.mock'
 
     publishing {
@@ -190,39 +184,6 @@ dependencies {
     javadocDeps "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"
 }
 
-//task sourcesJar(type: Jar) {
-//    from android.sourceSets.main.java.srcDirs
-//    classifier 'sources'
-//    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
-//}
-//
-//task javadoc(type: Javadoc) {
-//    failOnError false
-//    source = android.sourceSets.main.java.srcDirs
-//    configurations.implementation.setCanBeResolved(true)
-//    classpath += configurations.implementation
-//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-//    classpath += configurations.javadocDeps
-//    exclude '**/*.aidl'
-//
-//    if (JavaVersion.current().isJava8Compatible()) {
-//        allprojects {
-//            tasks.withType(Javadoc) {
-//                options.addStringOption('Xdoclint:none', '-quiet')
-//            }
-//        }
-//    }
-//
-//    destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
-//}
-//
-//tasks.register('javadocJar', Jar) {
-//    dependsOn javadoc
-//    classifier 'javadoc'
-//    from javadoc.destinationDir
-//    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
-//}
-
 // For publishing to the remote maven repo.
 publishing {
     publications {
@@ -259,10 +220,6 @@ publishing {
                         version: project.version
                 ]
             }
-
-//            artifact(sourcesJar)
-//            artifact(javadocJar)
-//            artifact("$buildDir/outputs/aar/adal-${project.version}.aar")
         }
 
     }
@@ -296,11 +253,6 @@ def getTimestamp() {
     def date = new Date()
     return date.format('yyyyMMdd.HHmm')
 }
-
-//artifacts {
-//    archives javadocJar
-//    archives sourcesJar
-//}
 
 pmd {
     ignoreFailures = false

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] Update publishing tasks (#1792)
 
 Version 4.8.9
 ---------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -11,7 +11,7 @@ ext {
 
     // Plugins
     gradleVersion = '7.4.2'
-    kotlinVersion = '1.8.22'
+    kotlinVersion = '1.7.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
     

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -11,7 +11,7 @@ ext {
 
     // Plugins
     gradleVersion = '7.4.2'
-    kotlinVersion = '1.7.21'
+    kotlinVersion = '1.8.22'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
     


### PR DESCRIPTION
### Summary
(still in progress)
This PR:
- Adds the suggested way to automatically create sources and javadocs jar files (https://developer.android.com/build/publish-library/configure-pub-variants#single-pub-var and https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/LibraryPublishing).
- Removes tasks related to generating javadocs and pom files.

Pipeline run: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1304918&view=results&j=76b33e1f-4828-5f2f-d07d-022319483d4a

Artifacts created on a test pipeline run: https://identitydivision.visualstudio.com/Engineering/_artifacts/feed/AndroidADAL/maven/com.microsoft.aad%2Fadal/overview/1.0.20240523-melissaahn-PublishingChanges

Note the names of the artifacts and that most of the dependencies are listed under Runtime now instead of Compile. This means that our external dependencies which we declare with `implementation` configuration are no longer leaking to our consumers. The configurations are now working as described [here](https://developer.android.com/build/dependencies#dependency_configurations).
Consumers who have relied on the libraries for external dependencies will now need to add the dependencies directly.