### PR TITLE
Bumping BouncyCastle version to 1.78

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 V.Next
 ---------
-- [MINOR] Bumping BouncyCastle version to 1.78 (#1798)
 
 Version 4.8.10
 ---------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Bumping BouncyCastle version to 1.78 (#1798)
 
 Version 4.8.10
 ---------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -61,7 +61,7 @@ ext {
     junitVintageEngineVersion = "5.7.2"
     dbusJavaVersion = "3.3.0"
     dbusJavaUtilsVersion = "3.3.0"
-    bouncyCastleVersion = "1.77"
+    bouncyCastleVersion = "1.78"
     oshiCoreVersion = "5.7.5"
     tokenShare = "1.6.5"
     intuneAppSdkVersion = "8.6.3"


### PR DESCRIPTION
### Summary
Updating our Bouncy Castle version from 1.77 to 1.78. A number of CVEs are addressed in 1.78: https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-78

CP requested us to do this bump, and I got acks from AuthApp and LTW.