### PR TITLE
YubiKit 2.5.0 and CredMan 1.2.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] YubiKit 2.5.0 and CredMan 1.2.2 (#1793)
 
 Version 4.8.9
 ---------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -66,8 +66,8 @@ ext {
     tokenShare = "1.6.5"
     intuneAppSdkVersion = "8.6.3"
     javaAssistVersion = "3.27.0-GA"
-    yubikitAndroidVersion = "2.3.0"
-    yubikitPivVersion = "2.3.0"
+    yubikitAndroidVersion = "2.5.0"
+    yubikitPivVersion = "2.5.0"
     powerliftAndroidVersion="1.0.3"
     kotlinXCoroutinesVersion = "1.6.4"
     mockkVersion = "1.11.0"
@@ -78,7 +78,7 @@ ext {
     openTelemetryVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     lifecycleKtxVersion="2.5.1"
-    AndroidCredentialsVersion="1.2.0"
+    AndroidCredentialsVersion="1.2.2"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"


### PR DESCRIPTION
### Summary
Latest versions:
- CredMan 1.2.2: https://developer.android.com/jetpack/androidx/releases/credentials#1.2.2
- YubiKit 2.5.0: https://github.com/Yubico/yubikit-android/releases

Manual testing was conducted and passed.